### PR TITLE
fix(handlers): handle tar archives with same file present more than once

### DIFF
--- a/tests/integration/archive/tar/__input__/dual_entry.tar
+++ b/tests/integration/archive/tar/__input__/dual_entry.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8684178ad6cf02586da93ba255e90c9c345e31fa83b4beffe881cf8d0d6592fd
+size 9728

--- a/tests/integration/archive/tar/__output__/dual_entry.tar_extract/ppc64-POWER7-64cpu/proc/device-tree/hmc-managed?
+++ b/tests/integration/archive/tar/__output__/dual_entry.tar_extract/ppc64-POWER7-64cpu/proc/device-tree/hmc-managed?
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12a3ae445661ce5dee78d0650d33362dec29c4f82af05e7e57fb595bbbacf0ca
+size 8

--- a/tests/integration/archive/tar/__output__/dual_entry.tar_extract/ppc64-POWER7-64cpu/proc/device-tree/ibm,partition-name
+++ b/tests/integration/archive/tar/__output__/dual_entry.tar_extract/ppc64-POWER7-64cpu/proc/device-tree/ibm,partition-name
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab345a64089904876434b851ddacd13e9b92cf5faab998c6ee94edf00f19586d
+size 4

--- a/unblob/handlers/archive/_safe_tarfile.py
+++ b/unblob/handlers/archive/_safe_tarfile.py
@@ -40,4 +40,13 @@ class SafeTarFile(TarFile):
             logger.warning("traversal attempt", path=member_name_path)
             return
 
-        super().extract(member, path, set_attrs, numeric_owner=numeric_owner)
+        try:
+            super().extract(member, path, set_attrs, numeric_owner=numeric_owner)
+        except PermissionError as e:
+            logger.warning(
+                "A permission error occured when extracting tar file. This can happen when the same file is present in the archive more than once.",
+                exc=e,
+                member=member,
+                path=path,
+                set_attrs=set_attrs,
+            )


### PR DESCRIPTION
A `PermissionError: [Errno 13] Permission denied` is thrown when expanding a tarfile to which a file had been added more than once, *if* the file is not writeable.  (tarfile expands the file twice, but the second time finds a non-writeable file in the way.)

Decided to handle this gracefully by catching the PermissionError and logging it.

See https://bugs.python.org/issue30438 for a detailed discussion of this issue.