### PR TITLE
Zip chunk discovery performance fix

### DIFF
--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -57,6 +57,40 @@ class TestHandlerExc(Handler):
         raise Exception("Error")
 
 
+class TestHandlerForward(Handler):
+    """Matches stuff between parens: (whatever)
+
+    Matches the initial ( and finds the next ) as chunk end.
+    """
+
+    NAME = "handlerEXC"
+    PATTERNS = [Regex("[(]")]
+
+    def calculate_chunk(self, file, start_offset: int):
+        end_offset = file.find(b")", start_offset)
+        assert end_offset >= 0
+        return ValidChunk(start_offset, end_offset + 1)
+
+
+class TestHandlerBackward(Handler):
+    """Matches stuff between square brackets: [whatever]
+
+    Matches the closing ] and finds the previous [ as chunk start.
+
+    This is not a common strategy, but can be a valid/more efficient strategy in some cases
+    (e.g. ZIP files).
+    """
+
+    NAME = "handlerEXC"
+    PATTERNS = [Regex("]")]
+
+    def calculate_chunk(self, file, start_offset: int):
+        end_offset = start_offset
+        start_offset = file.rfind(b"[", 0, end_offset)
+        assert start_offset >= 0
+        return ValidChunk(start_offset, end_offset + 1)
+
+
 def test_build_hyperscan_database():
     db, handler_map = build_hyperscan_database((TestHandlerA, TestHandlerB))
     matches = []
@@ -104,18 +138,12 @@ def test_invalid_hexstring_pattern_raises():
     [
         pytest.param(b"00A23450", [ValidChunk(2, 7)], id="single-chunk"),
         pytest.param(
-            b"0BB34A678900", [ValidChunk(0, 10)], id="chunk-with-relative-match-offset"
+            b"0BB34X678900", [ValidChunk(0, 10)], id="chunk-with-relative-match-offset"
         ),
         pytest.param(
             b"A23450BB3456789",
             [ValidChunk(0, 5), ValidChunk(5, 15)],
             id="multiple-chunk",
-        ),
-        pytest.param(b"0BC34A67890", [ValidChunk(0, 10)], id="inner-chunk-ignored"),
-        pytest.param(
-            b"0BC34A67890A2345",
-            [ValidChunk(0, 10), ValidChunk(11, 16)],
-            id="inner-chunk-ignored-scan-continues",
         ),
         pytest.param(b"A23450BB34", [ValidChunk(0, 5)], id="overflowing-chunk-ignored"),
         pytest.param(
@@ -138,6 +166,56 @@ def test_invalid_hexstring_pattern_raises():
         pytest.param(
             b"EXCA2345", [ValidChunk(3, 8)], id="exception-ignored-scan-continues"
         ),
+        pytest.param(
+            b"(.....[overlap]......)",
+            # ^            [^ - this pattern match is optimized away]
+            # 0123456789012345678901
+            [ValidChunk(0, 22)],
+            id="internal-chunk-whole-file-match-optimization",
+        ),
+        pytest.param(
+            b"[.....(overlap)......]",
+            #       ^              ^ backward matched second, the internal chunk is already there
+            # 0123456789012345678901
+            [ValidChunk(0, 22), ValidChunk(6, 15)],
+            id="internal-chunk-whole-file-match-optimization-does-not-work-for-backward-match",
+        ),
+        pytest.param(
+            b"[zip(..]zlib)",
+            #     ^  ^
+            # 0123456789012
+            [ValidChunk(0, 8), ValidChunk(4, 13)],
+            id="overlapping-chunks-backward-first",
+        ),
+        pytest.param(
+            b"(zlib[..)zip]",
+            # ^           ^
+            # 01234567890123
+            [ValidChunk(0, 9), ValidChunk(5, 13)],
+            id="overlapping-chunks-backward-second",
+        ),
+        pytest.param(
+            b"((AAA(((..).",
+            # ^ ^
+            # 01234567890123456789
+            [ValidChunk(0, 11), ValidChunk(2, 7)],
+            id="internal-matches-of-same-handler-are-optimized-away",
+            # An extra at the end is needed, because whole file chunks are
+            # stopping the pattern match.
+            #
+            # This optimization is intended for containers, like tar, cpio, ...
+            # where we have many file headers and the same - well determined -
+            # end for all of the file headers.
+            #
+            # Unfortunately it is possible only for forward handlers,
+            # where the pattern is at the beginning of the structure, not for
+            # something like zip, which we can better match from the end.
+            #
+            # It is also somewhat questionable if we want it generally,
+            # as e.g. for HandlerA it will result matching only a single A chunk
+            # while in fact there are 3 overlapping matches here (2-7, 3-8, 4-9),
+            # but we just drop the last 2.
+        ),
     ],
 )
 def test_search_chunks(content, expected_chunks, task_result):
