### PR TITLE
Ignore special files

### DIFF
--- a/tests/integration/filesystem/squashfs/squashfs_v4_le/__input__/squashfs_v4.specfile.bin
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_le/__input__/squashfs_v4.specfile.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d27f2e4baf57df961b9aa7298ac390a54fd0d2c904bf1d4baaee49cbdd0a93f1
+size 4096

--- a/tests/integration/filesystem/squashfs/squashfs_v4_le/__output__/squashfs_v4.specfile.bin_extract/file.symlink
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_le/__output__/squashfs_v4.specfile.bin_extract/file.symlink
@@ -1,0 +1,1 @@
+hello.txt

--- a/tests/integration/filesystem/squashfs/squashfs_v4_le/__output__/squashfs_v4.specfile.bin_extract/hello.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_le/__output__/squashfs_v4.specfile.bin_extract/hello.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
+size 6

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -255,8 +255,10 @@ class Processor:
                 )
             return
 
-        if stat_report.is_link:
-            log.debug("Ignoring symlink")
+        if not stat_report.is_file:
+            log.debug(
+                "Ignoring special file (link, chrdev, blkdev, fifo, socket, door)."
+            )
             return
 
         magic = self._get_magic(task.path)

--- a/unblob/testing.py
+++ b/unblob/testing.py
@@ -68,6 +68,15 @@ def check_output_is_the_same(reference_dir: Path, extract_dir: Path):
         "--brief",
         "--exclude",
         ".gitkeep",
+        # Special files in test samples follows a strict naming convention
+        # so that we can have them without triggering errors on diff.
+        # Example diff with special files: https://www.mail-archive.com/bug-diffutils@gnu.org/msg00863.html
+        "--exclude",
+        "*.socket",
+        "--exclude",
+        "*.symlink",
+        "--exclude",
+        "*.fifo",
         str(reference_dir),
         str(extract_dir),
     ]

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -5,7 +5,7 @@ from unblob import cli
 from unblob.file_utils import File, iterbits, round_down
 from unblob.models import _JSONEncoder
 from unblob.parser import _HexStringToRegex
-from unblob.report import ChunkReport, FileMagicReport
+from unblob.report import ChunkReport, FileMagicReport, StatReport
 
 _HexStringToRegex.literal
 _HexStringToRegex.wildcard
@@ -18,6 +18,7 @@ _JSONEncoder.default
 ChunkReport.handler_name
 FileMagicReport.magic
 FileMagicReport.mime_type
+StatReport.is_link
 
 sys.breakpointhook
 cli.cli.context_class


### PR DESCRIPTION
Fix #429

A change has been applied so that we only process files and directories.

A naming convention has been defined for special files:
- `name.socket` for socket files
- `name.fifo` for fifo files
- `name.symlink` for symink files

This can be used by integration test files so that they can contain special files without triggering false alarms on diff. Diff would report errors like `File /A/fifo0 is a fifo while file /B/fifo0 is a fifo`, which is useless.

Thanks to this change, I could add a squashfs filesystem sample that contains the following special files:
    
- block device: not extracted because we're not running as root
- character device: not extracted because we're not running as root
- fifo device: extracted
- symlink: extracted
- socket: extracted
    
The fifo, symlink, and socket files are not processed by unblob, otherwise it would hang (e.g. by waiting for data on the fifo)., demonstrating that we have a proper fix.
    
Note that these special files cannot be tracked by git, so they're not present in the output directory.