### PR TITLE
Benchmark handlers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+benches/assets/** filter=lfs diff=lfs merge=lfs -text
+benches/assets/justfile !filter !diff !merge
 tests/integration/** filter=lfs diff=lfs merge=lfs -text

--- a/benches/assets/compression/bzip2/1
+++ b/benches/assets/compression/bzip2/1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f95c6657c950bcb13235af5b8647de19c49537f50eb8bbb50a63328bc2481f3d
+size 1053791

--- a/benches/assets/compression/bzip2/100
+++ b/benches/assets/compression/bzip2/100
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:153df07de352a223aacb29fdab380eacb36e3bfbf405200ee54f8e7f30e64283
+size 105326334

--- a/benches/assets/compression/bzip2/20
+++ b/benches/assets/compression/bzip2/20
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37e0a57a8d0b4edad264a73a43b0e1e6e22697f13178640b676a938435e757c8
+size 21065603

--- a/benches/assets/compression/bzip2/5
+++ b/benches/assets/compression/bzip2/5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bb3e5ad12a24785204332214ff357f7dd3700bdf7170113c4cc67d2f2ac4434
+size 5266768

--- a/benches/assets/compression/lz4-legacy/1
+++ b/benches/assets/compression/lz4-legacy/1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e03814aa25fb854e502fc3cff289349a9b7d22488f3cc8862bb7c4fca315b654
+size 1052698

--- a/benches/assets/compression/lz4-legacy/100
+++ b/benches/assets/compression/lz4-legacy/100
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3055ac26de2dc5af07166d0c2d808c14bafa7a9d50c883632c4471dc3712adf3
+size 105268882

--- a/benches/assets/compression/lz4-legacy/20
+++ b/benches/assets/compression/lz4-legacy/20
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:321e75f1c7d07f4758d46bac60a2febb58f946182646636708bb4dc836afe890
+size 21053782

--- a/benches/assets/compression/lz4-legacy/5
+++ b/benches/assets/compression/lz4-legacy/5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:927bad6bd0e1cc0b4c3cb1cc1fe2de92ce2fba669d9ca639b80d2512545f8993
+size 5263450

--- a/benches/assets/compression/lz4/1
+++ b/benches/assets/compression/lz4/1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31d96ccfb764cf37fd1e36e37fd18f57e3870af433e5646432bc2278a8a6b32b
+size 1048595

--- a/benches/assets/compression/lz4/100
+++ b/benches/assets/compression/lz4/100
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e70ac3b6e6a7e3821b835d18d7c295178927801eea5bc7ec37e094217db5aa6e
+size 104857715

--- a/benches/assets/compression/lz4/20
+++ b/benches/assets/compression/lz4/20
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1e0613122ba7c98b4bfe74675d11ffedf5d3ce7c474acaa67ff0494d61de256
+size 20971555

--- a/benches/assets/compression/lz4/5
+++ b/benches/assets/compression/lz4/5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5ddd90723ebf7e09386b346379c0aebdfae13adb8d4cfbe437bd3b945b7bf87
+size 5242903

--- a/benches/assets/compression/lzma/1
+++ b/benches/assets/compression/lzma/1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e6031c2c27bfca5f93d049844ebbe43de4668dca14c1f0e2555df952ec90dc5
+size 1062877

--- a/benches/assets/compression/lzma/100
+++ b/benches/assets/compression/lzma/100
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eee8be9b11ea465e038f41ccf55656669181748c22ab908247084cf00a899b4c
+size 106281506

--- a/benches/assets/compression/lzma/20
+++ b/benches/assets/compression/lzma/20
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6aa0792e79d2d6ad050e8674a84002eae87921b88c48380e2ed8ba4ebf0a09f
+size 21256528

--- a/benches/assets/compression/lzma/5
+++ b/benches/assets/compression/lzma/5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de32daebd7783047f19ef5f7a86e021157b06131212e7c91588488b3ea45076a
+size 5314096

--- a/benches/assets/compression/lzo/1
+++ b/benches/assets/compression/lzo/1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7f7681d9655c854af9d3abe9d6ae78397cb640bc3ad6a97d1933c05c3d8e477
+size 1048666

--- a/benches/assets/compression/lzo/100
+++ b/benches/assets/compression/lzo/100
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ed71a2bf8d9b998841e655be3bfef8ae57b3824548592de36a0da3daf2725fc
+size 104862442

--- a/benches/assets/compression/lzo/20
+++ b/benches/assets/compression/lzo/20
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31da0ee5ee2b0f32f881430dddb5b25fc7fb0fa88b4b7d91090c4fc2ba1f607b
+size 20972522

--- a/benches/assets/compression/lzo/5
+++ b/benches/assets/compression/lzo/5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:166bfbf001f7974bf0edf16792071209b31afff07c60adde9cf20726102c73df
+size 5243162

--- a/benches/assets/justfile
+++ b/benches/assets/justfile
@@ -1,0 +1,37 @@
+size := "50" # MiB
+
+all: bzip2 lz4 lz4-legacy lzh lzma lzo xz
+
+_random_to_stdout SIZE:
+    #!/usr/bin/env python
+    import random
+    import sys
+
+
+    random.seed(977)
+    sys.stdout.buffer.write(random.randbytes({{ SIZE }} * 1024 * 1024))
+
+
+_save-stdout NAME +COMMAND:
+    mkdir -p {{ NAME }}
+    just _random_to_stdout {{ size }} | {{ COMMAND }} > {{ NAME }}/{{ size }}
+
+bzip2: (_save-stdout "compression/bzip2" "bzip2 -c")
+
+lz4-legacy: (_save-stdout "compression/lz4-legacy" "lz4 -z -l")
+
+lz4: (_save-stdout "compression/lz4" "lz4 -z")
+
+lzo: (_save-stdout "compression/lzo" "lzop")
+
+lzma: (_save-stdout "compression/lzma" "xz --format=lzma -z")
+
+lzh:
+    #!/bin/sh
+    set -euo pipefail
+    mkdir -p lzh
+    f=$(mktemp)
+    trap "rm $f" EXIT INT TERM
+    just _random_to_stdout {{ size }} > $f && lha -c lzh/{{ size }} $f
+
+xz: (_save-stdout "xz" "xz -z")

--- a/benches/assets/lzh/1
+++ b/benches/assets/lzh/1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fec4c9889af6bb0e50b9f53bb0d8a394396e50ec97194e9fa8984fb45856b37c
+size 1048655

--- a/benches/assets/lzh/100
+++ b/benches/assets/lzh/100
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a31e0285fc090618a1037c6dd2a93eb3b72624139ab8abc9c4b598c6e864ac77
+size 104857679

--- a/benches/assets/lzh/20
+++ b/benches/assets/lzh/20
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3cdf5ae38a17a7ef860af3da4548d90f063b40afc1c32c5453b56df5b624052
+size 20971599

--- a/benches/assets/lzh/5
+++ b/benches/assets/lzh/5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a4bd7394bd2427743b7c75b5e044a487b75ded789a8f8b6b9a7c5773981ab18
+size 5242959

--- a/benches/assets/lzh/50
+++ b/benches/assets/lzh/50
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa13ae4f12d6c0ec7648ab1e3d49dff19fdee10225c43aeb120dc4c0a9b0daf7
+size 52428879

--- a/benches/assets/xz/1
+++ b/benches/assets/xz/1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a09d080452990d9f4e7bd8b179e179c84084bb734aa1f0e43f067ccb3e70044
+size 1048688

--- a/benches/assets/xz/100
+++ b/benches/assets/xz/100
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85a30db9bc2dcb5c6418f7a052c042f834d0349d02954242b19c840ee7a3864e
+size 104862856

--- a/benches/assets/xz/20
+++ b/benches/assets/xz/20
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf1c2315469ffb169feae72287cc2fe32652c2d17352a67e5d8cd18fde378374
+size 20972624

--- a/benches/assets/xz/5
+++ b/benches/assets/xz/5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f54b5b01f6cc748f56a0c0570be21b7e7262163f18cb4b6f7bb88a899111821
+size 5243204

--- a/benches/assets/xz/50
+++ b/benches/assets/xz/50
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3aa39736b4eaa9baefd8ad7e5f9d3d262e08d5e65b25e722dd7fc81802bee5d4
+size 52431460

--- a/benches/bench_handlers.py
+++ b/benches/bench_handlers.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import shutil
+import pytest
+
+from unblob.processing import DEFAULT_DEPTH, process_file
+
+
+TEST_DATA_PATH = Path(__file__).parent / "assets"
+
+TEST_FILES = [p for p in TEST_DATA_PATH.glob("*/**/*") if p.is_file()]
+TEST_DIRS = [p.parent for p in TEST_FILES]
+
+TEST_IDS = [
+    str(p.relative_to(TEST_DATA_PATH)).replace('/', '.') for p in TEST_FILES
+]
+
+@pytest.mark.benchmark(group="param:input_dir")
+@pytest.mark.parametrize(
+    "input_file, input_dir",
+    zip(TEST_FILES, TEST_DIRS),
+    ids=TEST_IDS,
+)
+def bench_compress(input_file, input_dir, tmp_path, benchmark):
+    extract_dir = tmp_path.joinpath("extract")
+
+    def setup_benchmark():
+        shutil.rmtree(extract_dir, ignore_errors=True)
+        extract_dir.mkdir()
+
+    benchmark.pedantic(
+        setup=setup_benchmark,
+        target=process_file,
+        kwargs=dict(
+            root=input_dir,
+            path=input_file,
+            extract_root=extract_dir,
+            max_depth=DEFAULT_DEPTH,
+        ),
+        rounds=1,
+        warmup_rounds=1,
+    )
+

--- a/benches/conftest.py
+++ b/benches/conftest.py
@@ -1,0 +1,16 @@
+def pytest_benchmark_scale_unit(config, unit, benchmarks, best, worst, sort):
+    prefix = ""
+    scale = 1.0
+
+    if unit == "operations":
+        prefix = "MiB/s "
+        for benchmark in benchmarks:
+            input_file = benchmark["params"].get("input_file")
+            if not input_file:
+                continue
+            input_size = input_file.stat().st_size
+            scale_factor = input_size / 1024 / 1024
+            benchmark["ops"] *= scale_factor
+            benchmark["scaled"] = True
+
+    return prefix, scale

--- a/poetry.lock
+++ b/poetry.lock
@@ -232,6 +232,36 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "py-cpuinfo"
+version = "8.0.0"
+description = "Get CPU info with pure Python 2 & 3"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pygal"
+version = "3.0.0"
+description = "A Python svg graph plotting library"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.extras]
+docs = ["sphinx", "sphinx-rtd-theme", "pygal-sphinx-directives"]
+lxml = ["lxml"]
+png = ["cairosvg"]
+test = ["pyquery", "flask", "cairosvg", "lxml", "pygal-maps-world", "pygal-maps-fr", "pygal-maps-ch", "coveralls", "pytest-runner", "pytest-cov", "pytest-flake8", "pytest-isort", "pytest"]
+
+[[package]]
+name = "pygaljs"
+version = "1.0.2"
+description = "Python package providing assets from https://github.com/Kozea/pygal.js"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pyparsing"
 version = "2.4.7"
 description = "Python parsing module"
@@ -274,6 +304,25 @@ toml = "*"
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-benchmark"
+version = "3.4.1"
+description = "A ``pytest`` fixture for benchmarking code. It will group the tests into rounds that are calibrated to the chosen timer."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+py-cpuinfo = "*"
+pygal = {version = "*", optional = true, markers = "extra == \"histogram\""}
+pygaljs = {version = "*", optional = true, markers = "extra == \"histogram\""}
+pytest = ">=3.8"
+
+[package.extras]
+aspect = ["aspectlib"]
+elasticsearch = ["elasticsearch"]
+histogram = ["pygal", "pygaljs"]
 
 [[package]]
 name = "pytest-cov"
@@ -417,7 +466,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "4ce7fb75dd8eacb9ff7d9fa4855310fe538fdb4973f994cfa639660986c4f2bd"
+content-hash = "b05fef7190ea8fec56fb3b2b00710062c6a196a7c68e02cf8fc3f84d2c8514eb"
 
 [metadata.files]
 arpy = [
@@ -549,6 +598,17 @@ py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
+py-cpuinfo = [
+    {file = "py-cpuinfo-8.0.0.tar.gz", hash = "sha256:5f269be0e08e33fd959de96b34cd4aeeeacac014dd8305f70eb28d06de2345c5"},
+]
+pygal = [
+    {file = "pygal-3.0.0-py2.py3-none-any.whl", hash = "sha256:9ae06e32dec1422f9cd0d606fe2728f78e0b5d644551137480d8d5806e2426f0"},
+    {file = "pygal-3.0.0.tar.gz", hash = "sha256:2923f95d2e515930aa5a997219dccefbf3d92b7eaf5fc1c9febb95b09935fdb2"},
+]
+pygaljs = [
+    {file = "pygaljs-1.0.2-py2.py3-none-any.whl", hash = "sha256:d75e18cb21cc2cda40c45c3ee690771e5e3d4652bf57206f20137cf475c0dbe8"},
+    {file = "pygaljs-1.0.2.tar.gz", hash = "sha256:0b71ee32495dcba5fbb4a0476ddbba07658ad65f5675e4ad409baf154dec5111"},
+]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
@@ -560,6 +620,10 @@ pyright = [
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
     {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+]
+pytest-benchmark = [
+    {file = "pytest-benchmark-3.4.1.tar.gz", hash = "sha256:40e263f912de5a81d891619032983557d62a3d85843f9a9f30b98baea0cd7b47"},
+    {file = "pytest_benchmark-3.4.1-py2.py3-none-any.whl", hash = "sha256:36d2b08c4882f6f997fd3126a3d6dfd70f3249cde178ed8bbc0b73db7c20f809"},
 ]
 pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ profile = "black"
 unblob = "unblob.cli:main"
 
 [tool.pytest.ini_options]
-addopts = "--cov=unblob --cov=tests --cov-branch --cov-fail-under=90"
+addopts = "--cov=unblob --cov=tests --cov-branch --cov-fail-under=90 --benchmark-disable"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ pyright = "^0.0.12"
 pre-commit = "^2.15.0"
 pytest-cov = "^3.0.0"
 setuptools-rust = "^1.1.2"
+pytest-benchmark = {version = "^3.4.1", extras = ["histogram"]}
 
 [tool.isort]
 profile = "black"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,3 +26,35 @@ class TestHandler(Handler):
     @staticmethod
     def make_extract_command(*args, **kwargs):
         return ["testcommand", "for", "test", "handler"]
+
+
+def pytest_benchmark_scale_unit(config, unit, benchmarks, best, worst, sort):
+    prefix = ""
+    scale = 1.0
+
+    for benchmark in benchmarks:
+        input_dir = benchmark["params"].get("input_dir")
+        if not input_dir or "scaled" in benchmark:
+            continue
+        input_size = sum(
+            f.stat().st_size for f in input_dir.glob("**/*") if f.is_file()
+        )
+        scale_factor = 1024 * 1024 / input_size
+        benchmark["ops"] /= scale_factor
+        for time_idx in (
+            "hd15iqr",
+            "iqr",
+            "ld15iqr",
+            "max",
+            "mean",
+            "median",
+            "min",
+            "q1",
+            "q3",
+            # "stddev",
+            "total",
+        ):
+            benchmark[time_idx] *= scale_factor
+        benchmark["scaled"] = True
+
+    return prefix, scale


