### PR TITLE
fix tar handler: truncated tar files were not processed correctly

### DIFF
--- a/tests/integration/archive/tar/__input__/damaged.gnu.tar
+++ b/tests/integration/archive/tar/__input__/damaged.gnu.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:413d93982446e6ebaf405d4ba8479ebab48f417f57b8de1b86c0961e10eff781
+size 10240

--- a/tests/integration/archive/tar/__input__/truncated-cherry.posix.tar
+++ b/tests/integration/archive/tar/__input__/truncated-cherry.posix.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a8f79fae21e46b977882ed2665a89f8391caffd7a4844b0b62dd02c5a4b2a02
+size 82439

--- a/tests/integration/archive/tar/__input__/truncated-header.tar
+++ b/tests/integration/archive/tar/__input__/truncated-header.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:482c6c41eda31e50ae678d383bcf84d78920bc532de4414e32423ccbe771f2bf
+size 1023

--- a/tests/integration/archive/tar/__output__/damaged.gnu.tar_extract/0-1024.tar
+++ b/tests/integration/archive/tar/__output__/damaged.gnu.tar_extract/0-1024.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9804c193530de7cec80335025fd3b8928b274c06b67a3861c213045e76e40b0
+size 1024

--- a/tests/integration/archive/tar/__output__/damaged.gnu.tar_extract/0-1024.tar_extract/cherry1.txt
+++ b/tests/integration/archive/tar/__output__/damaged.gnu.tar_extract/0-1024.tar_extract/cherry1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7592083f2355ad7e207557efabb3594bf62c9e39677298e8265766a37d835c39
+size 8

--- a/tests/integration/archive/tar/__output__/damaged.gnu.tar_extract/1024-2048.unknown
+++ b/tests/integration/archive/tar/__output__/damaged.gnu.tar_extract/1024-2048.unknown
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c486060599c2b3d08d9ba18d8f115b8c582c163630f51b819a546870101bc84
+size 1024

--- a/tests/integration/archive/tar/__output__/damaged.gnu.tar_extract/2048-10240.tar
+++ b/tests/integration/archive/tar/__output__/damaged.gnu.tar_extract/2048-10240.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4c002915fb9ea3ccf729288165572524435a0e679a29cb6408265cdeeb3aa53
+size 8192

--- a/tests/integration/archive/tar/__output__/damaged.gnu.tar_extract/2048-10240.tar_extract/cherry3.txt
+++ b/tests/integration/archive/tar/__output__/damaged.gnu.tar_extract/2048-10240.tar_extract/cherry3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4d09282b5ac47cc58aa5dc4fe3e8d6829ac737adfe49ee32efee9cf4bf6cdf3
+size 8

