### PR TITLE
feat(reporting): report meta-data information about chunks.

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -94,8 +94,8 @@ $ cat alpine-report.json
         "start_offset": 0,
         "end_offset": 2711958,
         "size": 2711958,
-        "is_encrypted": false,
         "extraction_reports": [],
+        "metadata_reports": [],
         "__typename__": "ChunkReport"
       }
     ],

--- a/python/unblob/handlers/archive/rar.py
+++ b/python/unblob/handlers/archive/rar.py
@@ -11,6 +11,7 @@ import rarfile
 from structlog import get_logger
 
 from unblob.extractors import Command
+from unblob.report import EncryptionMetadataReport
 
 from ...models import (
     File,
@@ -68,5 +69,7 @@ class RarHandler(Handler):
         return ValidChunk(
             start_offset=start_offset,
             end_offset=rar_end_offset,
-            is_encrypted=rar_file.needs_password(),
+            metadata_reports=[
+                EncryptionMetadataReport(is_encrypted=rar_file.needs_password())
+            ],
         )

--- a/python/unblob/handlers/archive/sevenzip.py
+++ b/python/unblob/handlers/archive/sevenzip.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from structlog import get_logger
 
 from unblob.extractors import Command
+from unblob.report import MetadataReport, register_report_type
 
 from ...extractors.command import MultiFileCommand
 from ...file_utils import Endian, InvalidInputFormat, StructParser
@@ -77,6 +78,14 @@ def calculate_sevenzip_size(header) -> int:
     return len(header) + header.next_header_offset + header.next_header_size
 
 
+@register_report_type
+class SevenZipMetadataReport(MetadataReport):
+    """Report for 7-Zip metadata."""
+
+    version_major: int
+    version_minor: int
+
+
 class SevenZipHandler(StructHandler):
     NAME = "sevenzip"
 
@@ -106,6 +115,14 @@ class SevenZipHandler(StructHandler):
         limitations=[],
     )
 
+    def get_metadata_reports(self, header) -> list[MetadataReport]:
+        return [
+            SevenZipMetadataReport(
+                version_major=int(header.version_maj),
+                version_minor=int(header.version_min),
+            )
+        ]
+
     def calculate_chunk(self, file: File, start_offset: int) -> ValidChunk | None:
         header = self.parse_header(file)
 
@@ -113,7 +130,13 @@ class SevenZipHandler(StructHandler):
 
         size = calculate_sevenzip_size(header)
 
-        return ValidChunk(start_offset=start_offset, end_offset=start_offset + size)
+        metadata_reports = self.get_metadata_reports(header)
+
+        return ValidChunk(
+            start_offset=start_offset,
+            end_offset=start_offset + size,
+            metadata_reports=metadata_reports,
+        )
 
 
 class MultiVolumeSevenZipHandler(DirectoryHandler):

--- a/python/unblob/handlers/archive/zip.py
+++ b/python/unblob/handlers/archive/zip.py
@@ -3,6 +3,8 @@ import struct
 
 from structlog import get_logger
 
+from unblob.report import EncryptionMetadataReport
+
 from ...extractors import Command
 from ...file_utils import InvalidInputFormat, iterate_patterns
 from ...models import (
@@ -227,5 +229,7 @@ class ZIPHandler(StructHandler):
         return ValidChunk(
             start_offset=start_offset,
             end_offset=file.tell(),
-            is_encrypted=has_encrypted_files,
+            metadata_reports=[
+                EncryptionMetadataReport(is_encrypted=has_encrypted_files)
+            ],
         )

--- a/python/unblob/models.py
+++ b/python/unblob/models.py
@@ -19,6 +19,7 @@ from .report import (
     CarveDirectoryReport,
     ChunkReport,
     ErrorReport,
+    MetadataReport,
     MultiFileReport,
     RandomnessReport,
     Report,
@@ -181,6 +182,7 @@ class ValidChunk(Chunk):
 
     handler: Handler = attrs.field(init=False, eq=False)
     is_encrypted: bool = attrs.field(default=False)
+    metadata_reports: list[MetadataReport] = attrs.field(factory=list, kw_only=True)
 
     def extract(self, inpath: Path, outdir: Path) -> ExtractResult | None:
         if self.is_encrypted:
@@ -201,6 +203,7 @@ class ValidChunk(Chunk):
             size=self.size,
             handler_name=self.handler.NAME,
             is_encrypted=self.is_encrypted,
+            metadata_reports=self.metadata_reports,
             extraction_reports=extraction_reports,
         )
 
@@ -246,6 +249,7 @@ class PaddingChunk(Chunk):
             is_encrypted=False,
             handler_name="padding",
             extraction_reports=[],
+            metadata_reports=[],
         )
 
 
