### PR TITLE
fix(handlers): improve ZIP handler to support ZIP64.

### DIFF
--- a/tests/integration/archive/zip/zip64/__input__/apple.zip
+++ b/tests/integration/archive/zip/zip64/__input__/apple.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12808b48650a41a1c5e32cc585a5b62d79ff233e71b91f0180dc5f31ed9d8314
+size 846

--- a/tests/integration/archive/zip/zip64/__output__/apple.zip_extract/apple1.txt
+++ b/tests/integration/archive/zip/zip64/__output__/apple.zip_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/zip/zip64/__output__/apple.zip_extract/apple2.txt
+++ b/tests/integration/archive/zip/zip64/__output__/apple.zip_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/archive/zip/zip64/__output__/apple.zip_extract/apple3.txt
+++ b/tests/integration/archive/zip/zip64/__output__/apple.zip_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/archive/zip/zip64/__output__/apple.zip_extract/apple4.txt
+++ b/tests/integration/archive/zip/zip64/__output__/apple.zip_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7


### PR DESCRIPTION
Documentation about ZIP64:
https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE-6.3.1.TXT

zip64 sample was generated with `zip -fz apple.zip *txt`, the `-fz` switch force ZIP64 usage.

Resolve #439 