### PR DESCRIPTION
By default all tests will run as before. There is no impact on their
performance.

To benchmark e.g. all compression handlers, run the following command:
`poetry run pytest -k "test_all_handlers[compression." --no-cov --benchmark-enable
--benchmark-histogram`

By default all time unit will be scaled to represent throughput in
MiB/s. Unfortunately `pytest-benchmark` doesn't really support that
mode of operation so there is some hackery involved to do so.

Output of the above example should look like this:

```
--------------------------------------------------------------------------------------------------- benchmark: 8 tests --------------------------------------------------------------------------------------------------
Name (time in s)                                          Min                 Max                Mean            StdDev              Median               IQR            Outliers       OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_all_handlers[compression.lz4.lz4_skippable]      31.3502 (>1000.0)   57.1229 (>1000.0)   35.8496 (>1000.0)  0.0005 (1.78)      33.9003 (>1000.0)  4.5031 (>1000.0)       6;3    0.0279 (0.00)         50           1
test_all_handlers[compression.lz4.lz4_legacy]          0.9306 (288.19)     1.7924 (304.65)     1.0922 (295.80)   0.0008 (2.74)       0.9952 (285.02)   0.1463 (>1000.0)       8;8    0.9156 (0.00)         50           1
test_all_handlers[compression.lzo]                     0.8415 (260.61)     1.1408 (193.90)     0.9310 (252.13)   0.0008 (2.59)       0.8976 (257.09)   0.0568 (399.70)      11;10    1.0741 (0.00)         50           1
test_all_handlers[compression.xz]                      3.5616 (>1000.0)    4.3744 (743.50)     3.7427 (>1000.0)  0.0003 (1.0)        3.7306 (>1000.0)  0.0566 (398.40)        8;7    0.2672 (0.00)         50           1
test_all_handlers[compression.bzip2]                   5.8341 (>1000.0)    6.5419 (>1000.0)    6.0760 (>1000.0)  0.0003 (1.11)       6.0609 (>1000.0)  0.1395 (981.76)       13;3    0.1646 (0.00)         50           1
test_all_handlers[compression.lz4.lz4_default]         0.8940 (276.88)     1.3362 (227.12)     0.9618 (260.47)   0.0016 (5.58)       0.9341 (267.53)   0.0569 (400.19)        6;4    1.0398 (0.00)         50           1
test_all_handlers[compression.lzma]                    3.7157 (>1000.0)    4.4260 (752.28)     3.8710 (>1000.0)  0.0008 (2.81)       3.8208 (>1000.0)  0.1100 (774.20)        6;6    0.2583 (0.00)         50           1
test_all_handlers[compression.lzh]                   193.6711 (>1000.0)  258.6279 (>1000.0)  201.6275 (>1000.0)  0.0051 (17.49)    196.9241 (>1000.0)  8.5945 (>1000.0)       4;4    0.0050 (0.00)         50           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
It will also output a graph like this (in reality it would be an interactive SVG, but it is unsupported by GitHub). Keep in mind, that the time axis contains throughput so the higher, the better:
![benchmark_20220112_114348](https://user-images.githubusercontent.com/1771332/149135454-d19abef9-6623-4407-a5d0-082d397e821f.png)

Unfortunately, the input data is varying greatly in entropy and size so it may not be suited for such comparisons. We could either create a separate perf-test file-set or replace the current very small files with bigger ones.