### PR TITLE
elf: fix kernel initramfs extraction padding calculation

### DIFF
--- a/unblob/handlers/executable/elf.py
+++ b/unblob/handlers/executable/elf.py
@@ -73,7 +73,14 @@ class ELFKernelExtractor(Extractor):
                     endian=endian,
                 )
 
-            padding = round_up(initramfs_size + 4, 8) - initramfs_size - 4
+            max_padding = 0
+            while (
+                file[initramfs_size_offset - max_padding - 1] == 0 and max_padding < 8
+            ):
+                max_padding += 1
+
+            padding = min(max_padding, round_up(initramfs_size, 8) - initramfs_size + 4)
+
             initramfs_end = initramfs_size_offset - padding
             initramfs_start = initramfs_end - initramfs_size
 


### PR DESCRIPTION
As the initramfs starts on a 4 byte offset and the size is put on an 8byte
offset it is not too well defined on where the start offset is, as we can
exactly calculate it from just the size and the size offset.

#define INIT_RAM_FS                                                     \
        . = ALIGN(4);                                                   \
        __initramfs_start = .;                                          \
        KEEP(*(.init.ramfs))                                            \
        . = ALIGN(8);                                                   \
        KEEP(*(.init.ramfs.info))

To calculate the padding we try to look at the max padding size where the
padding is the alignment before the ALIGN(8), which should be 0 padded.

Unfortunatelly sometime the init.ramfs itself has some zero padding, so
we use the calculated padding +4 bytes for the cases when there is an extra
4 bytes but use maximum padding up till 0 bytes are detected. This could
still result in misscalculation, but only if the 4 byte alignments overlap
with 0bytes at the end of valid initramfs.