### PR TITLE
replace jefferson fork by the recently released PyPi package

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -62,6 +62,7 @@ let
             # Use the _same_ version as unblob
             self.cstruct
             self.python-lzo
+            self.click
           ];
         });
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -908,7 +908,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "ab7e15241ec62b44c346677b4235d05456967f5ebc809c0f74c7199697d3b54e"
+content-hash = "5bb42d945153cd59fa2c2a235e5b85654989fd69a0c956cd6813c0d97b0f02df"
 
 [metadata.files]
 arpy = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -152,11 +152,14 @@ test = ["flake8", "isort", "pytest"]
 
 [[package]]
 name = "cstruct"
-version = "2.1"
+version = "5.2"
 description = "C-style structs for Python"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
+
+[package.extras]
+test = ["pytest"]
 
 [[package]]
 name = "defusedxml"
@@ -267,18 +270,16 @@ python-versions = "*"
 
 [[package]]
 name = "jefferson"
-version = "0.4.1"
-description = ""
+version = "0.4.2"
+description = "JFFS2 filesystem extraction tool."
 category = "main"
 optional = false
-python-versions = "*"
-develop = false
+python-versions = ">=3.8,<4.0"
 
-[package.source]
-type = "git"
-url = "https://github.com/onekey-sec/jefferson.git"
-reference = "51de1f5ba3255ed707bb402bee89e442e11b55c1"
-resolved_reference = "51de1f5ba3255ed707bb402bee89e442e11b55c1"
+[package.dependencies]
+click = ">=8.1.3,<9.0.0"
+cstruct = ">=5.2,<6.0"
+python-lzo = ">=1.14,<2.0"
 
 [[package]]
 name = "jinja2"
@@ -907,7 +908,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c13f4c1342bbf338d800db8c61845165cde4d9adc35b1814051b3c2a24cba704"
+content-hash = "ab7e15241ec62b44c346677b4235d05456967f5ebc809c0f74c7199697d3b54e"
 
 [metadata.files]
 arpy = [
@@ -1070,8 +1071,8 @@ cssselect2 = [
     {file = "cssselect2-0.7.0.tar.gz", hash = "sha256:1ccd984dab89fc68955043aca4e1b03e0cf29cad9880f6e28e3ba7a74b14aa5a"},
 ]
 cstruct = [
-    {file = "cstruct-2.1-py2.py3-none-any.whl", hash = "sha256:ed4449bc672a37abbc0ecfbdaf4c26aa6ab1bafe7dfdb83eab2953cdbb153cf4"},
-    {file = "cstruct-2.1.tar.gz", hash = "sha256:9c2741f46fb12613a4f746369ec0a7b3b1f25712178c567437902d446f7c3648"},
+    {file = "cstruct-5.2-py2.py3-none-any.whl", hash = "sha256:b2f7f0ce9dc5d3c638d544fb31a5dd0b6c155e75a7963d587bfcf872ee067ab2"},
+    {file = "cstruct-5.2.tar.gz", hash = "sha256:88b2f02791926366dabc422c0caa17091373200f2e92140e6ef8225a93cd0e9c"},
 ]
 defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
@@ -1113,7 +1114,10 @@ iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
-jefferson = []
+jefferson = [
+    {file = "jefferson-0.4.2-py3-none-any.whl", hash = "sha256:8a9a91585bb6fce44a70dce2b12d437c15600a5dac1d6a40ed730f428e4eea20"},
+    {file = "jefferson-0.4.2.tar.gz", hash = "sha256:e59473b882972577ae25592ee7b5fd517818f9e8307c69df8a36dff438fd7b2f"},
+]
 jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
     {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ arpy = "^2.2.0"
 rarfile = "^4.0"
 ubi-reader = "^0.8.5"
 python-lzo = "^1.14"
-cstruct = "2.1"
-jefferson = { git = "https://github.com/onekey-sec/jefferson.git", rev = "51de1f5ba3255ed707bb402bee89e442e11b55c1" }
+cstruct = "5.2"
 yaffshiv = { git = "https://github.com/onekey-sec/yaffshiv.git", rev = "a8f21283c25057740371fd34e9b6f3c4771375f1" }
 plotext = "^4.1.5"
 pluggy = "^1.0.0"
@@ -30,6 +29,7 @@ pyperscan = "^0.2.0"
 lark = "^1.1.2"
 lz4 = "^4.0.0"
 lief = "^0.12.3"
+jefferson = "^0.4.2"
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build = "build.py"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-click = "^8.0.1"
+click = "^8.1.3"
 "dissect.cstruct" = "^2.0"
 attrs = "^21.2.0"
 structlog = "^21.2.0"


### PR DESCRIPTION
We're now the official maintainers of Jefferson and released the latest version to PyPi. We therefore switched the dependency source from our Github fork to PyPi.

Poetry identified a dependency mismatch between our required version of cstruct (2.1) and the one required by Jefferson (5.2).

We upgraded cstruct to the latest version so that dependency resolution works. The jump in major version may seem steep but cstruct maintainers did not introduce API breaking changes.