@@ -150,10 +228,17 @@ def test_search_chunks(content, expected_chunks, task_result):
         TestHandlerEof,
         TestHandlerInvalid,
         TestHandlerExc,
+        TestHandlerForward,
+        TestHandlerBackward,
     )
 
     chunks = search_chunks(file, len(content), handlers, task_result)
 
     assert len(chunks) == len(expected_chunks)
+
+    # chunks are sorted by the pattern position, which in general do not match the chunk start
+    # when processed with a "backward" handler, it can come even later than another match
+    chunks = sorted(chunks, key=lambda chunk: (chunk.start_offset, chunk.end_offset))
+
     for expected_chunk, chunk in zip(expected_chunks, chunks):
         assert attr.evolve(chunk, id="") == attr.evolve(expected_chunk, id="")

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -78,6 +78,11 @@ def assert_same_chunks(expected, actual, explanation=None):
             [ValidChunk(1, 5), ValidChunk(6, 10)],
             "Multiple outer chunks, with chunks inside",
         ),
+        (
+            [ValidChunk(10, 50), ValidChunk(40, 80), ValidChunk(70, 90)],
+            [ValidChunk(10, 50), ValidChunk(40, 80), ValidChunk(70, 90)],
+            "Overlapping chunks",
+        ),
     ],
 )
 def test_remove_inner_chunks(
@@ -100,6 +105,18 @@ def test_remove_inner_chunks(
             [ValidChunk(0x8, 0xA), ValidChunk(0x0, 0x5), ValidChunk(0xF, 0x14)],
             20,
             [UnknownChunk(0x5, 0x8), UnknownChunk(0xA, 0xF)],
+        ),
+        pytest.param(
+            [ValidChunk(10, 50), ValidChunk(40, 80), ValidChunk(70, 90)],
+            100,
+            [UnknownChunk(0, 10), UnknownChunk(90, 100)],
+            id="overlapping-input-chunks",
+        ),
+        pytest.param(
+            [ValidChunk(10, 50), ValidChunk(30, 40), ValidChunk(60, 70)],
+            100,
+            [UnknownChunk(0, 10), UnknownChunk(50, 60), UnknownChunk(70, 100)],
+            id="overlapping-internal-chunk",
         ),
     ],
 )

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -158,7 +158,7 @@ def decode_multibyte_integer(data: bytes) -> Tuple[int, int]:
 def iterate_patterns(
     file: File, pattern: bytes, chunk_size: int = 0x1000
 ) -> Iterator[int]:
-    """Iterate on the file searching for pattern until all occurences has been found.
+    """Iterate on the file searching for byte-sequence pattern until all occurences have been found.
 
     Seek the file pointer to the next byte of where we found the pattern or
     seek back to the initial position when the iterator is exhausted.

--- a/unblob/models.py
+++ b/unblob/models.py
@@ -73,7 +73,7 @@ class Chunk:
         return self.start_offset <= offset < self.end_offset
 
     def __repr__(self) -> str:
-        return self.range_hex
+        return f"{self.__class__.__name__}:{self.range_hex}:{self.size}"
 
 
 @attr.define(repr=False)
@@ -104,6 +104,13 @@ class ValidChunk(Chunk):
             is_encrypted=self.is_encrypted,
             extraction_reports=extraction_reports,
         )
+
+    def __repr__(self) -> str:
+        try:
+            return f"{self.handler.NAME}:{self.range_hex}:{self.size}"
+        except AttributeError:
+            # super() might no work at __attrs_post_init__ time
+            return Chunk.__repr__(self)
 
 
 @attr.define(repr=False)


### PR DESCRIPTION
Eliminate loops for chunk discovery.

Zip handler used the initial local file header signature to find zip chunks. Once the local file header was found the end of central directory signature was looked for, then the distance between the two was used to validate the match.

This is not optimal, as there are one local file signature for every file in a zip file, resulting in a huge amount of signature matches and also a lot of failed chunk calculation. Worse still, for every match there are potentially many end of central directory headers to check against.

The new method directly looks only at the end of central directory headers, and from that calculates the first local file header (= start of the chunk).

Changing how zip file calculation works surfaced another problem: the handling of overlapping chunks.

When overlapping chunks have been found, the whole file have been rejected (in most cases silently, but in rare cases with a visible exception) by an `InvalidInputFormat` exception raised from `calculate_unknown_chunks`.

This has been changed, which also results in extraction of overlapping chunks - there is a chance, that one of them will be the real one, producing usable output.
