### PR TITLE
feat(handler/cpio): add support for truncated CPIO archives

### DIFF
--- a/tests/integration/archive/cpio/cpio_binary/__input__/apple.cpio-bin.truncated
+++ b/tests/integration/archive/cpio/cpio_binary/__input__/apple.cpio-bin.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e33b7832c25974b72f5e6fa323593530504a76d6ecf81a69fb7ee4a3be36adc
+size 184

--- a/tests/integration/archive/cpio/cpio_binary/__input__/empty.cpio-bin.truncated
+++ b/tests/integration/archive/cpio/cpio_binary/__input__/empty.cpio-bin.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f256ce3b6bb5531b007df2e8db3679c6ba70c8f09c8c43ae34279aa6337f515
+size 224

--- a/tests/integration/archive/cpio/cpio_binary/__input__/test.bin.cpio.truncated
+++ b/tests/integration/archive/cpio/cpio_binary/__input__/test.bin.cpio.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f8cf46a8caf8320cefed8b8bb3e81dc2b7eb62b6dafb8cb8d30c0227a1dad74
+size 592

--- a/tests/integration/archive/cpio/cpio_binary/__output__/apple.cpio-bin.truncated_extract/apple1.txt
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/apple.cpio-bin.truncated_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/cpio/cpio_binary/__output__/apple.cpio-bin.truncated_extract/apple2.txt
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/apple.cpio-bin.truncated_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/archive/cpio/cpio_binary/__output__/apple.cpio-bin.truncated_extract/apple3.txt
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/apple.cpio-bin.truncated_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/archive/cpio/cpio_binary/__output__/apple.cpio-bin.truncated_extract/apple4.txt
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/apple.cpio-bin.truncated_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/archive/cpio/cpio_binary/__output__/empty.cpio-bin.truncated_extract/apple1.txt
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/empty.cpio-bin.truncated_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/cpio/cpio_binary/__output__/empty.cpio-bin.truncated_extract/hello1.txt
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/empty.cpio-bin.truncated_extract/hello1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d678c54ff53cac1efd6d62697aeb5a005491cd04b83228fd8411ba9f02b98e7
+size 7

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test0
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test00
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test00
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test000
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test0000
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test0000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test0001
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test0001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test0002
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test0002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test0003
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test0003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test001
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test002
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test003
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test01
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test01
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test02
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test02
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test03
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test03
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test1
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test2
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test3
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/test.bin.cpio.truncated_extract/test3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__input__/apple.cpio-newc.truncated
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__input__/apple.cpio-newc.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6ca1be250631b6491034de1cb8d9c108ddf66e31e860028757ff53e467011cd
+size 528

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__input__/empty.cpio-newc.truncated
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__input__/empty.cpio-newc.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45b8f9a65a4dcb3fe21d144d58515456761dc9916bd079fd650bd99a6aadadf1
+size 736

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__input__/test.newc.cpio.truncated
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__input__/test.newc.cpio.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f813b2facfccb835bef2b68f7f2e2bce86bb685eef500ad6c44d198338254b0b
+size 1968

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/apple.cpio-newc.truncated_extract/apple1.txt
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/apple.cpio-newc.truncated_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/apple.cpio-newc.truncated_extract/apple2.txt
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/apple.cpio-newc.truncated_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/apple.cpio-newc.truncated_extract/apple3.txt
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/apple.cpio-newc.truncated_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/apple.cpio-newc.truncated_extract/apple4.txt
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/apple.cpio-newc.truncated_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/empty.cpio-newc.truncated_extract/apple1.txt
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/empty.cpio-newc.truncated_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/empty.cpio-newc.truncated_extract/hello1.txt
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/empty.cpio-newc.truncated_extract/hello1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d678c54ff53cac1efd6d62697aeb5a005491cd04b83228fd8411ba9f02b98e7
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test0
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test00
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test00
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test000
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test0000
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test0000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test0001
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test0001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test0002
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test0002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test0003
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test0003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test001
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test002
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test003
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test01
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test01
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test02
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test02
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test03
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test03
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test1
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test2
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test3
+++ b/tests/integration/archive/cpio/cpio_portable_ascii/__output__/test.newc.cpio.truncated_extract/test3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__input__/apple.cpio-crc.truncated
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__input__/apple.cpio-crc.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cead46491006737c5817bb7f941467604e0d34abaf26bad74f9e35cc8005b31
+size 528

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__input__/empty.cpio-crc.truncated
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__input__/empty.cpio-crc.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4a9dc103742ba37104abd7dd22449210d71ea34dc000ef9b8ef79cb710aaf13
+size 736

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__input__/test.crc.cpio.truncated
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__input__/test.crc.cpio.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a61484c134598ab66a4fc61708a609b2616f2f1822414eac48bed1f9256a3615
+size 1968

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/apple.cpio-crc.truncated_extract/apple1.txt
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/apple.cpio-crc.truncated_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/apple.cpio-crc.truncated_extract/apple2.txt
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/apple.cpio-crc.truncated_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/apple.cpio-crc.truncated_extract/apple3.txt
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/apple.cpio-crc.truncated_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/apple.cpio-crc.truncated_extract/apple4.txt
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/apple.cpio-crc.truncated_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/empty.cpio-crc.truncated_extract/apple1.txt
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/empty.cpio-crc.truncated_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/empty.cpio-crc.truncated_extract/hello1.txt
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/empty.cpio-crc.truncated_extract/hello1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d678c54ff53cac1efd6d62697aeb5a005491cd04b83228fd8411ba9f02b98e7
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test0
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test00
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test00
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test000
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test0000
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test0000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test0001
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test0001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test0002
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test0002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test0003
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test0003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test001
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test002
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test003
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test01
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test01
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test02
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test02
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test03
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test03
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test1
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test2
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test3
+++ b/tests/integration/archive/cpio/cpio_portable_ascii_crc/__output__/test.crc.cpio.truncated_extract/test3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__input__/apple.cpio-odc.truncated
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__input__/apple.cpio-odc.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dbda427d3d1a86ac48f7c435353c513c2c4a74f583227c4525ca86a61ffe159
+size 376

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__input__/empty.cpio-odc.truncated
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__input__/empty.cpio-odc.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b672365073259a53a5a1d939fdae7439f6360be03371e488b88fc0ffd462107a
+size 520

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__input__/test.odc.cpio.truncated
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__input__/test.odc.cpio.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8eed7c05bdb0b23b23867b1dcde5a9901e33e1261d8c5b28347e12e405e777a
+size 1376

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/apple.cpio-odc.truncated_extract/apple1.txt
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/apple.cpio-odc.truncated_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/apple.cpio-odc.truncated_extract/apple2.txt
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/apple.cpio-odc.truncated_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/apple.cpio-odc.truncated_extract/apple3.txt
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/apple.cpio-odc.truncated_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/apple.cpio-odc.truncated_extract/apple4.txt
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/apple.cpio-odc.truncated_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/empty.cpio-odc.truncated_extract/apple1.txt
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/empty.cpio-odc.truncated_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/empty.cpio-odc.truncated_extract/hello1.txt
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/empty.cpio-odc.truncated_extract/hello1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d678c54ff53cac1efd6d62697aeb5a005491cd04b83228fd8411ba9f02b98e7
+size 7

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test0
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test00
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test00
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test000
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test0000
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test0000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b68ab3847feda7d6c62c1fbcbeebfa35eab7351ed5e78f4ddadea5df64b8015
+size 1

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test0001
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test0001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test0002
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test0002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test0003
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test0003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test001
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test002
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test002
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test003
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test003
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test01
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test01
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test02
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test02
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test03
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test03
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test1
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecc76c19c9f3c5108773d6c3a18a6c25c9bf1131c4e250b71213274e3b2b5d08
+size 2

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test2
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b38b8f5877f2395b4361c1f68c059078ee9c0c8b0cbb22c97d2906e011e40a3
+size 3

