### PR TITLE
fix(handler/tar): replace 7zip with python tarfile module.

### DIFF
--- a/unblob/handlers/archive/tar.py
+++ b/unblob/handlers/archive/tar.py
@@ -102,9 +102,7 @@ class TarHandler(StructHandler):
     """
     HEADER_STRUCT = "posix_header_t"
 
-    EXTRACTOR = Command(
-        "7z", "x", "-xr!PaxHeaders*", "-xr!GlobalHead*", "-y", "{inpath}", "-o{outdir}"
-    )
+    EXTRACTOR = Command("python3", "-m", "tarfile", "-e", "{inpath}", "{outdir}")
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         file.seek(start_offset)


### PR DESCRIPTION
Given that 7zip just creates a text file with the symlink target path in it, which is inaccurate, we had to switch to another extractor.

The decision was made to move to Python3's built-in tarfile module given that's what we already use to calculate the chunk offsets.

tarfile module, like the tar and unar cli is unsafe when it comes to symlink based traversal. This is no longer a problem since 97230c2 given that unblob fixes link based traversal once the extraction has been performed.

Fixes #435 