### PR TITLE
unblob: renaming leftover references to IoT-Inspector

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: Install sasquatch
       run: |
-        curl -L -o sasquatch_1.0_amd64.deb https://github.com/IoT-Inspector/sasquatch/releases/download/sasquatch-v1.0/sasquatch_1.0_amd64.deb
+        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v1.0/sasquatch_1.0_amd64.deb
         sudo dpkg -i sasquatch_1.0_amd64.deb
         rm -f sasquatch_1.0_amd64.deb
       shell: bash

--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -9,7 +9,7 @@ on:
       - '**'
 
 env:
-  DOCKER_IMAGE: ghcr.io/iot-inspector/unblob:latest
+  DOCKER_IMAGE: ghcr.io/onekey-sec/unblob:latest
 
 jobs:
   build-and-push-image:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -35,9 +35,9 @@ This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project maintainers at research@iot-inspector.com. If
+reported by contacting the project maintainers at research@onekey.com. If
 the incident involves a committer, you may report directly to
-florian.lukavsky@iot-inspector.com.
+florian.lukavsky@onekey.com.
 
 All complaints will be reviewed and investigated and will result in a
 response that is deemed necessary and appropriate to the circumstances.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ unblob is a tool for getting information out of any kind of binary blob.
 ## Quickstart
 
 Unblob can be used right away from a `docker` container: \
-`ghcr.io/iot-inspector/unblob:latest`
+`ghcr.io/onekey-sec/unblob:latest`
 
 The `--pull always` option is recommended, because the project is currently under heavy development, so we expect frequent changes.
 
@@ -16,12 +16,12 @@ docker run \
   --pull always \
   -v /path/to/out/dir/on/host:/data/output \
   -v /path/to/files/on/host:/data/input \
-ghcr.io/iot-inspector/unblob:latest /data/input/path/to/file
+ghcr.io/onekey-sec/unblob:latest /data/input/path/to/file
 ```
 
 Help on usage:
 ```shell
-docker run --rm --pull always ghcr.io/iot-inspector/unblob:latest --help
+docker run --rm --pull always ghcr.io/onekey-sec/unblob:latest --help
 ```
 
 ### Using Nix

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,14 @@
 # Security Policy
 
 ## Reporting
-As a security company, IoT Inspector commits to all of its open source products having sound and secure implementations.
+As a security company, ONEKEY commits to all of its open source products having sound and secure implementations.
 
-All security bugs in IoT Inspector products should be reported by email to security@iot-inspector.com. We strongly suggest that you encrypt your email content using our PGP public key (see below). Security bugs must not  be reported through public Github issues.
+All security bugs in ONEKEY products should be reported by email to security@onekey.com. We strongly suggest that you encrypt your email content using our PGP public key (see below). Security bugs must not  be reported through public Github issues.
 
 In accordance with the [Responsible Full Disclosure Policy (RFPolicy) v2.0](https://dl.packetstormsecurity.net/papers/general/rfpolicy-2.0.txt), your email will be acknowledged within five days. The security team will then keep you informed of the progress being made towards a fix and full announcement at least every five days.
 
 ## Disclosure policy
-IoT Inspector has a 5 step disclosure process.
+ONEKEY has a 5 step disclosure process.
 
 1. The security report is received and is assigned a primary handler. This person will coordinate the fix and release process.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "unblob"
 version = "0.1.0"
 description = "Extract files from any kind of container formats"
-authors = ["IoT Inspector <support@iot-inspector.com>"]
+authors = ["ONEKEY <support@onekey.com>"]
 license = "MIT"
 packages = [
     { include = "unblob" },


### PR DESCRIPTION
One functional breakage beside references to the company name right
now is the container registry which makes publishing images break.