### PR TITLE
nix: propagate required overlays to downstream users

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,16 +28,18 @@
       nixpkgsFor = forAllSystems (system: import nixpkgs {
         inherit system;
         overlays = [
-          filter.overlays.default
-          sasquatch.overlays.default
           self.overlays.default
         ];
       });
     in
     {
-      overlays.default = import ./overlay.nix {
-        inherit pyperscan crane;
-      };
+      overlays.default = nixpkgs.lib.composeManyExtensions [
+        filter.overlays.default
+        sasquatch.overlays.default
+        (import ./overlay.nix {
+          inherit pyperscan crane;
+        })
+      ];
       packages = forAllSystems (system: rec {
         inherit (nixpkgsFor.${system}) unblob;
         default = unblob;


### PR DESCRIPTION
Downstream users pulling in `overlays.default` don't receive the required dependencies from crane and nix-filter.

These are combined to a single overlay with unblob, so all transitive dependencies are pulled in as well.