### PR TITLE
fix(processing): remove PE32 from skip list

### DIFF
--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -57,7 +57,6 @@ DEFAULT_SKIP_MAGIC = (
     "PDF document",
     "magic binary file",
     "MS Windows icon resource",
-    "PE32",
     "Web Open Font Format",
     "GNU message catalog",
     "Xilinx BIT data",


### PR DESCRIPTION
Being able to extract updater executables to get the firmware out outweight the fact that sometimes PE32 can generate noisy output.

Initially introduced by cfa761f6f5b5a1a42335d34d4021b592b4179fdd