### PR TITLE
Fix CI issues

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -23,6 +23,7 @@ jobs:
         uses: ./.github/actions/setup-git-lfs
       - uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Setup emulation

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -4,7 +4,7 @@ from pytest import approx
 import unblob._py as python_binding
 
 try:
-    import unblob._rust as rust_binding
+    import unblob._rust as rust_binding  # type: ignore
 except ModuleNotFoundError:
     rust_binding = None
 

--- a/unblob/math.py
+++ b/unblob/math.py
@@ -1,4 +1,4 @@
 try:
-    from ._rust import shannon_entropy
+    from ._rust import shannon_entropy  # type: ignore
 except ImportError:
     from ._py.math import shannon_entropy  # noqa: F401


### PR DESCRIPTION
- Pin nix version to work-around regression, it is introduced by Nix 14.0 https://github.com/cachix/cachix-action/issues/138
- Ignore newly reported missing import when rust binding is unavailable