### PR TITLE
Resolve path traversal and unhandled permission error in tar handler

### DIFF
--- a/tests/integration/archive/tar/__input__/traversal.tar
+++ b/tests/integration/archive/tar/__input__/traversal.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c0558a0d64c93f706175b7a38158a2909c07bf174ed54572e9f31896ddb20a6
+size 260

--- a/tests/integration/archive/tar/__output__/traversal.tar_extract/traversal
+++ b/tests/integration/archive/tar/__output__/traversal.tar_extract/traversal
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d4ab5759508af8d62e4686b236f896210a4145a146ab399797993dcddcc9b22
+size 10240

--- a/unblob/handlers/archive/_safe_tarfile.py
+++ b/unblob/handlers/archive/_safe_tarfile.py
@@ -1,0 +1,29 @@
+import os
+from pathlib import Path
+from tarfile import TarFile
+
+from structlog import get_logger
+
+from unblob.extractor import is_safe_path
+
+logger = get_logger()
+
+RUNNING_AS_ROOT = os.getuid() == 0
+
+
+class SafeTarFile(TarFile):
+    def extract(self, member, path="", set_attrs=True, *, numeric_owner=False):
+        path_as_path = Path(str(path))
+        member_name_path = Path(str(member.name))
+
+        if not RUNNING_AS_ROOT and (member.ischr() or member.isblk()):
+            logger.warn(
+                "missing elevated permissions, skipping block and character device creation",
+                path=member_name_path,
+            )
+            return
+        if not is_safe_path(path_as_path, member_name_path):
+            logger.warn("traversal attempt", path=member_name_path)
+            return
+
+        super().extract(member, path, set_attrs, numeric_owner=numeric_owner)


### PR DESCRIPTION
Fixed path traversal in python's builtin tarfile module and added a privilege check when tarfile attempts to create device files.

This fixes #456 and #459

Brought to you by the excellent upstream connection on Thalys high speed train.

More info about traversal: https://davidhamann.de/2022/09/23/python-tarfile-vulnerability/