### PR TITLE
profiling: write high level profiling data of the extraction process

### DIFF
--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -11,6 +11,7 @@ import pytest
 
 from unblob.models import Handler, Handlers, ValidChunk
 from unblob.processing import ExtractionConfig, process_file
+from unblob.testing import check_reports
 
 _ZIP_CONTENT = b"good file"
 # replacing _ZIP_CONTENT with _DAMAGED_ZIP_CONTENT will result in CRC error at unpacking time
@@ -52,7 +53,7 @@ def test_remove_extracted_chunks(input_dir: Path, output_dir: Path):
 
     all_reports = process_file(config, path=input_dir)
     assert list(output_dir.glob("**/*.zip")) == []
-    assert all_reports == [], f"Unexpected error reports: {all_reports}"
+    check_reports(all_reports)
 
 
 def test_keep_all_problematic_chunks(input_dir: Path, output_dir: Path):
@@ -64,7 +65,7 @@ def test_keep_all_problematic_chunks(input_dir: Path, output_dir: Path):
 
     all_reports = process_file(config, path=input_dir)
     # damaged zip file should not be removed
-    assert all_reports != [], "Unexpectedly no errors found!"
+    assert all_reports.errors != [], "Unexpectedly no errors found!"
     assert list(output_dir.glob("**/*.zip"))
 
 
@@ -77,7 +78,7 @@ def test_keep_all_unknown_chunks(input_dir: Path, output_dir: Path):
 
     all_reports = process_file(config, path=input_dir)
     assert list(output_dir.glob("**/*.unknown"))
-    assert all_reports == [], f"Unexpected error reports: {all_reports}"
+    check_reports(all_reports)
 
 
 class _HandlerWithNullExtractor(Handler):
@@ -107,4 +108,4 @@ def test_keep_chunks_with_null_extractor(input_dir: Path, output_dir: Path):
     )
     all_reports = process_file(config, path=input_dir)
     assert list(output_dir.glob("**/*.null"))
-    assert all_reports == [], f"Unexpected error reports: {all_reports}"
+    check_reports(all_reports)

--- a/unblob/models.py
+++ b/unblob/models.py
@@ -8,7 +8,7 @@ import yara
 from structlog import get_logger
 
 from .file_utils import Endian, InvalidInputFormat, StructParser
-from .report import Report
+from .report import Report, Reports
 
 logger = get_logger()
 
@@ -115,8 +115,9 @@ class UnknownChunk(Chunk):
 
 
 class TaskResult:
-    def __init__(self):
-        self._reports = []
+    def __init__(self, task=None):
+        self._task = task
+        self._reports = Reports()
         self._new_tasks = []
 
     def add_report(self, report: Report):
@@ -126,11 +127,15 @@ class TaskResult:
         self._new_tasks.append(task)
 
     @property
+    def task(self):
+        return self._task
+
+    @property
     def new_tasks(self):
         return self._new_tasks
 
     @property
-    def reports(self):
+    def reports(self) -> Reports:
         return self._reports
 
 

--- a/unblob/profiling.py
+++ b/unblob/profiling.py
@@ -1,0 +1,106 @@
+import json
+import os
+import threading
+import time
+from collections import defaultdict
+from typing import cast
+
+import attr
+
+from unblob.report import Report
+
+
+def get_thread_description():
+    pid = os.getpid()
+    current_thread = threading.current_thread()
+    tid = current_thread.native_id
+    tname = current_thread.name
+    return f'Process {pid} Thread {tid} "{tname}"'
+
+
+@attr.define(kw_only=True)
+class OpenEvent(Report):
+    tag: str
+    path: str
+    thread_description: str = attr.field(factory=get_thread_description)
+    timestamp: int = attr.field(factory=time.perf_counter_ns)
+
+
+@attr.define(kw_only=True)
+class CloseEvent(Report):
+    open_event: OpenEvent
+    thread_description: str = attr.field(factory=get_thread_description)
+    timestamp: int = attr.field(factory=time.perf_counter_ns)
+
+
+class PerfCounter:
+    def __init__(self, result, tag, **meta):
+        self.open_event = None
+        self.result = result
+        if meta:
+            kvpairs = ",".join(f"{k}={v!r}" for k, v in meta.items())
+            self.tag = f"{tag} [{kvpairs}]"
+        else:
+            self.tag = tag
+
+    def __enter__(self):
+        self.open_event = OpenEvent(tag=self.tag, path=str(self.result.task.path))
+
+    def __exit__(self, _exc_type, _exc_value, _tb):
+        self.result.add_report(self.open_event)
+        self.result.add_report(CloseEvent(open_event=cast(OpenEvent, self.open_event)))
+
+
+def to_speedscope(report, fd):
+    # Speedscope's file format specification:
+    #   https://github.com/jlfwong/speedscope/wiki/Importing-from-custom-sources#speedscopes-file-format
+    frames = []
+    events = defaultdict(list)
+
+    frame_stack = {}
+
+    type_map = {OpenEvent: "O", CloseEvent: "C"}
+
+    perf_events = [e for e in report if isinstance(e, (OpenEvent, CloseEvent))]
+    perf_events = sorted(perf_events, key=lambda e: e.timestamp)
+    start = perf_events[0].timestamp
+    end = perf_events[-1].timestamp
+
+    for entry in perf_events:
+        if isinstance(entry, OpenEvent):
+            frame_index = len(frames)
+            frame_stack[entry] = frame_index
+            frame = {
+                "name": entry.tag,
+                "file": entry.path,
+            }
+            frames.append(frame)
+        else:
+            frame_index = frame_stack.pop(entry.open_event)
+        thread = entry.thread_description
+        event = {
+            "type": type_map[type(entry)],
+            "frame": frame_index,
+            "at": entry.timestamp,
+        }
+
+        events[thread].append(event)
+
+    profiles = [
+        {
+            "type": "evented",
+            "name": name,
+            "unit": "nanoseconds",
+            "startValue": start,
+            "endValue": end,
+            "events": events,
+        }
+        for name, events in events.items()
+    ]
+
+    speedscope = {
+        "$schema": "https://www.speedscope.app/file-format-schema.json",
+        "shared": {"frames": frames},
+        "profiles": profiles,
+    }
+    json.dump(speedscope, fd, indent=4)

