### PR TITLE
fix(xz): fix early return and EOFError on stream size calculation

### DIFF
--- a/unblob/handlers/compression/xz.py
+++ b/unblob/handlers/compression/xz.py
@@ -135,7 +135,6 @@ def get_stream_size(footer_offset: int, file: File) -> int:
 def _hyperscan_match(
     pattern_id: int, offset: int, end: int, flags: int, context: XZSearchContext
 ) -> bool:
-
     # if we matched before our start offset, continue looking
     end_offset = offset + FLAG_LEN + EOS_MAGIC_LEN
     if end_offset < context.start_offset:
@@ -143,8 +142,9 @@ def _hyperscan_match(
 
     stream_size = get_stream_size(offset, context.file)
 
+    # stream_size does not match, we continue our search
     if stream_size != (end_offset - context.start_offset):
-        return True
+        return False
 
     # stream padding validation
     # padding MUST contain only null bytes and be 4 bytes aligned
@@ -153,7 +153,7 @@ def _hyperscan_match(
     padding_size = end_padding_offset - end_offset
     if padding_size % 4 != 0:
         context.end_streams_offset = end_offset
-        return True
+        return False
 
     # next magic validation
     context.end_streams_offset = end_padding_offset


### PR DESCRIPTION
Fixed a bug where stream size calculation would raise an EOFError due to backward size being too large. 

Fixed a bug where xz would return too early from hyperscan search if the first identified end marker is either unaligned or has a non-matching stream size.

Resolves #453 