### PR TITLE
Fix docker build on debian bookworm

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -9,15 +9,8 @@ description: "Install all required dependencies for worflows to run."
 runs:
   using: "composite"
   steps:
-    - name: Install 3rd party from apt
-      run: sudo apt install e2fsprogs p7zip-full unar zlib1g-dev liblzo2-dev lz4 lzop lziprecover img2simg zstd
-      shell: bash
-
-    - name: Install sasquatch
-      run: |
-        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_amd64.deb
-        sudo dpkg -i sasquatch_1.0_amd64.deb
-        rm -f sasquatch_1.0_amd64.deb
+    - name: Install 3rd party dependencies
+      run: sudo unblob/install-deps.sh
       shell: bash
 
     - name: Setup Python

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,25 +6,8 @@ RUN chown -R unblob /data
 
 WORKDIR /data/output
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    curl \
-    e2fsprogs \
-    gcc \
-    git \
-    img2simg \
-    liblzo2-dev \
-    lz4 \
-    lziprecover \
-    lzop \
-    p7zip-full \
-    unar \
-    xz-utils \
-    zlib1g-dev \
-    libmagic1 \
-    zstd
-RUN curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_amd64.deb \
-    && dpkg -i sasquatch_1.0_amd64.deb \
-    && rm -f sasquatch_1.0_amd64.deb
+COPY unblob/install-deps.sh /
+RUN /install-deps.sh
 
 USER unblob
 ENV PATH="/home/unblob/.local/bin:${PATH}"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,7 +116,7 @@ There is a handy `install-deps.sh` script included in the repository and PyPI pa
 1.  With your operating system package manager:  
     On Ubuntu 22.04, install extractors with APT:
 
-        sudo apt install e2fsprogs p7zip-full unar zlib1g-dev liblzo2-dev lzop lziprecover img2simg libhyperscan-dev zstd
+        sudo apt install android-sdk-libsparse-utils e2fsprogs p7zip-full unar zlib1g-dev liblzo2-dev lzop lziprecover libhyperscan-dev zstd
 
 2.  If you need **squashfs support**, install sasquatch:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -111,6 +111,8 @@ The Nix derivation installs all 3rd party dependencies.
 
 ## Install extractors
 
+There is a handy `install-deps.sh` script included in the repository and PyPI packages that can be used to install the following dependencies.
+
 1.  With your operating system package manager:  
     On Ubuntu 22.04, install extractors with APT:
 

--- a/unblob/install-deps.sh
+++ b/unblob/install-deps.sh
@@ -3,11 +3,11 @@
 apt-get update
 
 apt-get install --no-install-recommends -y \
+    android-sdk-libsparse-utils \
     curl \
     e2fsprogs \
     gcc \
     git \
-    img2simg \
     liblzo2-dev \
     lz4 \
     lziprecover \

--- a/unblob/install-deps.sh
+++ b/unblob/install-deps.sh
@@ -6,15 +6,12 @@ apt-get install --no-install-recommends -y \
     android-sdk-libsparse-utils \
     curl \
     e2fsprogs \
-    gcc \
-    git \
     lz4 \
     lziprecover \
     lzop \
     p7zip-full \
     unar \
     xz-utils \
-    zlib1g-dev \
     libmagic1 \
     zstd
 

--- a/unblob/install-deps.sh
+++ b/unblob/install-deps.sh
@@ -1,0 +1,24 @@
+#/bin/sh -xeu
+
+apt-get update
+
+apt-get install --no-install-recommends -y \
+    curl \
+    e2fsprogs \
+    gcc \
+    git \
+    img2simg \
+    liblzo2-dev \
+    lz4 \
+    lziprecover \
+    lzop \
+    p7zip-full \
+    unar \
+    xz-utils \
+    zlib1g-dev \
+    libmagic1 \
+    zstd
+
+curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_amd64.deb
+dpkg -i sasquatch_1.0_amd64.deb
+rm -f sasquatch_1.0_amd64.deb

--- a/unblob/install-deps.sh
+++ b/unblob/install-deps.sh
@@ -8,7 +8,6 @@ apt-get install --no-install-recommends -y \
     e2fsprogs \
     gcc \
     git \
-    liblzo2-dev \
     lz4 \
     lziprecover \
     lzop \


### PR DESCRIPTION
`img2simg` is no longer available. Also extracted the dependency installer part of dockerfile so that it can be used in github actions and users.