### PR TITLE
fix(typing): Remove int restriction from decode_int

### DIFF
--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -144,7 +144,7 @@ def convert_int64(value: bytes, endian: Endian) -> int:
         raise InvalidInputFormat from exc
 
 
-def decode_int(value: bytes, base: int) -> int:
+def decode_int(value, base: int) -> int:
     try:
         return int(value, base)
     except ValueError as exc:


### PR DESCRIPTION
The only thing is done with this value is a direct `int()` call. We should not restrict the type of the `value` to `int`, everything should be acceptable which is acceptable by `int()`.