### PR TITLE
chore: enforce linear history for PRs

### DIFF
--- a/.github/workflows/check-mergeable.yml
+++ b/.github/workflows/check-mergeable.yml
@@ -1,0 +1,33 @@
+name: Check branch status
+
+on:
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  check_branch_history:
+    name: Check - Linear history
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} # otherwise, it'd create a merge commit
+          fetch-depth: "0"
+      - name: Check HEAD is rebased on ${{ github.event.pull_request.base.ref }}
+        run: |
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "github-actions@github.com"
+          git fetch origin $GITHUB_BASE_REF
+          PR_HEAD_SHA=$(git rev-parse HEAD)
+          git rebase FETCH_HEAD
+          REBASED_SHA=$(git rev-parse HEAD)
+          echo "PR HEAD: $PR_HEAD_SHA"
+          echo "Rebased HEAD: $REBASED_SHA"
+          git range-diff FETCH_HEAD..$PR_HEAD_SHA FETCH_HEAD..$REBASED_SHA
+          if [[ "$REBASED_SHA" != "$PR_HEAD_SHA" ]]; then
+              echo "Not fast forward, aborting!"
+              echo "Ensure that the PR branch is rebased on $GITHUB_BASE_REF and does not contain merge commits."
+              exit 1
+          fi


### PR DESCRIPTION
The `Rebase and merge` strategy does a fast-forward merge, not creating a merge commit. The regular `Merge Pull Request` strategy doesn't enforce the to-be-merged branch to be linear (e.g. not containing merge commits on its own), just that it is up-to-date with the base.

We like having merge commits on otherwise fast-forward branches, hence introduced a new workflow ensuring this linearity.