### PR TITLE
fix github build by pinning the runner

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2


### PR DESCRIPTION
Github updated ubuntu-latest from 20.04 to 22.04 on 2022-11-19, which also meant a libc6 update from 2.31 to 2.35. For python wheels libc version contributes a binary compatibility tag, and because it has been updated it was no longer possible to install the created wheel in python:3.8-slim, which still has libc6 2.31.