### PR TITLE
fix(handler): handle integer too large situation in ELF handler

### DIFF
--- a/unblob/handlers/executable/elf.py
+++ b/unblob/handlers/executable/elf.py
@@ -29,6 +29,8 @@ KERNEL_MODULE_SIGNATURE_FOOTER = b"~Module signature appended~\n"
 
 KERNEL_INIT_DATA_SECTION = ".init.data"
 
+SSIZE_MAX = 2147483647
+
 
 @attr.define(repr=False)
 class ElfChunk(ValidChunk):
@@ -261,6 +263,9 @@ class _ELFBase(StructHandler):
         if not self.is_valid_header(header):
             return None
         end_offset = self.get_end_offset(file, start_offset, header, endian)
+
+        if end_offset > SSIZE_MAX:
+            return None
 
         # kernel modules are always relocatable
         if header.e_type == lief.ELF.E_TYPE.RELOCATABLE.value:


### PR DESCRIPTION
The following situation could arise when trying to compute the end offset of a malformedELF64 kernel module:

```
2022-11-24T15:43:38.766446267Z ESC[2m2022-11-24 15:43.38ESC[0m [ESC[31mESC[1merror    ESC[0m] ESC[1m2022-11-24 15:43.38 [error    ] Unhandled Exception during chunk calculation handler=elf64 pid=16 severit
y=<Severity.ERROR: 'ERROR'> start_offset=0xee61000
2022-11-24T15:43:38.766486208Z Traceback (most recent call last):
2022-11-24T15:43:38.766493091Z   File "/app/.venv/lib/python3.10/site-packages/unblob/finder.py", line 42, in _calculate_chunk
2022-11-24T15:43:38.766516567Z     return handler.calculate_chunk(file, real_offset)
2022-11-24T15:43:38.766522307Z   File "/app/.venv/lib/python3.10/site-packages/unblob/handlers/executable/elf.py", line 255, in calculate_chunk
2022-11-24T15:43:38.766526717Z     end_offset = self.get_signed_kernel_module_end_offset(file, end_offset)
2022-11-24T15:43:38.766531047Z   File "/app/.venv/lib/python3.10/site-packages/unblob/handlers/executable/elf.py", line 218, in get_signed_kernel_module_end_offset
2022-11-24T15:43:38.766535665Z     file.seek(end_offset, io.SEEK_SET)
2022-11-24T15:43:38.766540152Z   File "/app/.venv/lib/python3.10/site-packages/unblob/file_utils.py", line 37, in seek
2022-11-24T15:43:38.766545234Z     super().seek(pos, whence)
2022-11-24T15:43:38.766562177Z OverflowError: Python int too large to convert to C ssize_t
```

Fixed by adding a bound check.