### PR TITLE
Change from file-magic to python-magic, use MAGIC_CONTINUE

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -63,9 +63,9 @@ let
         ];
       });
 
-      file-magic = (super.file-magic.override { preferWheel = false; }).overridePythonAttrs (_: {
+      python-magic = (super.python-magic.override { preferWheel = false; }).overridePythonAttrs (_: {
         patchPhase = ''
-          substituteInPlace magic.py --replace "find_library('magic')" "'${file}/lib/libmagic.so'"
+          substituteInPlace magic/loader.py --replace "find_library('magic')" "'${file}/lib/libmagic.so'"
         '';
       });
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -106,14 +106,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "file-magic"
-version = "0.4.0"
-description = "(official) libmagic Python bindings"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "filelock"
 version = "3.4.0"
 description = "A platform independent file lock."
@@ -347,6 +339,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "python-magic"
+version = "0.4.27"
+description = "File type identification using libmagic"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
@@ -482,7 +482,7 @@ resolved_reference = "24e6e453a36a02144ae2d159eb3229f9c6312828"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "da0b1ce25e41110fbc2efd471195febe8fa492695981095f4f10cb331de5f9b9"
+content-hash = "5a046d7c4fcb81e6b34746e359368432125612384756147827362a13479592b5"
 
 [metadata.files]
 arpy = [
@@ -566,10 +566,6 @@ cstruct = [
 distlib = [
     {file = "distlib-0.3.3-py2.py3-none-any.whl", hash = "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31"},
     {file = "distlib-0.3.3.zip", hash = "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"},
-]
-file-magic = [
-    {file = "file-magic-0.4.0.tar.gz", hash = "sha256:4dd1492b9a9ca57c272aaa9cc495cd65310115b2aec5503c7d047ad9bfae1035"},
-    {file = "file_magic-0.4.0-py3-none-any.whl", hash = "sha256:8ea03da58cf4de5a69909c0e27746cf17fc903356a601967ab01577916a73aed"},
 ]
 filelock = [
     {file = "filelock-3.4.0-py3-none-any.whl", hash = "sha256:2e139a228bcf56dd8b2274a65174d005c4a6b68540ee0bdbb92c76f43f29f7e8"},
@@ -691,6 +687,10 @@ pytest-cov = [
 ]
 python-lzo = [
     {file = "python-lzo-1.14.tar.gz", hash = "sha256:83cbd8ecaae284735250e31d6c0ecc18ac08763fab2a8c910dc5a6910db6250c"},
+]
+python-magic = [
+    {file = "python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b"},
+    {file = "python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ jefferson = { git = "https://github.com/onekey-sec/jefferson.git", rev = "ddbc59
 yaffshiv = { git = "https://github.com/onekey-sec/yaffshiv.git", rev = "24e6e453a36a02144ae2d159eb3229f9c6312828" }
 plotext = "^4.1.5"
 pluggy = "^1.0.0"
-file-magic = "^0.4.0"
+python-magic = "^0.4.27"
 hyperscan = "^0.3.0"
 lark = "^1.1.2"
 lz4 = "^4.0.0"

--- a/unblob/report.py
+++ b/unblob/report.py
@@ -140,6 +140,18 @@ class StatReport(Report):
         )
 
 
+# libmagic helpers
+# file magic uses a rule-set to guess the file type, however as rules are added they could
+# shadow each other. File magic uses rule priorities to determine which is the best matching
+# rule, however this could shadow other valid matches as well, which could eventually break
+# any further processing that depends on magic.
+# By enabling keep_going (which eventually enables MAGIC_CONTINUE) all matching patterns
+# will be included in the magic string at the cost of being a bit slower, but increasing
+# accuracy by no shadowing rules.
+get_magic = magic.Magic(keep_going=True).from_file
+get_mime_type = magic.Magic(mime=True).from_file
+
+
 @attr.define(kw_only=True)
 class FileMagicReport(Report):
     magic: str
@@ -147,8 +159,7 @@ class FileMagicReport(Report):
 
     @classmethod
     def from_path(cls, path: Path):
-        detected = magic.detect_from_filename(path)
-        return cls(magic=detected.name, mime_type=detected.mime_type)
+        return cls(magic=get_magic(path), mime_type=get_mime_type(path))
 
 
 @attr.define(kw_only=True)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -5,7 +5,7 @@ from unblob import cli
 from unblob.file_utils import File, iterbits, round_down
 from unblob.models import _JSONEncoder
 from unblob.parser import _HexStringToRegex
-from unblob.report import ChunkReport
+from unblob.report import ChunkReport, FileMagicReport
 
 _HexStringToRegex.literal
 _HexStringToRegex.wildcard
@@ -16,6 +16,8 @@ _HexStringToRegex.alternative
 _JSONEncoder.default
 
 ChunkReport.handler_name
+FileMagicReport.magic
+FileMagicReport.mime_type
 
 sys.breakpointhook
 cli.cli.context_class


### PR DESCRIPTION
MAGIC_CONTINUE is more transparently supported with python-magic.
Also file-magic's last release was in 2018,
while there are recent changes on github.