### PR TITLE
fix(handler): fix a bug when extracting squashfs with LZMA adaptive.

### DIFF
--- a/unblob/handlers/filesystem/squashfs.py
+++ b/unblob/handlers/filesystem/squashfs.py
@@ -18,7 +18,7 @@ class _SquashFSBase(StructHandler):
     BIG_ENDIAN_MAGIC = 0x73_71_73_68
 
     EXTRACTOR = Command(
-        "sasquatch", "-no-exit-code", "-f", "-d", "{outdir}", "{inpath}"
+        "sasquatch", "-no-exit-code", "-ig", "-f", "-d", "{outdir}", "{inpath}"
     )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:


### PR DESCRIPTION
We had a report that sasquatch did not extract filesystems compressed with LZMA adaptive properly (see
https://github.com/onekey-sec/sasquatch/issues/14).

We thought it would be a good idea to fix it in sasquatch (see https://github.com/onekey-sec/sasquatch/pull/15) but then figured out that there's a command line switch that we can use for that.

I'm gonna go cry now.