### PR TITLE
Nix improvements

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -96,8 +96,6 @@ let
       rust.cargo
       rust.rustc
     ];
-
-    editablePackageSources = { "unblob" = ./unblob; };
   };
 in
 self // {

--- a/flake.nix
+++ b/flake.nix
@@ -29,8 +29,6 @@
 
       defaultPackage.${system} = unblob;
 
-      devShell.${system} = pkgs.mkShell {
-        packages = [ unblob.editableEnv unblob.runtimeDeps ];
-      };
+      devShell.${system} = import ./shell.nix { inherit pkgs; };
     };
 }

--- a/nix/poetry/default.nix
+++ b/nix/poetry/default.nix
@@ -30,7 +30,7 @@ let
             # cargoSetupHook won't work for building the python environment
             nativeBuildInputs = builtins.filter
               (inp: inp != rustPlatform.cargoSetupHook)
-              args.nativeBuildInputs;
+              (args.nativeBuildInputs or [ ]);
           } // builtins.removeAttrs args [
             "editablePackageSources"
             "nativeBuildInputs"

--- a/nix/poetry/default.nix
+++ b/nix/poetry/default.nix
@@ -6,38 +6,41 @@
 
 { lib, mkShell, poetry2nix, stdenv, rustPlatform }:
 
-{ projectDir, overrides, editablePackageSources, preferWheels ? false, ... }@args:
-
 let
-  # pass all args which are not specific to mkPoetryEnv
-  app = poetry2nix.mkPoetryApplication (builtins.removeAttrs args [ "editablePackageSources" ]);
+  self = { projectDir, overrides, editablePackageSources, python, preferWheels ? false, ... }@args:
 
-  # pass args specific to mkPoetryEnv and all remaining arguments to mkDerivation
-  editableEnv =
-    stdenv.mkDerivation (
-      {
-        name = "${app.pname}-editable-env";
-        src = poetry2nix.mkPoetryEnv {
-          inherit projectDir editablePackageSources overrides preferWheels;
-        };
+    let
+      # pass all args which are not specific to mkPoetryEnv
+      app = poetry2nix.mkPoetryApplication (builtins.removeAttrs args [ "editablePackageSources" ]);
 
-        installPhase = ''
-          mkdir -p $out
-          cp -a * $out
-        '';
+      # pass args specific to mkPoetryEnv and all remaining arguments to mkDerivation
+      editableEnv =
+        stdenv.mkDerivation (
+          {
+            name = "${app.pname}-editable-env";
+            src = poetry2nix.mkPoetryEnv {
+              inherit projectDir editablePackageSources overrides preferWheels python;
+            };
 
-        # cargoSetupHook won't work for building the python environment
-        nativeBuildInputs = builtins.filter
-          (inp: inp != rustPlatform.cargoSetupHook)
-          args.nativeBuildInputs;
-      } // builtins.removeAttrs args [
-        "editablePackageSources"
-        "nativeBuildInputs"
-        "overrides"
-        "projectDir"
-      ]
-    );
+            installPhase = ''
+              mkdir -p $out
+              cp -a * $out
+            '';
+
+            # cargoSetupHook won't work for building the python environment
+            nativeBuildInputs = builtins.filter
+              (inp: inp != rustPlatform.cargoSetupHook)
+              args.nativeBuildInputs;
+          } // builtins.removeAttrs args [
+            "editablePackageSources"
+            "nativeBuildInputs"
+            "overrides"
+            "projectDir"
+          ]
+        );
+    in
+    app.overrideAttrs (super: {
+      passthru = super.passthru // { inherit app editableEnv; };
+    });
 in
-app.overrideAttrs (super: {
-  passthru = super.passthru // { inherit app editableEnv; };
-})
+lib.makeOverridable self

--- a/nix/poetry/default.nix
+++ b/nix/poetry/default.nix
@@ -7,14 +7,14 @@
 { lib, mkShell, poetry2nix, stdenv, rustPlatform }:
 
 let
-  self = { projectDir, overrides, editablePackageSources, python, preferWheels ? false, ... }@args:
+  self = { projectDir, overrides, python, preferWheels ? false, ... }@args:
 
     let
       # pass all args which are not specific to mkPoetryEnv
       app = poetry2nix.mkPoetryApplication (builtins.removeAttrs args [ "editablePackageSources" ]);
 
       # pass args specific to mkPoetryEnv and all remaining arguments to mkDerivation
-      editableEnv =
+      mkEditableEnv = editablePackageSources:
         stdenv.mkDerivation (
           {
             name = "${app.pname}-editable-env";
@@ -40,7 +40,7 @@ let
         );
     in
     app.overrideAttrs (super: {
-      passthru = super.passthru // { inherit app editableEnv; };
+      passthru = super.passthru // { inherit app mkEditableEnv; };
     });
 in
 lib.makeOverridable self

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,15 @@
 # This file is to let "legacy" nix-shell command work in addition to `nix develop`
 let
   flake = builtins.getFlake (toString ./.);
-  system = builtins.currentSystem;
+  flakePkgs = flake.legacyPackages.${builtins.currentSystem};
 in
-flake.devShell."${system}"
+{ pkgs ? flakePkgs }:
+
+with pkgs; mkShell {
+  packages = [
+    (unblob.mkEditableEnv { "unblob" = ./.; })
+    unblob.runtimeDeps
+    poetry
+    lzo
+  ];
+}


### PR DESCRIPTION
- A `nix-shell` will create an editable environment from which all the imports are properly resolved inside the source tree. Previously it required a `PYTHONPATH=.` magic.
- I'd like to have `mkPoetryApp` helper extracted some time. This PR contains some work to make it little more general and not specific to unblob.
- Also extending `mkPoetryApp` to be able to override its attributes from downstream Nix derivations, e.g. to use a different Python version.