### PR TITLE
fix(zlib): fix infinite loop in zlib handler.

### DIFF
--- a/tests/integration/compression/zlib/__input__/sample.truncated.zlib
+++ b/tests/integration/compression/zlib/__input__/sample.truncated.zlib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51a0a52eb2ddc0ac7750b39e4eb920d819a278eed25f522f84e695e40cc80647
+size 32

--- a/tests/integration/compression/zlib/__output__/sample.truncated.zlib_extract/sample.truncated
+++ b/tests/integration/compression/zlib/__output__/sample.truncated.zlib_extract/sample.truncated
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d121ef4c4adf575b3c8f4c9f8d9e1a1887f1fe09bb718a33141a0bc6009d52d
+size 28

--- a/unblob/handlers/compression/zlib.py
+++ b/unblob/handlers/compression/zlib.py
@@ -18,8 +18,10 @@ class ZlibExtractor(Extractor):
         decompressor = zlib.decompressobj()
         outpath = outdir.joinpath(inpath.stem)
         with File.from_path(inpath) as f:
-            while not decompressor.eof:
-                outpath.write_bytes(decompressor.decompress(f.read(DEFAULT_BUFSIZE)))
+            content = f.read(DEFAULT_BUFSIZE)
+            while content and not decompressor.eof:
+                outpath.write_bytes(decompressor.decompress(content))
+                content = f.read(DEFAULT_BUFSIZE)
 
 
 class ZlibHandler(Handler):
@@ -45,8 +47,11 @@ class ZlibHandler(Handler):
         decompressor = zlib.decompressobj()
 
         try:
-            while not decompressor.eof:
-                decompressor.decompress(file.read(DEFAULT_BUFSIZE))
+            content = file.read(DEFAULT_BUFSIZE)
+            while content and not decompressor.eof:
+                decompressor.decompress(content)
+                content = file.read(DEFAULT_BUFSIZE)
+
         except zlib.error:
             raise InvalidInputFormat("invalid zlib stream")
 


### PR DESCRIPTION
We fixed the infinite loop by checking that the string returned by file.read() is not empty, and return otherwise.

We designed it this way to support partial streams.

Fix #441 