### PR TITLE
feat(handler): add support for squashfsv2.

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Install sasquatch
       run: |
-        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-1/sasquatch_1.0_amd64.deb
+        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-2/sasquatch_1.0_amd64.deb
         sudo dpkg -i sasquatch_1.0_amd64.deb
         rm -f sasquatch_1.0_amd64.deb
       shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     zlib1g-dev \
     libmagic1 \
     zstd
-RUN curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-1/sasquatch_1.0_amd64.deb \
+RUN curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-2/sasquatch_1.0_amd64.deb \
     && dpkg -i sasquatch_1.0_amd64.deb \
     && rm -f sasquatch_1.0_amd64.deb
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -124,6 +124,6 @@ The Nix derivation installs all 3rd party dependencies.
 
 2.  If you need **squashfs support**, install sasquatch:
 
-        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-1/sasquatch_1.0_amd64.deb
+        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-2/sasquatch_1.0_amd64.deb
         sudo dpkg -i sasquatch_1.0_amd64.deb
         rm sasquatch_1.0_amd64.deb

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1677370089,
-        "narHash": "sha256-sdZ3ull2bldQYXK7tsX097C8JEuhBGIFPSfmA5nVoXE=",
+        "lastModified": 1678152261,
+        "narHash": "sha256-cPRDxwygVMleiSEGELrvAiq9vYAN4c3KK/K4UEO13vU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "685e7494b02c6ac505482b1a471de4c285e87543",
+        "rev": "5291dd0aa7a52d607fc952763ef60714e4c881d4",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
     },
     "filter": {
       "locked": {
-        "lastModified": 1676294984,
-        "narHash": "sha256-hdLUa/3RH1VJ+gMUysQE0JGM4F2Q/tIIFbtoxAOurJQ=",
+        "lastModified": 1678109515,
+        "narHash": "sha256-C2X+qC80K2C1TOYZT8nabgo05Dw2HST/pSn6s+n6BO8=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "fc282c5478e4141842f9644c239a41cfe9586732",
+        "rev": "aa9ff6ce4a7f19af6415fb3721eaa513ea6c763c",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677383253,
-        "narHash": "sha256-UfpzWfSxkfXHnb4boXZNaKsAcUrZT9Hw+tao1oZxd08=",
+        "lastModified": 1678298120,
+        "narHash": "sha256-iaV5xqgn29xy765Js3EoZePQyZIlLZA3pTYtTnKkejg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9952d6bc395f5841262b006fbace8dd7e143b634",
+        "rev": "1e383aada51b416c6c27d4884d2e258df201bc11",
         "type": "github"
       },
       "original": {
@@ -143,17 +143,18 @@
       "locked": {
         "lastModified": 1677081717,
         "narHash": "sha256-jkHeH+vm93nI0NQ5ygQ/csa4/hCuBGJ9ZxJTa5ewRp8=",
-        "ref": "refs/heads/main",
+        "ref": "main",
         "rev": "4bc92387dd2996cb67fdfbe185ebc172b36f4cbd",
         "revCount": 27,
         "submodules": true,
         "type": "git",
-        "url": "https://github.com/vlaci/pyperscan"
+        "url": "https://github.com/vlaci/pyperscan/"
       },
       "original": {
+        "ref": "main",
         "submodules": true,
         "type": "git",
-        "url": "https://github.com/vlaci/pyperscan"
+        "url": "https://github.com/vlaci/pyperscan/"
       }
     },
     "root": {
@@ -177,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676437770,
-        "narHash": "sha256-mhJye91Bn0jJIE7NnEywGty/U5qdELfsT8S+FBjTdG4=",
+        "lastModified": 1677812689,
+        "narHash": "sha256-EakqhgRnjVeYJv5+BJx/NZ7/eFTMBxc4AhICUNquhUg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a619538647bd03e3ee1d7b947f7c11ff289b376e",
+        "rev": "e53e8853aa7b0688bc270e9e6a681d22e01cf299",
         "type": "github"
       },
       "original": {
@@ -216,11 +217,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677749816,
-        "narHash": "sha256-2kJQHwSstJ6bdnlEQ40Q/eoAUK5IwPBPHkC2derYm3U=",
+        "lastModified": 1678359750,
+        "narHash": "sha256-mqkSEcI798nrVv4yMX6HTsU8sD0yXXkLg07PG4oWdRM=",
         "owner": "onekey-sec",
         "repo": "sasquatch",
-        "rev": "4f75d7034aff7b79fb39f5e8b2e8e8367b2aac40",
+        "rev": "ef06d235b825c7c350db2eada1952e86aa7d1e93",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.filter.url = "github:numtide/nix-filter";
   inputs.pyperscan = {
-    url = "git+https://github.com/vlaci/pyperscan?submodules=1";
+    url = "git+https://github.com/vlaci/pyperscan/?ref=main&submodules=1";
     inputs.nixpkgs.follows = "nixpkgs";
   };
   inputs.crane = {

--- a/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__input__/squashfs_v2.0_be.bin
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__input__/squashfs_v2.0_be.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79c0f3886291f4abcc656acd49932446cf16afaa67e6ffb0c5258e3c2e2dfcc0
+size 4096

--- a/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__input__/squashfs_v2.1_be.bin
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__input__/squashfs_v2.1_be.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0140bac22d92df7d6c63fdf6de2d3e75a8fad6b30e6f9eeeb9ef533134f35db
+size 4096

--- a/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.0_be.bin_extract/apple1.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.0_be.bin_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.0_be.bin_extract/apple2.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.0_be.bin_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.0_be.bin_extract/apple3.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.0_be.bin_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.0_be.bin_extract/apple4.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.0_be.bin_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.1_be.bin_extract/apple1.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.1_be.bin_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.1_be.bin_extract/apple2.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.1_be.bin_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.1_be.bin_extract/apple3.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.1_be.bin_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.1_be.bin_extract/apple4.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/big_endian/__output__/squashfs_v2.1_be.bin_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__input__/squashfs_v2.0_le.bin
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__input__/squashfs_v2.0_le.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c62dbe388b972119f5d17a12836a016737d58276184f4caa2a90dafd924f124
+size 4096

--- a/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__input__/squashfs_v2.1_le.bin
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__input__/squashfs_v2.1_le.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b6cd2fd63e17a499861d2d89d617bd836b169601e46cb2f5a5c66bea8ef253a
+size 4096

--- a/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.0_le.bin_extract/apple1.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.0_le.bin_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.0_le.bin_extract/apple2.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.0_le.bin_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.0_le.bin_extract/apple3.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.0_le.bin_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.0_le.bin_extract/apple4.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.0_le.bin_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.1_le.bin_extract/apple1.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.1_le.bin_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.1_le.bin_extract/apple2.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.1_le.bin_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.1_le.bin_extract/apple3.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.1_le.bin_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.1_le.bin_extract/apple4.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v2/little_endian/__output__/squashfs_v2.1_le.bin_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/unblob/handlers/__init__.py
+++ b/unblob/handlers/__init__.py
@@ -40,6 +40,7 @@ BUILTIN_HANDLERS: Handlers = (
     jffs2.JFFS2OldHandler,
     ntfs.NTFSHandler,
     romfs.RomFSFSHandler,
+    squashfs.SquashFSv2Handler,
     squashfs.SquashFSv3Handler,
     squashfs.SquashFSv3DDWRTHandler,
     squashfs.SquashFSv3BroadcomHandler,

--- a/unblob/handlers/filesystem/squashfs.py
+++ b/unblob/handlers/filesystem/squashfs.py
@@ -45,6 +45,45 @@ class _SquashFSBase(StructHandler):
         )
 
 
+class SquashFSv2Handler(_SquashFSBase):
+    NAME = "squashfs_v2"
+
+    PATTERNS = [
+        HexString(
+            """
+            // 00000000  73 71 73 68 00 00 00 03  00 00 00 00 00 00 00 00  |sqsh............|
+            // 00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 02 00 00  |................|
+            // squashfs_v2_magic_be
+            73 71 73 68 [24] 00 02
+        """
+        ),
+        HexString(
+            """
+            // 00000000  68 73 71 73 03 00 00 00  00 00 00 00 00 00 00 00  |hsqs............|
+            // 00000010  00 00 00 00 00 00 00 00  00 00 00 00 02 00 00 00  |................|
+            // squashfs_v2_magic_le
+            68 73 71 73 [24] 02 00
+        """
+        ),
+    ]
+
+    C_DEFINITIONS = r"""
+        typedef struct squashfs2_super_block
+        {
+            char   s_magic[4];
+            uint32 inodes;
+            uint32 bytes_used;
+            uint32 uid_start;
+            uint32 guid_start;
+            uint32 inode_table_start;
+            uint32 directory_table_start;
+            uint16 s_major;
+            uint16 s_minor;
+        } squashfs2_super_block_t;
+    """
+    HEADER_STRUCT = "squashfs2_super_block_t"
+
+
 class SquashFSv3Handler(_SquashFSBase):
     NAME = "squashfs_v3"
 


### PR DESCRIPTION
We could not support old versions of squashfs due to a bug in squashfs-tools. It's now fixed in our fork so time to move here.

See #474 and https://github.com/onekey-sec/sasquatch/pull/13