### PR TITLE
Nix flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657177452,
-        "narHash": "sha256-CojBqno3Zbw9/788+kCjRXXornpc4jJGC6RYvTYdVkg=",
+        "lastModified": 1658850041,
+        "narHash": "sha256-HA4koSVBPEERWSrH0LVBy28y2FGJnOeUmGDEyeQPmDY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5cbfadba693e0453f3a4090e83fbf845e18d184b",
+        "rev": "3bbb296d9a0088c314ce83038b896753bbe33acb",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1657202131,
-        "narHash": "sha256-Kb6RDO0BuN0qBcoKpErA0GUC0w8vs/KIAbRDyu0WwM0=",
+        "lastModified": 1658934575,
+        "narHash": "sha256-EfXDlOgvu8NKcVaCTbTI4z7FfcbZkpF6OB38sVL4m4c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64cc7abb6e54250618b45a6be88255cc33c0c716",
+        "rev": "4a1f5a1a7da8bcf205f4f691408f8cc0bd906fee",
         "type": "github"
       },
       "original": {
@@ -52,11 +52,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1657149754,
-        "narHash": "sha256-iSnZoqwNDDVoO175whSuvl4sS9lAb/2zZ3Sa4ywo970=",
+        "lastModified": 1658665240,
+        "narHash": "sha256-/wkx7D7enyBPRjIkK0w7QxLQhzEkb3UxNQnjyc3FTUI=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "fc1930e011dea149db81863aac22fe701f36f1b5",
+        "rev": "8b8edc85d24661d5a6d0d71d6a7011f3e699780f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,5 +30,7 @@
       defaultPackage.${system} = unblob;
 
       devShell.${system} = import ./shell.nix { inherit pkgs; };
+
+      legacyPackages.${system} = pkgs;
     };
 }


### PR DESCRIPTION
Updated nix dependencies

```
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/5cbfadba693e0453f3a4090e83fbf845e18d184b' (2022-07-07)
  → 'github:NixOS/nixpkgs/3bbb296d9a0088c314ce83038b896753bbe33acb' (2022-07-26)
• Updated input 'poetry2nix':
    'github:nix-community/poetry2nix/fc1930e011dea149db81863aac22fe701f36f1b5' (2022-07-06)
  → 'github:nix-community/poetry2nix/8b8edc85d24661d5a6d0d71d6a7011f3e699780f' (2022-07-24)
• Updated input 'poetry2nix/nixpkgs':
    'github:NixOS/nixpkgs/64cc7abb6e54250618b45a6be88255cc33c0c716' (2022-07-07)
  → 'github:NixOS/nixpkgs/4a1f5a1a7da8bcf205f4f691408f8cc0bd906fee' (2022-07-27)
```

Also fixed a mistake, from the previous nix-shell refactor. (I have no idea how it got introduced)

`shell.nix` was changed recently to use the package set from
`flake.nix`, however the required output attribute was missing,
causing this error:

```
error: attribute 'legacyPackages' missing

       at /home/vlaci/devel/git/github.com/IoT-Inspector/unblob/shell.nix:4:15:

            3|   flake = builtins.getFlake (toString ./.);
            4|   flakePkgs = flake.legacyPackages.${builtins.currentSystem};
             |               ^
            5| in
```
