### PR TITLE
feat(handler): Add support for HP BDL and HP IPKG format

### DIFF
--- a/tests/integration/archive/hp/bdl/__input__/sample.bdl
+++ b/tests/integration/archive/hp/bdl/__input__/sample.bdl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:240533e4188e0af859989fca729c4a0847de3d5688906c4a22d36f843afdf271
+size 4043

--- a/tests/integration/archive/hp/bdl/__output__/sample.bdl_extract/ipkg000
+++ b/tests/integration/archive/hp/bdl/__output__/sample.bdl_extract/ipkg000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c99dd4e215b508395aed42ebfee1e87d64b6bb5551c165934fe1a759e40093ee
+size 1345

--- a/tests/integration/archive/hp/bdl/__output__/sample.bdl_extract/ipkg000_extract/sample.txt
+++ b/tests/integration/archive/hp/bdl/__output__/sample.bdl_extract/ipkg000_extract/sample.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6478ea19e2122817e1986151847d3590e114ffd7c5d65d8d91cccea316c1cf2
+size 17

--- a/tests/integration/archive/hp/bdl/__output__/sample.bdl_extract/ipkg001
+++ b/tests/integration/archive/hp/bdl/__output__/sample.bdl_extract/ipkg001
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c99dd4e215b508395aed42ebfee1e87d64b6bb5551c165934fe1a759e40093ee
+size 1345

--- a/tests/integration/archive/hp/bdl/__output__/sample.bdl_extract/ipkg001_extract/sample.txt
+++ b/tests/integration/archive/hp/bdl/__output__/sample.bdl_extract/ipkg001_extract/sample.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6478ea19e2122817e1986151847d3590e114ffd7c5d65d8d91cccea316c1cf2
+size 17

--- a/tests/integration/archive/hp/ipkg/__input__/sample.ipkg
+++ b/tests/integration/archive/hp/ipkg/__input__/sample.ipkg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c99dd4e215b508395aed42ebfee1e87d64b6bb5551c165934fe1a759e40093ee
+size 1345

--- a/tests/integration/archive/hp/ipkg/__output__/sample.ipkg_extract/sample.txt
+++ b/tests/integration/archive/hp/ipkg/__output__/sample.ipkg_extract/sample.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6478ea19e2122817e1986151847d3590e114ffd7c5d65d8d91cccea316c1cf2
+size 17

--- a/unblob/handlers/__init__.py
+++ b/unblob/handlers/__init__.py
@@ -2,6 +2,7 @@ from ..models import Handlers
 from .archive import ar, arc, arj, cab, cpio, dmg, rar, sevenzip, stuffit, tar, zip
 from .archive.dlink import encrpted_img, shrs
 from .archive.engeniustech import engenius
+from .archive.hp import bdl
 from .archive.instar import bneg
 from .archive.netgear import chk, trx
 from .archive.qnap import qnap_nas
