### PR TITLE
Explicitly set LIEF logging level.

### DIFF
--- a/unblob/handlers/executable/elf.py
+++ b/unblob/handlers/executable/elf.py
@@ -16,6 +16,8 @@ from unblob.file_utils import (
 )
 from unblob.models import ExtractError, Extractor, HexString, StructHandler, ValidChunk
 
+lief.logging.set_level(lief.logging.LOGGING_LEVEL.ERROR)
+
 
 class NullExtract(ExtractError):
     pass


### PR DESCRIPTION
We don't want informational logs from LIEF polluting unblob logs, but we do want to be informed when something really wrong happened so instead of completely disabling LIEF logging, we set the level to CRITICAL.

Fixes #391