@@ -266,6 +270,7 @@ class MultiFile(Blob):
             paths=self.paths,
             handler_name=self.handler.NAME,
             extraction_reports=extraction_reports,
+            metadata_reports=[],
         )
 
 

--- a/python/unblob/models.py
+++ b/python/unblob/models.py
@@ -18,6 +18,7 @@ from .parser import hexstring2regex
 from .report import (
     CarveDirectoryReport,
     ChunkReport,
+    EncryptionMetadataReport,
     ErrorReport,
     MetadataReport,
     MultiFileReport,
@@ -181,8 +182,15 @@ class ValidChunk(Chunk):
     """Known to be valid chunk of a File, can be extracted with an external program."""
 
     handler: Handler = attrs.field(init=False, eq=False)
-    is_encrypted: bool = attrs.field(default=False)
     metadata_reports: list[MetadataReport] = attrs.field(factory=list, kw_only=True)
+
+    @property
+    def is_encrypted(self) -> bool:
+        return any(
+            report.is_encrypted
+            for report in self.metadata_reports
+            if isinstance(report, EncryptionMetadataReport)
+        )
 
     def extract(self, inpath: Path, outdir: Path) -> ExtractResult | None:
         if self.is_encrypted:
@@ -202,7 +210,6 @@ class ValidChunk(Chunk):
             end_offset=self.end_offset,
             size=self.size,
             handler_name=self.handler.NAME,
-            is_encrypted=self.is_encrypted,
             metadata_reports=self.metadata_reports,
             extraction_reports=extraction_reports,
         )
@@ -246,7 +253,6 @@ class PaddingChunk(Chunk):
             start_offset=self.start_offset,
             end_offset=self.end_offset,
             size=self.size,
-            is_encrypted=False,
             handler_name="padding",
             extraction_reports=[],
             metadata_reports=[],

