### PR TITLE
fix(extractor): do not set permission on symlink

### DIFF
--- a/unblob/extractor.py
+++ b/unblob/extractor.py
@@ -23,6 +23,9 @@ def carve_chunk_to_file(carve_path: Path, file: File, chunk: Chunk):
 
 
 def fix_permission(path: Path):
+    if path.is_symlink():
+        return
+
     if path.is_file():
         path.chmod(0o644)
     elif path.is_dir():


### PR DESCRIPTION
fix_permission is called before fix_symlink, hence the symlink might be an absolute target and setting an permission would fail, so we should ignore setting permission on symlink.

Setting follow_symlinks=False on chmod() would be a solution, but not all platforms support it as of now.

Ignoring permission setting on the target is ok, as that would be taken care separately.