--- a/unblob/report.py
+++ b/unblob/report.py
@@ -11,11 +11,9 @@ class Severity(Enum):
     WARNING = "WARNING"
 
 
-@attr.define(kw_only=True)
+@attr.define(frozen=True, kw_only=True)
 class Report:
     """A common base class for different reports"""
-
-    severity: Severity
 
     # Stored in `str` rather than `Handler`, because the pickle picks ups structs from `C_DEFINITIONS`
     handler: Optional[str] = None
@@ -24,8 +22,18 @@ class Report:
         return attr.asdict(self)
 
 
+class Error(Report):
+    severity: Severity
+
+
+class Reports(List[Report]):
+    @property
+    def errors(self) -> List[Error]:
+        return [r for r in self if isinstance(r, Error)]
+
+
 @attr.define(kw_only=True)
-class UnknownError(Report):
+class UnknownError(Error):
     """Describes an exception raised during file processing"""
 
     severity: Severity = Severity.ERROR
@@ -40,7 +48,7 @@ class CalculateChunkExceptionReport(UnknownError):
 
 
 @attr.define(kw_only=True)
-class ExtractCommandFailedReport(Report):
+class ExtractCommandFailedReport(Error):
     """Describes an error when failed to run the extraction command"""
 
     severity: Severity = Severity.WARNING
@@ -51,7 +59,7 @@ class ExtractCommandFailedReport(Report):
 
 
 @attr.define(kw_only=True)
-class ExtractorDependencyNotFoundReport(Report):
+class ExtractorDependencyNotFoundReport(Error):
     """Describes an error when the dependency of an extractor doesn't exist"""
 
     severity: Severity = Severity.ERROR
@@ -59,7 +67,7 @@ class ExtractorDependencyNotFoundReport(Report):
 
 
 @attr.define(kw_only=True)
-class MaliciousSymlinkRemoved(Report):
+class MaliciousSymlinkRemoved(Error):
     """Describes an error when malicious symlinks have been removed from disk."""
 
     severity: Severity = Severity.WARNING

--- a/unblob/testing.py
+++ b/unblob/testing.py
@@ -1,13 +1,12 @@
 import shlex
 import subprocess
 from pathlib import Path
-from typing import List
 
 import pytest
 from pytest_cov.embed import cleanup_on_sigterm
 
 from unblob.logging import configure_logger
-from unblob.report import Report
+from unblob.report import Reports
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -62,7 +61,7 @@ def check_output_is_the_same(reference_dir: Path, extract_dir: Path):
         pytest.fail(f"\nDiff command: {runnable_diff_command}\n{exc.stdout}\n")
 
 
-def check_reports(reports: List[Report]):
+def check_reports(reports: Reports):
     __tracebackhide__ = True
 
-    assert reports == [], "Unexpected error reports"
+    assert reports.errors == [], "Unexpected error reports"


### PR DESCRIPTION
To try the visualization without checking out this branch, here is a [sample file (zip)](https://github.com/IoT-Inspector/unblob/files/8364912/speescope_sample.zip). Extract it, then upload it to https://speedscope.app

Questions:
- [x] **Q**: Where should we put the profile files? It makes sense to put them next to the extract folder or also into the extract folder.
  **A**: As there can be multiple input files, but we could write a single profile for the whole run, so it makes sense to expect the output location as an argument.