--- a/python/unblob/report.py
+++ b/python/unblob/report.py
@@ -6,7 +6,7 @@ import stat
 import traceback
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -15,6 +15,7 @@ from pydantic import (
     BaseModel,
     BeforeValidator,
     ConfigDict,
+    Field,
     computed_field,
     field_serializer,
     field_validator,
@@ -222,6 +223,10 @@ class RandomnessReport(Report):
     chi_square: RandomnessMeasurements
 
 
+class MetadataReport(Report):
+    pass
+
+
 class ChunkReport(Report):
     id: str
     handler_name: str
@@ -230,10 +235,16 @@ class ChunkReport(Report):
     size: int
     is_encrypted: bool
     extraction_reports: list[Report]
+    metadata_reports: list[MetadataReport] = Field(default_factory=list)
 
     @field_validator("extraction_reports", mode="before")
     @classmethod
     def validate_extraction_reports(cls, value: Any) -> list[Report]:
+        return validate_report_list(value)
+
+    @field_validator("metadata_reports", mode="before")
+    @classmethod
+    def validate_metadata_reports(cls, value: Any) -> list[Report]:
         return validate_report_list(value)
 
 
@@ -265,10 +276,16 @@ class MultiFileReport(Report):
     name: str
     paths: list[Path]
     extraction_reports: list[Report]
+    metadata_reports: list[MetadataReport] = Field(default_factory=list)
 
     @field_validator("extraction_reports", mode="before")
     @classmethod
     def validate_extraction_reports(cls, value: Any) -> list[Report]:
+        return validate_report_list(value)
+
+    @field_validator("metadata_reports", mode="before")
+    @classmethod
+    def validate_metadata_reports(cls, value: Any) -> list[Report]:
         return validate_report_list(value)
 
 
@@ -364,14 +381,16 @@ BUILTIN_REPORT_TYPES: tuple[type[Report], ...] = (
 )
 
 _REPORT_REGISTRY: dict[str, type[Report]] = {}
+ReportType = TypeVar("ReportType", bound=type[Report])
 
 
-def register_report_type(report_type: type[Report]) -> None:
+def register_report_type(report_type: ReportType) -> ReportType:
     typename = report_type.__name__
     existing = _REPORT_REGISTRY.get(typename)
     if existing is not None and existing is not report_type:
         raise ValueError(f"Report type name conflict: {typename}")
     _REPORT_REGISTRY[typename] = report_type
+    return report_type
 
 
 def register_report_types(report_types: Iterable[type[Report]]) -> None:

--- a/python/unblob/report.py
+++ b/python/unblob/report.py
@@ -227,6 +227,10 @@ class MetadataReport(Report):
     pass
 
 
+class EncryptionMetadataReport(MetadataReport):
+    is_encrypted: bool
+
+
 class HandledBlobReport(Report):
     id: str
     handler_name: str
@@ -243,7 +247,6 @@ class ChunkReport(HandledBlobReport):
     start_offset: int
     end_offset: int
     size: int
-    is_encrypted: bool
 
 
 class UnknownChunkReport(Report):
@@ -354,6 +357,7 @@ BUILTIN_REPORT_TYPES: tuple[type[Report], ...] = (
     HashReport,
     FileMagicReport,
     RandomnessReport,
+    EncryptionMetadataReport,
     ChunkReport,
     UnknownChunkReport,
     CarveDirectoryReport,

--- a/python/unblob/report.py
+++ b/python/unblob/report.py
@@ -227,25 +227,23 @@ class MetadataReport(Report):
     pass
 
 
-class ChunkReport(Report):
+class HandledBlobReport(Report):
     id: str
     handler_name: str
+    extraction_reports: list[Report]
+    metadata_reports: list[MetadataReport] = Field(default_factory=list)
+
+    @field_validator("extraction_reports", "metadata_reports", mode="before")
+    @classmethod
+    def validate_reports(cls, value: Any) -> list[Report]:
+        return validate_report_list(value)
+
+
+class ChunkReport(HandledBlobReport):
     start_offset: int
     end_offset: int
     size: int
     is_encrypted: bool
-    extraction_reports: list[Report]
-    metadata_reports: list[MetadataReport] = Field(default_factory=list)
-
-    @field_validator("extraction_reports", mode="before")
-    @classmethod
-    def validate_extraction_reports(cls, value: Any) -> list[Report]:
-        return validate_report_list(value)
-
-    @field_validator("metadata_reports", mode="before")
-    @classmethod
-    def validate_metadata_reports(cls, value: Any) -> list[Report]:
-        return validate_report_list(value)
 
 
 class UnknownChunkReport(Report):
@@ -270,23 +268,9 @@ class CarveDirectoryReport(Report):
     carve_dir: Path
 
 
-class MultiFileReport(Report):
-    id: str
-    handler_name: str
+class MultiFileReport(HandledBlobReport):
     name: str
     paths: list[Path]
-    extraction_reports: list[Report]
-    metadata_reports: list[MetadataReport] = Field(default_factory=list)
-
-    @field_validator("extraction_reports", mode="before")
-    @classmethod
-    def validate_extraction_reports(cls, value: Any) -> list[Report]:
-        return validate_report_list(value)
-
-    @field_validator("metadata_reports", mode="before")
-    @classmethod
-    def validate_metadata_reports(cls, value: Any) -> list[Report]:
-        return validate_report_list(value)
 
 
 class ExtractedFileDeletedReport(Report):

--- a/tests/handlers/archive/test_encryption_metadata.py
+++ b/tests/handlers/archive/test_encryption_metadata.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+import pytest
+
+from unblob.file_utils import File
+from unblob.handlers.archive.rar import RarHandler
+from unblob.handlers.archive.zip import ZIPHandler
+from unblob.report import EncryptionMetadataReport
+
+TEST_DATA_PATH = Path(__file__).parents[2] / "integration" / "archive"
+
+
+@pytest.mark.parametrize(
+    "handler_type, relative_path, expected",
+    [
+        pytest.param(
+            RarHandler,
+            "rar/default/__input__/erdbeere.rar",
+            False,
+            id="rar-regular",
+        ),
+        pytest.param(
+            RarHandler,
+            "rar/password/__input__/cherry_password.rar",
+            True,
+            id="rar-password-protected",
+        ),
+        pytest.param(
+            RarHandler,
+            "rar/encrypted/__input__/cherry_encrypted.rar",
+            True,
+            id="rar-encrypted-headers",
+        ),
+        pytest.param(
+            ZIPHandler,
+            "zip/regular/__input__/apple.zip",
+            False,
+            id="zip-regular",
+        ),
+        pytest.param(
+            ZIPHandler,
+            "zip/encrypted/__input__/apple_encrypted.zip",
+            True,
+            id="zip-encrypted",
+        ),
+        pytest.param(
+            ZIPHandler,
+            "zip/partly_encrypted/__input__/kaki1_aes.zip",
+            True,
+            id="zip-partly-encrypted",
+        ),
+    ],
+)
+def test_archive_encryption_metadata(handler_type, relative_path, expected):
+    with File.from_path(TEST_DATA_PATH / relative_path) as file:
+        chunk = handler_type().calculate_chunk(file, 0)
+
+    assert chunk is not None
+    assert chunk.metadata_reports == [EncryptionMetadataReport(is_encrypted=expected)]
+    assert chunk.is_encrypted is expected

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from unblob.file_utils import InvalidInputFormat
+from unblob.handlers.archive.sevenzip import SevenZipMetadataReport
 from unblob.models import (
     Chunk,
     Glob,
@@ -18,6 +19,8 @@ from unblob.report import (
     ExtractCommandFailedReport,
     FileMagicReport,
     HashReport,
+    MetadataReport,
+    MultiFileReport,
     RandomnessMeasurements,
     RandomnessReport,
     Report,
@@ -211,6 +214,7 @@ class Test_to_json:  # noqa: N801
                         "handler_name": "zip",
                         "id": "test_basic_conversion:id",
                         "is_encrypted": False,
+                        "metadata_reports": [],
                         "size": 384,
                         "start_offset": 0,
                     },
@@ -337,6 +341,50 @@ def test_custom_report_registration_and_deserialization():
     assert isinstance(report_data[0].reports[0], CustomReport)
     assert isinstance(report_data[0].reports[1], ChunkReport)
     assert isinstance(report_data[0].reports[1].extraction_reports[0], CustomReport)
+
+
+def test_metadata_report_registration_and_deserialization():
+    class TestMetadataReport(MetadataReport):
+        value: int
+
+    register_report_type(TestMetadataReport)
+
+    metadata_report = TestMetadataReport(value=42)
+    chunk_report = ChunkReport(
+        id="sevenzip-chunk",
+        handler_name="sevenzip",
+        start_offset=0,
+        end_offset=1,
+        size=1,
+        is_encrypted=False,
+        extraction_reports=[],
+        metadata_reports=[metadata_report],
+    )
+    process_result = ProcessResult(
+        results=[
+            TaskResult(
+                task=Task(path=Path("/archive.7z"), depth=0, blob_id=""),
+                reports=[chunk_report],
+            )
+        ]
+    )
+
+    report_data = ReportModelAdapter.validate_json(process_result.to_json())
+    deserialized_process_result = ProcessResult(results=report_data)
+    [deserialized_chunk_report] = deserialized_process_result.results[0].reports
+
+    assert isinstance(deserialized_chunk_report, ChunkReport)
+    deserialized_metadata_report, deserialized_encryption_report = (
+        deserialized_chunk_report.metadata_reports
+    )
+    assert deserialized_metadata_report == metadata_report
+    assert isinstance(deserialized_encryption_report, EncryptionMetadataReport)
+    assert deserialized_encryption_report.is_encrypted is True
+
+    assert isinstance(deserialized_multi_file_report, MultiFileReport)
+    [deserialized_metadata_report] = deserialized_multi_file_report.metadata_reports
+    assert isinstance(deserialized_metadata_report, TestMetadataReport)
+    assert deserialized_metadata_report == metadata_report
 
 
 def test_unknown_chunk_report_randomness_validation():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,9 +12,11 @@ from unblob.models import (
     Task,
     TaskResult,
     UnknownChunk,
+    ValidChunk,
 )
 from unblob.report import (
     ChunkReport,
+    EncryptionMetadataReport,
     ExtractCommandFailedReport,
     FileMagicReport,
     HashReport,
@@ -128,6 +130,40 @@ class TestChunk:
             Chunk(start_offset=start_offset, end_offset=end_offset)
 
 
+@pytest.mark.parametrize(
+    "metadata_reports, expected",
+    [
+        pytest.param([], False, id="not-reported"),
+        pytest.param(
+            [EncryptionMetadataReport(is_encrypted=False)],
+            False,
+            id="not-encrypted",
+        ),
+        pytest.param(
+            [EncryptionMetadataReport(is_encrypted=True)],
+            True,
+            id="encrypted",
+        ),
+        pytest.param(
+            [
+                EncryptionMetadataReport(is_encrypted=False),
+                EncryptionMetadataReport(is_encrypted=True),
+            ],
+            True,
+            id="conflicting-status-is-encrypted",
+        ),
+    ],
+)
+def test_valid_chunk_encryption_status(metadata_reports, expected):
+    chunk = ValidChunk(
+        start_offset=0,
+        end_offset=1,
+        metadata_reports=metadata_reports,
+    )
+
+    assert chunk.is_encrypted is expected
+
+
 class Test_to_json:  # noqa: N801
     def test_process_result_conversion(self):
         task = Task(path=Path("/nonexistent"), depth=0, blob_id="")
@@ -164,7 +200,6 @@ class Test_to_json:  # noqa: N801
                 start_offset=0,
                 end_offset=384,
                 size=384,
-                is_encrypted=False,
                 extraction_reports=[],
             )
         )
@@ -212,7 +247,6 @@ class Test_to_json:  # noqa: N801
                         "extraction_reports": [],
                         "handler_name": "zip",
                         "id": "test_basic_conversion:id",
-                        "is_encrypted": False,
                         "metadata_reports": [],
                         "size": 384,
                         "start_offset": 0,
@@ -270,7 +304,6 @@ class Test_to_json:  # noqa: N801
                 start_offset=0,
                 end_offset=384,
                 size=384,
-                is_encrypted=False,
                 extraction_reports=[],
             )
         )
