### PR TITLE
Improve cramfs CRC check

### DIFF
--- a/tests/integration/filesystem/cramfs/big_endian/__input__/fruits.crc_swap.cramfs_be
+++ b/tests/integration/filesystem/cramfs/big_endian/__input__/fruits.crc_swap.cramfs_be
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de1d6be79d816470ff54836760a0a1574fba6c2efa9ed13108f0669eb329d749
+size 4096

--- a/tests/integration/filesystem/cramfs/big_endian/__input__/fruits.old.cramfs_be
+++ b/tests/integration/filesystem/cramfs/big_endian/__input__/fruits.old.cramfs_be
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad4972ed94445a852d88ecee148fe34699b417d9885a84e47d328a300c0d7a37
+size 4096

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be_extract/apple.txt
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be_extract/cherry.txt
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be_extract/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be_extract/apple.txt
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be_extract/cherry.txt
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be_extract/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/cramfs/little_endian/__input__/fruits.crc_swap.cramfs_le
+++ b/tests/integration/filesystem/cramfs/little_endian/__input__/fruits.crc_swap.cramfs_le
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e594657cd8a394eb7abb2a10041681a925edb95e829d37a7a4ac5168f026b9e
+size 4096

--- a/tests/integration/filesystem/cramfs/little_endian/__input__/fruits.old.cramfs_le
+++ b/tests/integration/filesystem/cramfs/little_endian/__input__/fruits.old.cramfs_le
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bd27287c45ce34df662963e1541f5f13cf8b22f30e14942031dabd80a1596ea
+size 4096

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le_extract/apple.txt
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le_extract/cherry.txt
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le_extract/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le_extract/apple.txt
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le_extract/cherry.txt
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le_extract/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7


### PR DESCRIPTION
We observed a sample from Cisco where the CRC value was stored in a different endianness. This is non standard but we decided to support it anyway.
    
We also added a check for old cramfs format. If it's an old format, the CRC check always returns true because it's not supported.
    
More information about CRC validation and old format: https://github.com/secularbird/cramfs/blob/master/cramfsck.c

Closes #394 