### PR TITLE
feat(processing): Re-add non-POSIX file path handling

### DIFF
--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,5 +1,4 @@
 import io
-from pathlib import Path
 from typing import List
 
 import pytest
@@ -19,7 +18,6 @@ from unblob.file_utils import (
     iterate_patterns,
     round_down,
     round_up,
-    valid_path,
 )
 
 
@@ -340,16 +338,3 @@ class TestGetEndian:
         with pytest.raises(InvalidInputFormat):
             get_endian(file, 0xFFFF_0000)
         assert file.tell() == pos
-
-
-@pytest.mark.parametrize(
-    "content, expected",
-    [
-        pytest.param("some_random_file.txt", True, id="valid_unicode_path"),
-        pytest.param(
-            "some/random/file\udce4\udc94.txt", False, id="invalid_unicode_path"
-        ),
-    ],
-)
-def test_valid_path(content: str, expected: bool):
-    assert valid_path(Path(content)) == expected

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -311,11 +311,3 @@ def read_until_past(file: File, pattern: bytes):
             return file.tell()
         if next_byte not in pattern:
             return file.tell() - 1
-
-
-def valid_path(path: Path) -> bool:
-    try:
-        path.as_posix().encode("utf-8")
-    except UnicodeEncodeError:
-        return False
-    return True

--- a/unblob/logging.py
+++ b/unblob/logging.py
@@ -47,6 +47,12 @@ def _format_message(value: Any, extract_root: Path) -> Any:
     if isinstance(value, int):
         return format_hex(value)
 
+    if isinstance(value, str):
+        try:
+            value.encode()
+        except UnicodeEncodeError:
+            return value.encode("utf-8", errors="surrogateescape")
+
     return value
 
 

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -13,7 +13,7 @@ from structlog import get_logger
 from unblob.handlers import BUILTIN_HANDLERS, Handlers
 
 from .extractor import carve_unknown_chunk, carve_valid_chunk, fix_extracted_directory
-from .file_utils import iterate_file, valid_path
+from .file_utils import iterate_file
 from .finder import search_chunks
 from .iter_utils import pairwise
 from .logging import noformat
@@ -242,10 +242,6 @@ class Processor:
         if task.depth >= self._config.max_depth:
             # TODO: Use the reporting feature to warn the user (ONLY ONCE) at the end of execution, that this limit was reached.
             log.debug("Reached maximum depth, stop further processing")
-            return
-
-        if not valid_path(task.path):
-            log.warning("Path contains invalid characters, it won't be processed")
             return
 
         if stat_report.is_dir:


### PR DESCRIPTION
The sole reason of the existence and usage of the valid_path function (to limit unblob not to handle files with non-POSIX path) was added because of yara-python limitations in commit
e903602c94e4ca550911e3e68e01f0b09e48012e.

Since we are not using yara-python anymore, these limitations can now be lifted!

The only consequence what I discovered during testing is that the logger's format needed to be extended. It was already implemented to encode Path-strings with surrogateescape, but paths can be logged in strings as well (for example when logging the extractor command, which contains the path of the file to be extracted).