### PR TITLE
fix github actions

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -19,12 +19,12 @@ runs:
       shell: bash
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Restore pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-${{ inputs.python-version }}
@@ -34,7 +34,7 @@ runs:
       shell: bash
 
     - name: Restore poetry cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cache/pypoetry/cache
@@ -42,7 +42,7 @@ runs:
         key: poetry-cache-and-artifacts-${{ inputs.python-version }}
 
     - name: Restore virtualenvs
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pypoetry/virtualenvs
         key: venv-${{ hashFiles('poetry.lock') }}-${{ inputs.python-version }}

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -4,6 +4,8 @@ inputs:
     required: false
     default: "3.8"
 
+name: "Setup dependencies"
+description: "Install all required dependencies for worflows to run."
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup-git-lfs/action.yml
+++ b/.github/actions/setup-git-lfs/action.yml
@@ -1,3 +1,5 @@
+name: "Setup git LFS"
+description: "Setup git LFS and pull files stored with git-lfs."
 runs:
   using: "composite"
   steps:

--- a/.github/actions/setup-git-lfs/action.yml
+++ b/.github/actions/setup-git-lfs/action.yml
@@ -6,7 +6,7 @@ runs:
       shell: bash
 
     - name: Restore LFS cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
           path: .git/lfs
           key: lfs-${{ hashFiles('.git/lfs-assets-id') }}

--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -8,15 +8,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v3
     - name: Setup git lfs
       uses: ./.github/actions/setup-git-lfs
 
-    - uses: cachix/install-nix-action@v15
+    - uses: cachix/install-nix-action@v19
       with:
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-    - uses: cachix/cachix-action@v10
+    - uses: cachix/cachix-action@v12
       with:
         name: unblob
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup git lfs
         uses: ./.github/actions/setup-git-lfs
@@ -28,17 +28,17 @@ jobs:
         run: UNBLOB_BUILD_RUST_EXTENSION=1 poetry build --format wheel
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           load: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,20 +11,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
       - name: Restore pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: pip-3.8
@@ -34,7 +34,7 @@ jobs:
         shell: bash
 
       - name: Restore poetry cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pypoetry/cache
@@ -42,7 +42,7 @@ jobs:
           key: poetry-cache-and-artifacts-3.8
 
       - name: Restore virtualenvs
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pypoetry/virtualenvs
           key: venv-${{ hashFiles('poetry.lock') }}-3.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup dependencies
         uses: ./.github/actions/setup-dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
@@ -27,10 +27,10 @@ jobs:
           toolchain: 1.57.0
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Check pre-commit hook
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
 
 
   check_pyright:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup 3rd party dependencies
         uses: ./.github/actions/setup-dependencies
@@ -55,7 +55,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup 3rd party dependencies
         uses: ./.github/actions/setup-dependencies

--- a/.github/workflows/rust-binding.yml
+++ b/.github/workflows/rust-binding.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
@@ -30,7 +30,7 @@ jobs:
           toolchain: 1.57.0
 
       - name: Setup cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Run cargo audit
         uses: actions-rs/audit-check@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,11 @@ repos:
     rev: master
     hooks:
     -   id: nixpkgs-fmt
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.21.0
+    hooks:
+      - id: check-github-actions
+        name: Check Github actions
+      - id: check-github-workflows
+        name: Check Github workflows

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: ^tests/integration|\.patch$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
         exclude: ".*\\.md"
@@ -32,7 +32,7 @@ repos:
         name: Check isort
 
   - repo: https://github.com/jendrikseipp/vulture
-    rev: v2.3
+    rev: v2.7
     hooks:
       - id: vulture
         name: Check vulture
@@ -44,7 +44,7 @@ repos:
       - id: clippy
 
   - repo: https://github.com/nix-community/nixpkgs-fmt
-    rev: master
+    rev: v1.3.0
     hooks:
     -   id: nixpkgs-fmt
 


### PR DESCRIPTION
Preventive strike so that we don't end up with a broken build when Github pulls the plug for outdated actions.
    
References:   
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Other things performed by this MR:
- add github actions and github workflows validators to pre-commit
- add missing fields to github actions (identified by pre-commit)
- upgrade pre-commit dependencies
