### PR TITLE
elf: consider cases when program segments are located at the end of the file

### DIFF
--- a/tests/integration/executable/elf/elf32/__input__/sample_32_prg_end.elf
+++ b/tests/integration/executable/elf/elf32/__input__/sample_32_prg_end.elf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5755d4f41982bdaae3edb565813ffe193db1d0576d77d4170b3b0082d04dda37
+size 36917


### PR DESCRIPTION

Program segments can be placed at the end of the file, up till now we did not
calculate the program segment end hence ELF files where program segments
were placed at the end of the file were miss calculated. This could happen
when there are no sections in the ELF file, which is unusual though possible.

closes #388 