### PR TITLE
chore(ci): fix intermittent build errors on macos

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git lfs
         uses: ./.github/actions/setup-git-lfs
-      - uses: cachix/install-nix-action@v19
+      - uses: cachix/install-nix-action@v22
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |

--- a/.github/workflows/update-nix.yml
+++ b/.github/workflows/update-nix.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v22
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |


### PR DESCRIPTION
The error message is complaning about:

> Could not set environment: 150: Operation not permitted while System Integrity Protection is engaged