### PR TITLE
Tar handler improvements

### DIFF
--- a/tests/integration/archive/tar/__input__/absolute.tar
+++ b/tests/integration/archive/tar/__input__/absolute.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b594d3fc6eb4ce49e4b2e1ba1c632bffa57174c5ce0082bd31a37bb245eb79e8
+size 10240

--- a/tests/integration/archive/tar/__input__/dual_entry.tar
+++ b/tests/integration/archive/tar/__input__/dual_entry.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8684178ad6cf02586da93ba255e90c9c345e31fa83b4beffe881cf8d0d6592fd
+size 9728

--- a/tests/integration/archive/tar/__output__/absolute.tar_extract/absolute/absolute-file
+++ b/tests/integration/archive/tar/__output__/absolute.tar_extract/absolute/absolute-file
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
+size 6

--- a/tests/integration/archive/tar/__output__/absolute.tar_extract/absolute/absolute-symlink
+++ b/tests/integration/archive/tar/__output__/absolute.tar_extract/absolute/absolute-symlink
@@ -1,0 +1,1 @@
+absolute/absolute-file

--- a/tests/integration/archive/tar/__output__/absolute.tar_extract/absolute/link_to_etc_shadow
+++ b/tests/integration/archive/tar/__output__/absolute.tar_extract/absolute/link_to_etc_shadow
@@ -1,0 +1,1 @@
+etc/shadow

--- a/tests/integration/archive/tar/__output__/absolute.tar_extract/absolute/post-link-traversal-file
+++ b/tests/integration/archive/tar/__output__/absolute.tar_extract/absolute/post-link-traversal-file
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
+size 6

--- a/tests/integration/archive/tar/__output__/dual_entry.tar_extract/ppc64-POWER7-64cpu/proc/device-tree/hmc-managed?
+++ b/tests/integration/archive/tar/__output__/dual_entry.tar_extract/ppc64-POWER7-64cpu/proc/device-tree/hmc-managed?
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12a3ae445661ce5dee78d0650d33362dec29c4f82af05e7e57fb595bbbacf0ca
+size 8

--- a/tests/integration/archive/tar/__output__/dual_entry.tar_extract/ppc64-POWER7-64cpu/proc/device-tree/ibm,partition-name
+++ b/tests/integration/archive/tar/__output__/dual_entry.tar_extract/ppc64-POWER7-64cpu/proc/device-tree/ibm,partition-name
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab345a64089904876434b851ddacd13e9b92cf5faab998c6ee94edf00f19586d
+size 4

--- a/unblob/handlers/archive/_safe_tarfile.py
+++ b/unblob/handlers/archive/_safe_tarfile.py
@@ -38,7 +38,7 @@ class SafeTarFile:
                 self.record_problem(member, str(e), "Ignored.")
         self.fix_directories(extract_root)
 