--- a/tests/integration/archive/tar/__output__/damaged.gnu.tar_extract/2048-10240.tar_extract/cherry4.txt
+++ b/tests/integration/archive/tar/__output__/damaged.gnu.tar_extract/2048-10240.tar_extract/cherry4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7843a44cca6d57497113ed505d027b9f5ffac78f1de7809f81ae9b314d943e79
+size 8

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5da5301b576255349a6f72f2f7b71fc76418902b1432a702c6f89b94411f91b9
+size 80896

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:851dd2e0848a989be0483cec20355c9ef383e16a6b7e1acfa99bfb219a9a6690
+size 30720

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.gnu.tar
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.gnu.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26d544f72787a611a28119c9c1b6d801c1c9fb2cc486c26e135b5062210166df
+size 10240

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.gnu.tar_extract/apple1.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.gnu.tar_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.gnu.tar_extract/apple2.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.gnu.tar_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.gnu.tar_extract/apple3.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.gnu.tar_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.gnu.tar_extract/apple4.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.gnu.tar_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.posix.tar
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.posix.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4986b6c581042cef9fd3031cae71d595cb6cf78b253c8af3d2db16f0c909957
+size 10240

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.posix.tar_extract/apple1.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.posix.tar_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.posix.tar_extract/apple2.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.posix.tar_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.posix.tar_extract/apple3.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.posix.tar_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.posix.tar_extract/apple4.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/apple.posix.tar_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/banana1.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/banana1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:022d66975222661648a212f974a822fac4d349c0f7c13ef7e0ba3ac0e7d9f519
+size 8

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/banana2.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/banana2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cec01facc588f339e757822825743d16fae68d80ddf9b5e9e08f2862644f7733
+size 8

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/banana3.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/banana3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da312e2d0258a4055f9863f680f165b29b39f32ecd806c75c1e8f8a2a079d221
+size 8

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/banana4.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.gnu.tar_extract/banana4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a93968fdfdadcfaf2f7c16a766f546894367585c063964dca393a0e86a65625
+size 8

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d9a6f8e49976475b836a417571b6c7e6be44a12b8cb6d6d4885f6171ea0f371
+size 40960

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.gnu.tar
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.gnu.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26d544f72787a611a28119c9c1b6d801c1c9fb2cc486c26e135b5062210166df
+size 10240

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.gnu.tar_extract/apple1.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.gnu.tar_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.gnu.tar_extract/apple2.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.gnu.tar_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.gnu.tar_extract/apple3.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.gnu.tar_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.gnu.tar_extract/apple4.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.gnu.tar_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.posix.tar
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.posix.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4986b6c581042cef9fd3031cae71d595cb6cf78b253c8af3d2db16f0c909957
+size 10240

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.posix.tar_extract/apple1.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.posix.tar_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.posix.tar_extract/apple2.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.posix.tar_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.posix.tar_extract/apple3.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.posix.tar_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.posix.tar_extract/apple4.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/apple.posix.tar_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/banana1.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/banana1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:022d66975222661648a212f974a822fac4d349c0f7c13ef7e0ba3ac0e7d9f519
+size 8

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/banana2.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/banana2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cec01facc588f339e757822825743d16fae68d80ddf9b5e9e08f2862644f7733
+size 8

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/banana3.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/banana3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da312e2d0258a4055f9863f680f165b29b39f32ecd806c75c1e8f8a2a079d221
+size 8

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/banana4.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/banana.posix.tar_extract/banana4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a93968fdfdadcfaf2f7c16a766f546894367585c063964dca393a0e86a65625
+size 8

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/cherry1.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/cherry1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7592083f2355ad7e207557efabb3594bf62c9e39677298e8265766a37d835c39
+size 8

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/cherry2.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/cherry2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb6f92894363eceff37d58287d2b8b37bb17a00b320312ed59924a8ec07004a6
+size 8

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/cherry3.txt
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/0-80896.tar_extract/cherry3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4d09282b5ac47cc58aa5dc4fe3e8d6829ac737adfe49ee32efee9cf4bf6cdf3
+size 8

--- a/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/80896-82439.unknown
+++ b/tests/integration/archive/tar/__output__/truncated-cherry.posix.tar_extract/80896-82439.unknown
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc6986f7fb9577874ece4341d57b29426e72f5853346a15faad53e599712097b
+size 1543

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -15,6 +15,10 @@ from .logging import format_hex
 DEFAULT_BUFSIZE = shutil.COPY_BUFSIZE  # type: ignore
 
 
+class SeekError(ValueError):
+    """Specific ValueError for File.seek"""
+
+
 class File(mmap.mmap):
     @classmethod
     def from_bytes(cls, content: bytes):
@@ -31,8 +35,8 @@ class File(mmap.mmap):
     def seek(self, pos: int, whence: int = os.SEEK_SET) -> int:
         try:
             super().seek(pos, whence)
-        except ValueError:
-            raise EOFError
+        except ValueError as e:
+            raise SeekError from e
         return self.tell()
 
     def __enter__(self):

--- a/unblob/finder.py
+++ b/unblob/finder.py
@@ -10,7 +10,7 @@ import attr
 import hyperscan
 from structlog import get_logger
 
-from .file_utils import InvalidInputFormat
+from .file_utils import InvalidInputFormat, SeekError
 from .handlers import Handlers
 from .models import File, Handler, TaskResult, ValidChunk
 from .parser import InvalidHexString
@@ -50,6 +50,13 @@ def _calculate_chunk(
     except EOFError as exc:
         logger.debug(
             "File ends before header could be read",
+            exc_info=exc,
+            handler=handler.NAME,
+            _verbosity=2,
+        )
+    except SeekError as exc:
+        logger.debug(
+            "Seek outside file during chunk calculation",
             exc_info=exc,
             handler=handler.NAME,
             _verbosity=2,

--- a/unblob/handlers/compression/bzip2.py
+++ b/unblob/handlers/compression/bzip2.py
@@ -6,7 +6,7 @@ from structlog import get_logger
 
 from unblob.extractors import Command
 
-from ...file_utils import InvalidInputFormat, StructParser
+from ...file_utils import InvalidInputFormat, SeekError, StructParser
 from ...models import File, Handler, HexString, Regex, ValidChunk
 
 logger = get_logger()
@@ -117,7 +117,7 @@ def _hyperscan_match(
     # We try seek to the end of the stream
     try:
         context.file.seek(last_block_end)
-    except EOFError:
+    except SeekError:
         return True
 
     context.end_block_offset = last_block_end


### PR DESCRIPTION
Truncated tar files had a performance impact due to an `EOFError` not being caught and thus the tar file not being recognized, and this got repeated for every file in the truncated tar file.