### PR TITLE
Extend default skip list

### DIFF
--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -53,14 +53,22 @@ DEFAULT_SKIP_MAGIC = (
     "PDF document",
     "magic binary file",
     "MS Windows icon resource",
-    "PE32+ executable (EFI application)",
+    "PE32",
     "Web Open Font Format",
     "GNU message catalog",
     "Xilinx BIT data",
     "Microsoft Excel",
     "Microsoft Word",
     "Microsoft PowerPoint",
+    "Microsoft OOXML",
     "OpenDocument",
+    "Macromedia Flash data",
+    "MPEG",
+    "HP Printer Job Language",
+    "Erlang BEAM file",
+    "python",  # (e.g. python 2.7 byte-compiled)
+    "Composite Document File V2 Document",
+    "Windows Embedded CE binary image",
 )
 
 


### PR DESCRIPTION
Extend default skip list with file types generating noise due to the presence of compressed streams.

The following magic are now skipped by default:

- Macromedia Flash data (swf files holding zlib streams)
- MPEG (audio/video files holding compressed streams)
- Printer Job Language (HP pjl files with compressed content)
- Erlang BEAM file
- Microsoft OOXML (open document format, can contain compressed streams)
- PE32 (extended the rule to cover any kind of PE file)
- python (specifically byte-compiled python files like .pyo and .pyc as they can contain compressed streams)
- Composite Document File V2 Document (Thumbs.db files)
- Windows Embedded CE binary image (will be removed when we have a dedicated handler)