@@ -327,7 +360,6 @@ def test_custom_report_registration_and_deserialization():
         start_offset=0,
         end_offset=1,
         size=1,
-        is_encrypted=False,
         extraction_reports=[custom_report],
     )
 
@@ -355,9 +387,11 @@ def test_metadata_report_registration_and_deserialization():
         start_offset=0,
         end_offset=1,
         size=1,
-        is_encrypted=False,
         extraction_reports=[],
-        metadata_reports=[metadata_report],
+        metadata_reports=[
+            metadata_report,
+            EncryptionMetadataReport(is_encrypted=True),
+        ],
     )
     multi_file_report = MultiFileReport(
         id="multi-sevenzip",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 
 from unblob.file_utils import InvalidInputFormat
-from unblob.handlers.archive.sevenzip import SevenZipMetadataReport
 from unblob.models import (
     Chunk,
     Glob,
@@ -360,18 +359,28 @@ def test_metadata_report_registration_and_deserialization():
         extraction_reports=[],
         metadata_reports=[metadata_report],
     )
+    multi_file_report = MultiFileReport(
+        id="multi-sevenzip",
+        handler_name="multi-sevenzip",
+        name="archive.7z.001",
+        paths=[Path("/archive.7z.001"), Path("/archive.7z.002")],
+        extraction_reports=[],
+        metadata_reports=[metadata_report],
+    )
     process_result = ProcessResult(
         results=[
             TaskResult(
                 task=Task(path=Path("/archive.7z"), depth=0, blob_id=""),
-                reports=[chunk_report],
+                reports=[chunk_report, multi_file_report],
             )
         ]
     )
 
     report_data = ReportModelAdapter.validate_json(process_result.to_json())
     deserialized_process_result = ProcessResult(results=report_data)
-    [deserialized_chunk_report] = deserialized_process_result.results[0].reports
+    deserialized_chunk_report, deserialized_multi_file_report = (
+        deserialized_process_result.results[0].reports
+    )
 
     assert isinstance(deserialized_chunk_report, ChunkReport)
     deserialized_metadata_report, deserialized_encryption_report = (

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -12,6 +12,7 @@ from unblob.processing import ExtractionConfig, process_file
 from unblob.report import (
     CarveDirectoryReport,
     ChunkReport,
+    EncryptionMetadataReport,
     ExtractCommandFailedReport,
     FileMagicReport,
     HashReport,
@@ -143,7 +144,6 @@ def hello_kitty_task_results(
                     end_offset=264,
                     size=1,
                     handler_name="padding",
-                    is_encrypted=False,
                     extraction_reports=[],
                 ),
                 ChunkReport(
@@ -152,8 +152,8 @@ def hello_kitty_task_results(
                     start_offset=6,
                     end_offset=131,
                     size=125,
-                    is_encrypted=False,
                     extraction_reports=[],
+                    metadata_reports=[EncryptionMetadataReport(is_encrypted=False)],
                 ),
                 ChunkReport(
                     id=kitty_id,
@@ -161,8 +161,8 @@ def hello_kitty_task_results(
                     start_offset=138,
                     end_offset=263,
                     size=125,
-                    is_encrypted=False,
                     extraction_reports=[],
+                    metadata_reports=[EncryptionMetadataReport(is_encrypted=False)],
                 ),
             ],
             subtasks=[
@@ -360,8 +360,8 @@ def container_task_results(
                     start_offset=0,
                     end_offset=384,
                     size=384,
-                    is_encrypted=False,
                     extraction_reports=[],
+                    metadata_reports=[EncryptionMetadataReport(is_encrypted=False)],
                 ),
             ],
             subtasks=[

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -8,6 +8,7 @@ from unblob import cli
 from unblob.doc import generate_markdown
 from unblob.file_utils import File, FileSystem, iterbits, round_down
 from unblob.handlers.archive.dlink.fpkg import FileType as FPKGFileType
+from unblob.handlers.archive.sevenzip import SevenZipMetadataReport
 from unblob.handlers.archive.tar._safe_tar_file import (  # pyright: ignore[reportMissingImports]
     UnblobTarInfo,
 )
@@ -114,3 +115,6 @@ UnblobTarInfo.devminor
 UnblobTarInfo._sparse_structs  # noqa: SLF001
 
 UCLDecompressor
+
+SevenZipMetadataReport.version_major
+SevenZipMetadataReport.version_minor

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -43,9 +43,11 @@ TaskResult.filter_reports
 TaskResult.validate_reports
 ChunkReport.handler_name
 ChunkReport.validate_extraction_reports
+ChunkReport.validate_metadata_reports
 FileMagicReport.magic
 FileMagicReport.mime_type
 MultiFileReport.validate_extraction_reports
+MultiFileReport.validate_metadata_reports
 StatReport.is_link
 
 SingleFile

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -24,6 +24,7 @@ from unblob.models import (
 )
 from unblob.parser import _HexStringToRegex
 from unblob.report import (
+    EncryptionMetadataReport,
     ExtractCommandFailedReport,
     FileMagicReport,
     HandledBlobReport,
@@ -43,6 +44,7 @@ TaskResult.filter_reports
 TaskResult.validate_reports
 HandledBlobReport.handler_name
 HandledBlobReport.validate_reports
+EncryptionMetadataReport.is_encrypted
 FileMagicReport.magic
 FileMagicReport.mime_type
 StatReport.is_link

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -24,10 +24,9 @@ from unblob.models import (
 )
 from unblob.parser import _HexStringToRegex
 from unblob.report import (
-    ChunkReport,
     ExtractCommandFailedReport,
     FileMagicReport,
-    MultiFileReport,
+    HandledBlobReport,
     Report,
     StatReport,
     UnknownChunkReport,
@@ -42,13 +41,10 @@ _HexStringToRegex.alternative
 
 TaskResult.filter_reports
 TaskResult.validate_reports
-ChunkReport.handler_name
-ChunkReport.validate_extraction_reports
-ChunkReport.validate_metadata_reports
+HandledBlobReport.handler_name
+HandledBlobReport.validate_reports
 FileMagicReport.magic
 FileMagicReport.mime_type
-MultiFileReport.validate_extraction_reports
-MultiFileReport.validate_metadata_reports
 StatReport.is_link
 
 SingleFile


### PR DESCRIPTION
Allow handlers to provide a dict value as part of a `ValidChunk` metadata attribute. That dictionary can contain any relevant metadata information from the perspective of the handler, but we advise handler writers to report parsed information such as header values.

This metadata dict is later reported as part of our `ChunkReports` and available in the JSON report file if the user requested one.

The idea is to expose metadata to further analysis steps through the unblob report. For example, a binary analysis toolkit would read the load address and architecture from a uImage chunk to analyze the file extracted from that chunk with the right settings.

**A note on the 'as_dict' implementation.**

The initial idea was to implement it in dissect.cstruct (see https://github.com/fox-it/dissect.cstruct/pull/29), but due to expected changes in the project's API I chose to implement it in unblob so we're not dependent on another project.

Related to #16 and initial discussion in https://github.com/onekey-sec/unblob/issues/16#issuecomment-1493368023

---

You can observe the changes like this:

```
poetry run unblob -vvv -e /tmp/out -f --report /tmp/report.json tests/integration/archive/sevenzip/__input__/cherry.7z

cat /tmp/report.json| jq '.[0].reports[-1].metadata'
{
  "magic": "7z��'\u001c",
  "version_maj": 0,
  "version_min": 4,
  "crc": 3845252377,
  "next_header_offset": 147,
  "next_header_size": 33,
  "next_header_crc": 2089891445
}
```
