### PR TITLE
feat(processing): Add `HashReport` for empty files

### DIFF
--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -269,12 +269,12 @@ class Processor:
         magic_report = FileMagicReport(magic=magic, mime_type=mime_type)
         result.add_report(magic_report)
 
+        hash_report = HashReport.from_path(task.path)
+        result.add_report(hash_report)
+
         if stat_report.size == 0:
             log.debug("Ignoring empty file")
             return
-
-        hash_report = HashReport.from_path(task.path)
-        result.add_report(hash_report)
 
         should_skip_file = any(
             magic.startswith(pattern) for pattern in self._config.skip_magic


### PR DESCRIPTION
`HashReport` was introduced in eb2f74f1046675cb3191e65e7a0aa56bd903dfc1.
There we tried to optimize it to skip calculations for empty files, but
honestly that is not a big overhead. This small patch to make the
code and the usage of reports cleaner, so we will have a `HashReport`
for every file, like `FileMagicReport`.