### PR TITLE
Report calculated entropies

### DIFF
--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -312,12 +312,26 @@ def hello_kitty_task_results(
                     sha1="febca6ed75dc02e0def065e7b08f1cca87b57c74",
                     sha256="144d8b2c949cb4943128aa0081153bcba4f38eb0ba26119cc06ca1563c4999e1",
                 ),
-                UnknownChunkReport(chunk_id=ANY, start_offset=0, end_offset=6, size=6),
                 UnknownChunkReport(
-                    chunk_id=ANY, start_offset=131, end_offset=138, size=7
+                    chunk_id=ANY,
+                    start_offset=0,
+                    end_offset=6,
+                    size=6,
+                    entropy=None,
                 ),
                 UnknownChunkReport(
-                    chunk_id=ANY, start_offset=263, end_offset=264, size=1
+                    chunk_id=ANY,
+                    start_offset=131,
+                    end_offset=138,
+                    size=7,
+                    entropy=None,
+                ),
+                UnknownChunkReport(
+                    chunk_id=ANY,
+                    start_offset=263,
+                    end_offset=264,
+                    size=1,
+                    entropy=None,
                 ),
                 ChunkReport(
                     chunk_id=hello_id,

--- a/unblob/math.py
+++ b/unblob/math.py
@@ -1,3 +1,7 @@
+from typing import Callable
+
+shannon_entropy: Callable[[bytes], float]
+
 try:
     from ._rust import shannon_entropy  # type: ignore
 except ImportError:

--- a/unblob/models.py
+++ b/unblob/models.py
@@ -11,7 +11,7 @@ from structlog import get_logger
 from .file_utils import Endian, File, InvalidInputFormat, StructParser
 from .identifiers import new_id
 from .parser import hexstring2regex
-from .report import ChunkReport, ErrorReport, Report, UnknownChunkReport
+from .report import ChunkReport, EntropyReport, ErrorReport, Report, UnknownChunkReport
 
 logger = get_logger()
 
@@ -123,12 +123,13 @@ class UnknownChunk(Chunk):
     like most common bytes (like \x00 and \xFF), ASCII strings, high entropy, etc.
     """
 
-    def as_report(self) -> UnknownChunkReport:
+    def as_report(self, entropy: Optional[EntropyReport]) -> UnknownChunkReport:
         return UnknownChunkReport(
             chunk_id=self.chunk_id,
             start_offset=self.start_offset,
             end_offset=self.end_offset,
             size=self.size,
+            entropy=entropy,
         )
 
 

--- a/unblob/report.py
+++ b/unblob/report.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import stat
+import statistics
 import traceback
 from enum import Enum
 from pathlib import Path
@@ -172,6 +173,24 @@ class FileMagicReport(Report):
     mime_type: str
 
 
+@attr.define(kw_only=True)
+class EntropyReport(Report):
+    percentages: List[float]
+    buffer_size: int
+
+    @property
+    def mean(self):
+        return statistics.mean(self.percentages)
+
+    @property
+    def highest(self):
+        return max(self.percentages)
+
+    @property
+    def lowest(self):
+        return min(self.percentages)
+
+
 @final
 @attr.define(kw_only=True)
 class ChunkReport(Report):
@@ -191,3 +210,4 @@ class UnknownChunkReport(Report):
     start_offset: int
     end_offset: int
     size: int
+    entropy: Optional[EntropyReport]


### PR DESCRIPTION
Extended existing code, so that entropy can be reported for outside use.

Refactor:
- shuffled around code to do only one thing in entropy-calculation functions

Fixes:
- typing for alternative imports from `unblob.math`
- logging of entropy charts, which was unfortunately broken due to global state in the `plotext` library
