### PR TITLE
upgrade sasquatch

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Install sasquatch
       run: |
-        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-2/sasquatch_1.0_amd64.deb
+        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-3/sasquatch_1.0_amd64.deb
         sudo dpkg -i sasquatch_1.0_amd64.deb
         rm -f sasquatch_1.0_amd64.deb
       shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     zlib1g-dev \
     libmagic1 \
     zstd
-RUN curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-2/sasquatch_1.0_amd64.deb \
+RUN curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-3/sasquatch_1.0_amd64.deb \
     && dpkg -i sasquatch_1.0_amd64.deb \
     && rm -f sasquatch_1.0_amd64.deb
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -124,6 +124,6 @@ The Nix derivation installs all 3rd party dependencies.
 
 2.  If you need **squashfs support**, install sasquatch:
 
-        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-2/sasquatch_1.0_amd64.deb
+        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-3/sasquatch_1.0_amd64.deb
         sudo dpkg -i sasquatch_1.0_amd64.deb
         rm sasquatch_1.0_amd64.deb

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1680063688,
-        "narHash": "sha256-hVt0i96VjwxKb/PvPfxM2otfvz923b8JHQ/l5XWeDIM=",
+        "lastModified": 1680584903,
+        "narHash": "sha256-uraq+D3jcLzw/UVk0xMHcnfILfIMa0DLrtAEq2nNlxU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "6736e8be8e451b49954213241360e3b72529e47f",
+        "rev": "65d3f6a3970cd46bef5eedfd458300f72c56b3c5",
         "type": "github"
       },
       "original": {
@@ -71,11 +71,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680030621,
-        "narHash": "sha256-qQa1NeS5Rvk2lgK5lSk986PC6I72yIHejzM8PFu+dHs=",
+        "lastModified": 1680789907,
+        "narHash": "sha256-0AOMkabjbOauxspnqfzqgLKhB2gSh3sLkz1p/jIckcs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "402cc3633cc60dfc50378197305c984518b30773",
+        "rev": "9de84cd029054adc54fdc6442e121fbc5ac33baf",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677812689,
-        "narHash": "sha256-EakqhgRnjVeYJv5+BJx/NZ7/eFTMBxc4AhICUNquhUg=",
+        "lastModified": 1680488274,
+        "narHash": "sha256-0vYMrZDdokVmPQQXtFpnqA2wEgCCUXf5a3dDuDVshn0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e53e8853aa7b0688bc270e9e6a681d22e01cf299",
+        "rev": "7ec2ff598a172c6e8584457167575b3a1a5d80d8",
         "type": "github"
       },
       "original": {
@@ -217,11 +217,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678359750,
-        "narHash": "sha256-mqkSEcI798nrVv4yMX6HTsU8sD0yXXkLg07PG4oWdRM=",
+        "lastModified": 1680861399,
+        "narHash": "sha256-lxzB+4OFEwGk0fLriz91VJUcXVaKQ/s0Jr1+k2IZQnQ=",
         "owner": "onekey-sec",
         "repo": "sasquatch",
-        "rev": "ef06d235b825c7c350db2eada1952e86aa7d1e93",
+        "rev": "91b5d70c5ccd7491a1039a8030c83eccee2fa579",
         "type": "github"
       },
       "original": {

--- a/tests/integration/filesystem/squashfs/squashfs_v3_adaptive/__input__/squashfs_v3_be.lzma.bin
+++ b/tests/integration/filesystem/squashfs/squashfs_v3_adaptive/__input__/squashfs_v3_be.lzma.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71971c7a05d2d0b44bc976bc168f7b9134af8dc9fec83553889a9b5473469495
+size 4096

--- a/tests/integration/filesystem/squashfs/squashfs_v3_adaptive/__input__/squashfs_v3_le.lzma.bin
+++ b/tests/integration/filesystem/squashfs/squashfs_v3_adaptive/__input__/squashfs_v3_le.lzma.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ac15e5c993f330854497b2fd032d2e87873a288fab6da2fe72106bb40b43124
+size 4096

--- a/tests/integration/filesystem/squashfs/squashfs_v3_adaptive/__output__/squashfs_v3_be.lzma.bin_extract/apple.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v3_adaptive/__output__/squashfs_v3_be.lzma.bin_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/squashfs/squashfs_v3_adaptive/__output__/squashfs_v3_be.lzma.bin_extract/orange.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v3_adaptive/__output__/squashfs_v3_be.lzma.bin_extract/orange.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be6fe11876282442bead98e8b24aca07f8972a763cd366c56b4b5f7bcdd23eac
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v3_adaptive/__output__/squashfs_v3_le.lzma.bin_extract/apple.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v3_adaptive/__output__/squashfs_v3_le.lzma.bin_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/squashfs/squashfs_v3_adaptive/__output__/squashfs_v3_le.lzma.bin_extract/orange.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v3_adaptive/__output__/squashfs_v3_le.lzma.bin_extract/orange.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be6fe11876282442bead98e8b24aca07f8972a763cd366c56b4b5f7bcdd23eac
+size 7


### PR DESCRIPTION
Upgrade sasquatch version to include our fix for https://github.com/onekey-sec/sasquatch/issues/14.

Added integration tests to cover the specific use of LZMA adaptive in squashfs.