### PR TITLE
Fix lzop extraction 

### DIFF
--- a/unblob/handlers/compression/lzo.py
+++ b/unblob/handlers/compression/lzo.py
@@ -75,7 +75,7 @@ class LZOHandler(StructHandler):
     """
     HEADER_STRUCT = "lzo_header"
 
-    EXTRACTOR = Command("lzop", "-d", "-f", "-N", "-p{outdir}", "{inpath}")
+    EXTRACTOR = Command("lzop", "-d", "-f", "-f", "-N", "-p{outdir}", "{inpath}")
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
 


### PR DESCRIPTION
lzop decompression command refuse to decompress files without a `.lzo` suffix unless the `-f|--force` command line switch is provided twice