@@ -62,6 +63,7 @@ BUILTIN_HANDLERS: Handlers = (
     hdr.HDR2Handler,
     qnap_nas.QnapHandler,
     bneg.BNEGHandler,
+    bdl.HPBDLHandler,
     sparse.SparseHandler,
     ar.ARHandler,
     arc.ARCHandler,

--- a/unblob/handlers/__init__.py
+++ b/unblob/handlers/__init__.py
@@ -2,7 +2,7 @@ from ..models import Handlers
 from .archive import ar, arc, arj, cab, cpio, dmg, rar, sevenzip, stuffit, tar, zip
 from .archive.dlink import encrpted_img, shrs
 from .archive.engeniustech import engenius
-from .archive.hp import bdl
+from .archive.hp import bdl, ipkg
 from .archive.instar import bneg
 from .archive.netgear import chk, trx
 from .archive.qnap import qnap_nas
@@ -64,6 +64,7 @@ BUILTIN_HANDLERS: Handlers = (
     qnap_nas.QnapHandler,
     bneg.BNEGHandler,
     bdl.HPBDLHandler,
+    ipkg.HPIPKGHandler,
     sparse.SparseHandler,
     ar.ARHandler,
     arc.ARCHandler,

--- a/unblob/handlers/archive/hp/bdl.py
+++ b/unblob/handlers/archive/hp/bdl.py
@@ -1,0 +1,104 @@
+import io
+from pathlib import Path
+from typing import Optional
+
+from dissect.cstruct import Instance
+from structlog import get_logger
+
+from unblob.extractor import carve_chunk_to_file
+from unblob.file_utils import Endian, File, InvalidInputFormat, StructParser, snull
+from unblob.models import Chunk, Extractor, HexString, StructHandler, ValidChunk
+
+logger = get_logger()
+
+C_DEFINITIONS = r"""
+    typedef struct bdl_toc_entry {
+        uint64 offset;
+        uint64 size;
+    } bdl_toc_entry_t;
+
+    typedef struct bdl_header {
+        char magic[4];
+        uint16 major;
+        uint16 minor;
+        uint32 toc_offset;
+        char unknown[4];
+        uint32 toc_entries;
+        uint32 unknowns_2[3];
+        char release[256];
+        char brand[256];
+        char device_id[256];
+        char unknown_3[9];
+        char version[256];
+        char revision[256];
+    } bdl_header_t;
+"""
+
+
+def is_valid_header(header: Instance) -> bool:
+    if header.toc_offset == 0 or header.toc_entries == 0:
+        return False
+    try:
+        snull(header.release).decode("utf-8")
+        snull(header.brand).decode("utf-8")
+        snull(header.device_id).decode("utf-8")
+        snull(header.version).decode("utf-8")
+        snull(header.revision).decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+class HPBDLExtractor(Extractor):
+    def __init__(self):
+        self._struct_parser = StructParser(C_DEFINITIONS)
+
+    def extract(self, inpath: Path, outdir: Path):
+        entries = []
+        with File.from_path(inpath) as file:
+            header = self._struct_parser.parse("bdl_header_t", file, Endian.LITTLE)
+            file.seek(header.toc_offset, io.SEEK_SET)
+            for i in range(header.toc_entries):
+                entry = self._struct_parser.parse(
+                    "bdl_toc_entry_t", file, Endian.LITTLE
+                )
+                entries.append(
+                    (
+                        outdir.joinpath(outdir.joinpath(Path(f"ipkg{i:03}"))),
+                        Chunk(
+                            start_offset=entry.offset,
+                            end_offset=entry.offset + entry.size,
+                        ),
+                    )
+                )
+
+            for carve_path, chunk in entries:
+                carve_chunk_to_file(
+                    file=file,
+                    chunk=chunk,
+                    carve_path=carve_path,
+                )
+
+
+class HPBDLHandler(StructHandler):
+    NAME = "bdl"
+
+    PATTERNS = [HexString("69 62 64 6C 01 00 01 00")]
+
+    C_DEFINITIONS = C_DEFINITIONS
+    HEADER_STRUCT = "bdl_header_t"
+    EXTRACTOR = HPBDLExtractor()
+
+    def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
+        header = self.parse_header(file, endian=Endian.LITTLE)
+
+        if not is_valid_header(header):
+            raise InvalidInputFormat("Invalid BDL header.")
+
+        file.seek(start_offset + header.toc_offset, io.SEEK_SET)
+        end_offset = -1
+        for _ in range(header.toc_entries):
+            entry = self._struct_parser.parse("bdl_toc_entry_t", file, Endian.LITTLE)
+            end_offset = max(end_offset, start_offset + entry.offset + entry.size)
+
+        return ValidChunk(start_offset=start_offset, end_offset=end_offset)

--- a/unblob/handlers/archive/hp/ipkg.py
+++ b/unblob/handlers/archive/hp/ipkg.py
@@ -1,0 +1,112 @@
+import io
+from pathlib import Path
+from typing import Optional
+
+from dissect.cstruct import Instance
+from structlog import get_logger
+
+from unblob.extractor import carve_chunk_to_file, is_safe_path
+from unblob.file_utils import Endian, File, InvalidInputFormat, StructParser, snull
+from unblob.models import Chunk, Extractor, HexString, StructHandler, ValidChunk
+
+logger = get_logger()
+
+C_DEFINITIONS = r"""
+    typedef struct ipkg_file_entry {
+        char name[256];
+        uint64 offset;
+        uint64 size;
+        uint32 crc32;
+    } ipkg_toc_entry_t;
+
+    typedef struct ipkg_header {
+        char magic[4];
+        uint16 major;
+        uint16 minor;
+        uint32 toc_offset;
+        uint32 unknown_1;
+        uint32 toc_entries;
+        uint32 unknown_2[2];
+        uint32 always_null;
+        char file_version[256];
+        char product_name[256];
+        char ipkg_name[256];
+        char signature[256];
+    } ipkg_header_t;
+"""
+
+
+def is_valid_header(header: Instance) -> bool:
+    if header.toc_offset == 0 or header.toc_entries == 0:
+        return False
+    try:
+        snull(header.ipkg_name).decode("utf-8")
+        snull(header.file_version).decode("utf-8")
+        snull(header.product_name).decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+class HPIPKGExtractor(Extractor):
+    def __init__(self):
+        self._struct_parser = StructParser(C_DEFINITIONS)
+
+    def extract(self, inpath: Path, outdir: Path):
+        entries = []
+        with File.from_path(inpath) as file:
+            header = self._struct_parser.parse("ipkg_header_t", file, Endian.LITTLE)
+            file.seek(header.toc_offset, io.SEEK_SET)
+            for _ in range(header.toc_entries):
+                entry = self._struct_parser.parse(
+                    "ipkg_toc_entry_t", file, Endian.LITTLE
+                )
+                entry_path = Path(snull(entry.name).decode("utf-8"))
+                if entry_path.parent.name:
+                    raise InvalidInputFormat("Entry name contains directories.")
+                if not is_safe_path(outdir, entry_path):
+                    logger.warning(
+                        "Path traversal attempt, discarding.",
+                        outdir=outdir,
+                    )
+                    continue
+                entries.append(
+                    (
+                        outdir.joinpath(outdir / entry_path.name),
+                        Chunk(
+                            start_offset=entry.offset,
+                            end_offset=entry.offset + entry.size,
+                        ),
+                    )
+                )
+
+            for carve_path, chunk in entries:
+                carve_chunk_to_file(
+                    file=file,
+                    chunk=chunk,
+                    carve_path=carve_path,
+                )
+
+
+class HPIPKGHandler(StructHandler):
+    NAME = "ipkg"
+
+    PATTERNS = [HexString("69 70 6B 67 01 00 03 00")]
+
+    C_DEFINITIONS = C_DEFINITIONS
+    HEADER_STRUCT = "ipkg_header_t"
+    EXTRACTOR = HPIPKGExtractor()
+
+    def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
+        header = self.parse_header(file, endian=Endian.LITTLE)
+
+        if not is_valid_header(header):
+            raise InvalidInputFormat("Invalid IPKG header.")
+
+        file.seek(start_offset + header.toc_offset, io.SEEK_SET)
+        end_offset = -1
+        for _ in range(header.toc_entries):
+            entry = self._struct_parser.parse("ipkg_toc_entry_t", file, Endian.LITTLE)
+            end_offset = max(end_offset, start_offset + entry.offset + entry.size)
+
+        return ValidChunk(start_offset=start_offset, end_offset=end_offset)


### PR DESCRIPTION
Format is build like this BDL -> multiple IPKG
the header contains the offset at which the table of content is built,
the table of content has the offset and the size of each IPKG
the same pattern is applied for the IPKG's

```
+---------------------+
|      BDL header     |
+---------------------+
|  Table of content   |
+---------------------+
|     ipkg header 1   |
+---------------------+
|     ipkg data 1     |
+---------------------+
|     ipkg header n   |
+---------------------+
|     ipkg data n     |
+---------------------+
```

some information can be found about this format on [this repo](https://github.com/tylerwhall/hpbdl/blob/master/src/main.rs)


plenty of sample [here](https://support.hp.com/us-en/drivers/selfservice/hp-laserjet-enterprise-500-color-printer-m551-series/4184891), [here](https://support.hp.com/us-en/drivers/selfservice/hp-laserjet-enterprise-m406-series/22732206), [here](https://support.hp.com/us-en/drivers/selfservice/hp-color-laserjet-managed-mfp-m577-series/8362240), or [here](https://support.hp.com/us-en/drivers/selfservice/hp-color-laserjet-enterprise-m552-series/7345200/model/7345201)
