### PR TITLE
Fix extraction of zipped up extractions

### DIFF
--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -20,6 +20,15 @@ def test_carve_unknown_chunk(tmp_path: Path):
     assert list(tmp_path.iterdir()) == [written_path]
     assert written_path.read_bytes() == content[1:8]
 
+    # carving the second time will fail, while not changing the file
+    unchanged_content = b"content is unchanged"
+    written_path.write_bytes(unchanged_content)
+
+    with pytest.raises(FileExistsError):
+        carve_unknown_chunk(tmp_path, test_file, chunk)
+
+    assert written_path.read_bytes() == unchanged_content
+
 
 def test_fix_permission(tmpdir: Path):
     tmpdir = PosixPath(tmpdir)

--- a/unblob/extractor.py
+++ b/unblob/extractor.py
@@ -18,7 +18,7 @@ def carve_chunk_to_file(carve_path: Path, file: File, chunk: Chunk):
     carve_path.parent.mkdir(parents=True, exist_ok=True)
     logger.debug("Carving chunk", path=carve_path)
 
-    with carve_path.open("wb") as f:
+    with carve_path.open("xb") as f:
         for data in iterate_file(file, chunk.start_offset, chunk.size):
             f.write(data)
 

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -397,7 +397,6 @@ class _FileTask:
 
         except ExtractError as e:
             extraction_reports.extend(e.reports)
-            delete_empty_extract_dir(extract_dir)
         except Exception as exc:
             logger.exception("Unknown error happened while extracting chunk")
             extraction_reports.append(UnknownError(exception=exc))
@@ -406,6 +405,7 @@ class _FileTask:
 
         # we want to get consistent partial output even in case of unforeseen problems
         fix_extracted_directory(extract_dir, self.result)
+        delete_empty_extract_dir(extract_dir)
 
         if extract_dir.exists():
             self.result.add_subtask(


### PR DESCRIPTION
This is a bunch of small fixes, that have been triggered by anomalies detected when unblob-ing of an accidentally zipped up previous extraction.

While the anomalies appear only in very specific inputs, that do not occur naturally, the tool should discover, handle, and report the appearing problems.