--- a/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test3
+++ b/tests/integration/archive/cpio/cpio_portable_old_ascii/__output__/test.odc.cpio.truncated_extract/test3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b346904f63cc07f1d8cc2d88d7dae08a3f088a0e4159d5214c27a6571a51eb4
+size 4

--- a/unblob/handlers/archive/cpio.py
+++ b/unblob/handlers/archive/cpio.py
@@ -99,6 +99,8 @@ class _CPIOHandlerBase(StructHandler):
         end_offset = start_offset + self._pad_file(
             file_with_offset, current_offset - start_offset
         )
+        if start_offset == end_offset:
+            return
         return ValidChunk(
             start_offset=start_offset,
             end_offset=end_offset,

--- a/unblob/handlers/archive/cpio.py
+++ b/unblob/handlers/archive/cpio.py
@@ -51,13 +51,18 @@ class _CPIOHandlerBase(StructHandler):
     _PAD_ALIGN: int
     _FILE_PAD_ALIGN: int = 512
 
-    def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
+    def calculate_chunk(  # noqa: C901
+        self, file: File, start_offset: int
+    ) -> Optional[ValidChunk]:
 
         file_with_offset = OffsetFile(file, start_offset)
         current_offset = start_offset
         while True:
             file.seek(current_offset)
-            header = self.parse_header(file)
+            try:
+                header = self.parse_header(file)
+            except EOFError:
+                break
 
             c_filesize = self._calculate_file_size(header)
             c_namesize = self._calculate_name_size(header)

--- a/unblob/testing.py
+++ b/unblob/testing.py
@@ -9,6 +9,7 @@ from unblob.finder import build_hyperscan_database
 from unblob.logging import configure_logger
 from unblob.models import ProcessResult
 from unblob.processing import ExtractionConfig
+from unblob.report import ExtractCommandFailedReport
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -80,5 +81,13 @@ def check_output_is_the_same(reference_dir: Path, extract_dir: Path):
 
 def check_result(reports: ProcessResult):
     __tracebackhide__ = True
-
-    assert reports.errors == [], "Unexpected error reports"
+    # filter out error reports about truncated integration test files
+    errors = [
+        error
+        for error in reports.errors
+        if not (
+            isinstance(error, ExtractCommandFailedReport)
+            and error.stderr == b"\nERRORS:\nUnexpected end of archive\n\n"
+        )
+    ]
+    assert errors == [], "Unexpected error reports"


### PR DESCRIPTION
We recently analyzed a sample containing a truncated CPIO archive, which led unblob to discard it.

Given that 7z is capable of extracting truncated CPIO archives, we now handle the EOFError that happens when unblob tries to parse the next CPIO header on a truncated file and cleanly break out of the parsing loop.

I have integration tests files locally, but due to 7z returning a non-zero status code on truncated CPIO archive extraction our integration test suite fails due to `AssertionError: Unexpected error reports`. I'll include them if we can find an elegant solution, otherwise we keep the CPIO integration tests samples this way.