-    def extract(self, tarinfo: tarfile.TarInfo, extract_root: Path):
+    def extract(self, tarinfo: tarfile.TarInfo, extract_root: Path):  # noqa: C901
         if not tarinfo.name:
             self.record_problem(
                 tarinfo,

--- a/unblob/handlers/archive/_safe_tarfile.py
+++ b/unblob/handlers/archive/_safe_tarfile.py
@@ -1,7 +1,8 @@
 import os
+import tarfile
 from pathlib import Path
-from tarfile import TarFile
 
+import attrs
 from structlog import get_logger
 
 from unblob.extractor import is_safe_path
@@ -12,32 +13,97 @@ RUNNING_AS_ROOT = os.getuid() == 0
 MAX_PATH_LEN = 255
 
 
-class SafeTarFile(TarFile):
-    def extract(
-        self, member, path="", set_attrs=True, *, numeric_owner=False  # noqa: FBT002
-    ):
-        if isinstance(member, str):
-            member = self.getmember(member)
+@attrs.define
+class ProblematicTarMember:
+    tarinfo: tarfile.TarInfo
+    problem: str
+    resolution: str
 
-        path_as_path = Path(str(path))
-        member_name_path = Path(str(member.name))
 
-        if not member.name:
-            logger.warning("File with empty filename in tar archive. Skipping")
-            return
+class SafeTarFile:
+    def __init__(self, inpath: Path):
+        self.inpath = inpath
+        self.problems = []
+        self.tarfile = tarfile.open(inpath)
+        self.directories = {}
 
-        if len(member.name) > MAX_PATH_LEN:
-            logger.warning("File with filename too long in tar archive. Skipping")
-            return
+    def close(self):
+        self.tarfile.close()
 
-        if not RUNNING_AS_ROOT and (member.ischr() or member.isblk()):
-            logger.warning(
-                "missing elevated permissions, skipping block and character device creation",
-                path=member_name_path,
+    def extractall(self, extract_root: Path):
+        for member in self.tarfile.getmembers():
+            try:
+                self.extract(member, extract_root)
+            except Exception as e:
+                self.record_problem(member, str(e), "Ignored.")
+        self.fix_directories(extract_root)
+
+    def extract(self, tarinfo: tarfile.TarInfo, extract_root: Path):
+        if not tarinfo.name:
+            self.record_problem(
+                tarinfo,
+                "File with empty filename in tar archive.",
+                "Skipped.",
             )
             return
-        if not is_safe_path(path_as_path, member_name_path):
-            logger.warning("traversal attempt", path=member_name_path)
+
+        if len(tarinfo.name) > MAX_PATH_LEN:
+            self.record_problem(
+                tarinfo,
+                "File with filename too long in tar archive.",
+                "Skipped.",
+            )
             return
 
-        super().extract(member, path, set_attrs, numeric_owner=numeric_owner)
+        if not RUNNING_AS_ROOT and (tarinfo.ischr() or tarinfo.isblk()):
+            self.record_problem(
+                tarinfo,
+                "Missing elevated permissions for block and character device creation.",
+                "Skipped.",
+            )
+            return
+
+        # prevent traversal attempts through file name
+        if not is_safe_path(basedir=extract_root, path=extract_root / tarinfo.name):
+            self.record_problem(
+                tarinfo,
+                "Traversal attempt.",
+                "Skipped.",
+            )
+            return
+
+        target_path = extract_root / tarinfo.name
+        # directories are special: we can not set their metadata now + they might also be already existing
+        if tarinfo.isdir():
+            # save (potentially duplicate) dir metadata for applying at the end of the extraction
+            self.directories[tarinfo.name] = tarinfo
+            target_path.mkdir(parents=True, exist_ok=True)
+            return
+
+        self.tarfile.extract(tarinfo, extract_root)
+
+    def fix_directories(self, extract_root):
+        """Complete directory extraction.
+
+        When extracting directories, setting metadata was intentionally skipped,
+        so that entries under the directory can be extracted, even if the directory
+        is write protected.
+        """
+        # need to set the permissions from leafs to root
+        directories = sorted(
+            self.directories.values(), key=lambda d: d.name, reverse=True
+        )
+
+        # copied from tarfile.extractall(), it is somewhat ugly, as uses private helpers!
+        for tarinfo in directories:
+            dirpath = str(extract_root / tarinfo.name)
+            try:
+                self.tarfile.chown(tarinfo, dirpath, numeric_owner=True)
+                self.tarfile.utime(tarinfo, dirpath)
+                self.tarfile.chmod(tarinfo, dirpath)
+            except tarfile.ExtractError as e:
+                self.record_problem(tarinfo, str(e), "Ignored.")
+
+    def record_problem(self, tarinfo, problem, resolution):
+        logger.warning(f"{problem} {resolution}", path=tarinfo.name)  # noqa: G004
+        self.problems.append(ProblematicTarMember(tarinfo, problem, resolution))

--- a/unblob/handlers/archive/_safe_tarfile.py
+++ b/unblob/handlers/archive/_safe_tarfile.py
@@ -80,6 +80,14 @@ class SafeTarFile:
             target_path.mkdir(parents=True, exist_ok=True)
             return
 
+        if target_path.exists():
+            self.record_problem(
+                tarinfo,
+                "Duplicate tar entry.",
+                "Removed older version.",
+            )
+            target_path.unlink()
+
         self.tarfile.extract(tarinfo, extract_root)
 
     def fix_directories(self, extract_root):

--- a/unblob/handlers/archive/tar.py
+++ b/unblob/handlers/archive/tar.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import tarfile
 from pathlib import Path
@@ -85,13 +86,8 @@ def _find_end_of_padding(file, *, find_from: int) -> int:
 
 class TarExtractor(Extractor):
     def extract(self, inpath: Path, outdir: Path):
-        tf = SafeTarFile.open(inpath.as_posix())
-        try:
-            tf.extractall(outdir.as_posix())
-        except FileExistsError as file_exists_error:
-            logger.warning(
-                "FileExistsError during tar archive extraction", error=file_exists_error
-            )
+        with contextlib.closing(SafeTarFile(inpath)) as tarfile:
+            tarfile.extractall(outdir)
 
 
 class TarHandler(StructHandler):


### PR DESCRIPTION
Improvements:
- handle duplicated entries (with test data taken from #586)
- (path traversal) handle tar entries with absolute paths
- (path traversal) handle link targets with absolute paths

At the source level there was also a refactor to slightly better decouple the code from `tarfile.TarFile` implementation details.