### PR TITLE
Fix unwanted python upgrade inside docker image build

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2


### PR DESCRIPTION
- https://github.com/onekey-sec/unblob/actions/runs/3534051009/jobs/5930468611#step:8:187
- https://github.com/onekey-sec/unblob/actions/runs/3524997467/jobs/5940957421

There is also a mismatch between the poetry build (running on `ubuntu-latest`) python version (`3.8` -> `3.8.14`) and the 3.8-slim version (`3.8.15`)

Python 3.9 is a new package upgrade taking precedence over the custom-built Python in the image: Python is not installed as a package in python:* images, but available as `/usr/local/bin/python`, `python3`, `python3.8`