### PR TITLE
Update hyperscan to 0.3.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -127,7 +127,7 @@ testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-co
 
 [[package]]
 name = "hyperscan"
-version = "0.2.0"
+version = "0.3.2"
 description = "Python bindings for Hyperscan."
 category = "main"
 optional = false
@@ -482,7 +482,7 @@ resolved_reference = "24e6e453a36a02144ae2d159eb3229f9c6312828"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "e8ab337cfe95470058dcf866c3582397e9cc57a6174489bbad5b37aa1b11d237"
+content-hash = "da0b1ce25e41110fbc2efd471195febe8fa492695981095f4f10cb331de5f9b9"
 
 [metadata.files]
 arpy = [
@@ -576,11 +576,12 @@ filelock = [
     {file = "filelock-3.4.0.tar.gz", hash = "sha256:93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4"},
 ]
 hyperscan = [
-    {file = "hyperscan-0.2.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:47ef10b4297f9976d257b7f260ae4ae8834e87e1abb7f46cf0707ba496fb6e49"},
-    {file = "hyperscan-0.2.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:78e97de71896b9fda4368c185e6609e53bb240c85302909ac46e738f14621f40"},
-    {file = "hyperscan-0.2.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:794eecc13fa9bcf061004340582aab342471fb22b710f92020e3ea508776ff53"},
-    {file = "hyperscan-0.2.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:fd0d0fe64484443b9e5ee1e8b156a30f2ba91494b1343fae5c943130ff847607"},
-    {file = "hyperscan-0.2.0.tar.gz", hash = "sha256:10cb8939d7db85d522ed319031ff5ab86fd0133126b986290f01aa83dbfb9ff7"},
+    {file = "hyperscan-0.3.2-cp310-cp310-manylinux_2_24_x86_64.whl", hash = "sha256:fa6eebbd9d4c618eb8d09680ae332d508c5c6060431a38b23ae336c8be6eb130"},
+    {file = "hyperscan-0.3.2-cp36-cp36m-manylinux_2_24_x86_64.whl", hash = "sha256:1863df991196a883472132e7945425f165bac3dd3ea05f45d98bdf44508fe55f"},
+    {file = "hyperscan-0.3.2-cp37-cp37m-manylinux_2_24_x86_64.whl", hash = "sha256:18b964bc277458eb2a915f1f02b5e326e1a3b48dbb790a7dd952a220ed7fec29"},
+    {file = "hyperscan-0.3.2-cp38-cp38-manylinux_2_24_x86_64.whl", hash = "sha256:866d635698f2767c1bccf78d8a5ebec415085a65d74fa1d6c1017d134504a13f"},
+    {file = "hyperscan-0.3.2-cp39-cp39-manylinux_2_24_x86_64.whl", hash = "sha256:f1c6c4fd4df700a0031501ab4e3e51db7615b73b86ca69a1775197ed9eadfecd"},
+    {file = "hyperscan-0.3.2.tar.gz", hash = "sha256:8dacf5b839cfb31004aee07cf3f3e0c57e0da7dc4445e2e70aeab3250863796f"},
 ]
 identify = [
     {file = "identify-2.3.7-py2.py3-none-any.whl", hash = "sha256:12f204544d1b718d5be2c82d95d30ff163614d7e15ae180bfbe923614a5f9a9f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ yaffshiv = { git = "https://github.com/onekey-sec/yaffshiv.git", rev = "24e6e453
 plotext = "^4.1.5"
 pluggy = "^1.0.0"
 file-magic = "^0.4.0"
-hyperscan = "^0.2.0"
+hyperscan = "^0.3.0"
 lark = "^1.1.2"
 lz4 = "^4.0.0"
 lief = "^0.12.1"


### PR DESCRIPTION
It seems from the hyperscan CHANGELOG:
https://github.com/darvid/python-hyperscan/blob/master/CHANGELOG.md

there are no breaking changes for us, it needs the Hyperscan v5.4.0 version,
which is the default version on python:3.8, python:3.10 and ubuntu:22.04
Docker images.