### PR TITLE
chore(deps): upgrade sasquatch to 4.5.1-4.

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Install sasquatch
       run: |
-        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-3/sasquatch_1.0_amd64.deb
+        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_amd64.deb
         sudo dpkg -i sasquatch_1.0_amd64.deb
         rm -f sasquatch_1.0_amd64.deb
       shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     zlib1g-dev \
     libmagic1 \
     zstd
-RUN curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-3/sasquatch_1.0_amd64.deb \
+RUN curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_amd64.deb \
     && dpkg -i sasquatch_1.0_amd64.deb \
     && rm -f sasquatch_1.0_amd64.deb
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -118,6 +118,6 @@ The Nix derivation installs all 3rd party dependencies.
 
 2.  If you need **squashfs support**, install sasquatch:
 
-        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-3/sasquatch_1.0_amd64.deb
+        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_amd64.deb
         sudo dpkg -i sasquatch_1.0_amd64.deb
         rm sasquatch_1.0_amd64.deb

--- a/flake.lock
+++ b/flake.lock
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684752981,
-        "narHash": "sha256-1/n7PTFQ8olbSoujr/pXrKAMv4fzTGLsy3zUVljDDAw=",
+        "lastModified": 1686077968,
+        "narHash": "sha256-0itva+j5WMKvueiUaO253UQ1S6W29xgtFvV4i3yvMtU=",
         "owner": "onekey-sec",
         "repo": "sasquatch",
-        "rev": "5549710465e2d5ef8ed9e2c88c1140110f244326",
+        "rev": "8d7b1edef55c9e7d995fcdd3bd3f0db1b3fac83f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
We released a new version of sasquatch yesterday with the introduction of https://github.com/onekey-sec/sasquatch/pull/18

This PR upgrades the sasquatch version we pulled in Docker container, Nix, and our installation documentation.