### PR TITLE
Report extraction problems from handlers/extractors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 *.so
 .idea
 .coverage*
+/.venv/

--- a/docs/development.md
+++ b/docs/development.md
@@ -515,7 +515,7 @@ class Extractor(abc.ABC):
         return []
 
     @abc.abstractmethod
-    def extract(self, inpath: Path, outdir: Path):
+    def extract(self, inpath: Path, outdir: Path) -> Optional[ExtractResult]:
         """Extract the carved out chunk. Raises ExtractError on failure."""
 ```
 
@@ -538,7 +538,7 @@ class DirectoryExtractor(abc.ABC):
         return []
 
     @abc.abstractmethod
-    def extract(self, paths: List[Path], outdir: Path):
+    def extract(self, paths: List[Path], outdir: Path) -> Optional[ExtractResult]:
         """Extract from a multi file path list.
 
         Raises ExtractError on failure.

--- a/docs/development.md
+++ b/docs/development.md
@@ -526,6 +526,15 @@ Two methods are exposed by this class:
 - `extract()`: you must override this function. This is where you'll perform the
   extraction of `inpath` content into `outdir` extraction directory
 
+!!! Recommendation
+
+    Although it is possible to implement `extract()` with path manipulations,
+    checks for path traversals, and performing io by using Python libraries
+    (`os`, `pathlib.Path`), but it turns out somewhat tedious.
+    Instead we recommend to remove boilerplate and use a helper class `FileSystem` from
+    [unblob/file_utils.py](https://github.com/onekey-sec/unblob/blob/main/unblob/file_utils.py)
+    which ensures that all file objects are created under its root.
+
 ### DirectoryExtractor class
 
 The `DirectoryExtractor` interface is defined in
@@ -551,6 +560,11 @@ Two methods are exposed by this class:
   external dependencies such as command line tools
 - `extract()`: you must override this function. This is where you'll perform the
   extraction of `paths` files into `outdir` extraction directory
+
+!!! Recommendation
+
+    Similarly to `Extractor`, it is recommended to use the `FileSystem` helper class to
+    implement `extract`.
 
 ### Example Extractor
 

--- a/tests/handlers/filesystem/test_romfs.py
+++ b/tests/handlers/filesystem/test_romfs.py
@@ -1,9 +1,7 @@
-from pathlib import Path
-
 import pytest
 
 from unblob.file_utils import File
-from unblob.handlers.filesystem.romfs import get_string, is_safe_path, valid_checksum
+from unblob.handlers.filesystem.romfs import get_string, valid_checksum
 
 
 @pytest.mark.parametrize(
@@ -44,23 +42,3 @@ def test_get_string(content, expected):
 )
 def test_valid_checksum(content, valid):
     assert valid_checksum(content) == valid
-
-
-@pytest.mark.parametrize(
-    "basedir, path, expected",
-    [
-        ("/lib/out", "/lib/out/file", True),
-        ("/lib/out", "file", True),
-        ("/lib/out", "dir/file", True),
-        ("/lib/out", "some/dir/file", True),
-        ("/lib/out", "some/dir/../file", True),
-        ("/lib/out", "some/dir/../../file", True),
-        ("/lib/out", "some/dir/../../../file", False),
-        ("/lib/out", "some/dir/../../../", False),
-        ("/lib/out", "some/dir/../../..", False),
-        ("/lib/out", "../file", False),
-        ("/lib/out", "/lib/out/../file", False),
-    ],
-)
-def test_is_safe_path(basedir, path, expected):
-    assert is_safe_path(Path(basedir), Path(path)) is expected

--- a/tests/integration/filesystem/yaffs/__output__/malformed.2048.16.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/malformed.2048.16.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/malformed.2048.16.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/malformed.2048.16.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.128.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.128.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.128.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.128.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.128.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.128.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.16.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.16.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.16.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.16.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.16.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.16.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.256.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.256.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.256.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.256.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.256.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.256.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.32.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.32.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.32.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.32.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.32.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.32.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.512.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.512.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.512.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.512.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.512.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.512.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.64.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.64.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.64.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.64.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.16384.64.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.16384.64.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.128.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.128.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.128.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.128.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.128.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.128.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.16.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.16.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.16.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.16.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.16.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.16.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.256.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.256.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.256.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.256.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.256.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.256.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.32.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.32.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.32.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.32.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.32.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.32.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.512.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.512.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.512.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.512.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.512.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.512.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.64.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.64.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.64.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.64.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.2048.64.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.2048.64.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.128.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.128.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.128.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.128.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.128.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.128.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.16.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.16.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.16.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.16.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.16.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.16.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.256.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.256.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.256.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.256.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.256.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.256.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.32.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.32.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.32.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.32.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.32.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.32.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.512.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.512.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.512.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.512.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.512.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.512.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.64.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.64.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.64.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.64.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.4096.64.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.4096.64.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.128.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.128.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.128.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.128.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.128.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.128.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.16.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.16.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.16.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.16.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.16.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.16.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.256.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.256.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.256.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.256.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.256.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.256.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.32.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.32.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.32.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.32.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.32.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.32.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.512.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.512.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.512.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.512.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.512.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.512.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.64.ecc.be.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.64.ecc.be.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.64.ecc.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.64.ecc.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/integration/filesystem/yaffs/__output__/sample.8192.64.le.yaffs2_extract/passwd
+++ b/tests/integration/filesystem/yaffs/__output__/sample.8192.64.le.yaffs2_extract/passwd
@@ -1,0 +1,1 @@
+etc/passwd

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,4 +1,5 @@
 import io
+import os
 from pathlib import Path
 from typing import List
 
@@ -7,8 +8,10 @@ import pytest
 from unblob.file_utils import (
     Endian,
     File,
+    FileSystem,
     InvalidInputFormat,
     StructParser,
+    chop_root,
     convert_int8,
     convert_int16,
     convert_int32,
@@ -360,3 +363,198 @@ class TestGetEndian:
         with pytest.raises(InvalidInputFormat):
             get_endian(file, 0xFFFF_0000)
         assert file.tell() == pos
+
+
+@pytest.mark.parametrize(
+    "input_path, expected",
+    [
+        pytest.param("/", ".", id="absolute-root"),
+        pytest.param("/path/to/file", "path/to/file", id="absolute-path"),
+        pytest.param(".", ".", id="current-directory"),
+        pytest.param("path/to/file", "path/to/file", id="relative-path"),
+    ],
+)
+def test_chop_root(input_path: str, expected: str):
+    assert chop_root(Path(input_path)) == Path(expected)
+
+
+class TestFileSystem:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/etc/passwd",
+            "file",
+            "some/dir/file",
+            "some/dir/../file",
+            "some/dir/../../file",
+        ],
+    )
+    def test_get_checked_path_success(self, path):
+        fs = FileSystem(Path("/unblob/sandbox"))
+        checked_path = fs.get_checked_path(Path(path), "test")
+        assert checked_path
+        assert fs.problems == []
+        assert checked_path.relative_to(fs.root)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "../file",
+            "some/dir/../../../file",
+            "some/dir/../../../",
+            "some/dir/../../..",
+        ],
+    )
+    def test_get_checked_path_path_traversal_is_reported(self, path):
+        fs = FileSystem(Path("/unblob/sandbox"))
+        assert not fs.get_checked_path(Path(path), "test")
+        assert fs.problems
+
+    def test_get_checked_path_path_traversal_reports(self):
+        fs = FileSystem(Path("/unblob/sandbox"))
+        op1 = f"test1-{object()}"
+        op2 = f"test2-{object()}"
+        assert op1 != op2
+        assert not fs.get_checked_path(Path("../file"), op1)
+        assert not fs.get_checked_path(Path("../etc/passwd"), op2)
+
+        report1, report2 = fs.problems
+
+        assert "path traversal" in report1.problem
+        assert op1 in report1.problem
+        assert report1.path == "../file"
+
+        assert "path traversal" in report2.problem
+        assert op2 in report2.problem
+        assert report2.path == "../etc/passwd"
+
+    @pytest.fixture
+    def sandbox_parent(self, tmp_path: Path):
+        return tmp_path
+
+    @pytest.fixture
+    def sandbox_root(self, sandbox_parent: Path):
+        return sandbox_parent / "sandbox"
+
+    @pytest.fixture
+    def sandbox(self, sandbox_root: Path):
+        sandbox_root.mkdir(parents=True, exist_ok=True)
+        return FileSystem(sandbox_root)
+
+    def test_carve(self, sandbox: FileSystem):
+        file = File.from_bytes(b"0123456789")
+        sandbox.carve(Path("carved"), file, 1, 2)
+
+        assert (sandbox.root / "carved").read_bytes() == b"12"
+        assert sandbox.problems == []
+
+    def test_carve_outside_sandbox(self, sandbox: FileSystem):
+        file = File.from_bytes(b"0123456789")
+        sandbox.carve(Path("../carved"), file, 1, 2)
+
+        assert not (sandbox.root / "../carved").exists()
+        assert sandbox.problems
+
+    def test_mkdir(self, sandbox: FileSystem):
+        sandbox.mkdir(Path("directory"))
+
+        assert (sandbox.root / "directory").is_dir()
+        assert sandbox.problems == []
+
+    def test_mkdir_outside_sandbox(self, sandbox: FileSystem):
+        sandbox.mkdir(Path("../directory"))
+
+        assert not (sandbox.root / "../directory").exists()
+        assert sandbox.problems
+
+    def test_mkfifo(self, sandbox: FileSystem):
+        sandbox.mkfifo(Path("named_pipe"))
+
+        assert (sandbox.root / "named_pipe").is_fifo()
+        assert sandbox.problems == []
+
+    def test_mkfifo_outside_sandbox(self, sandbox: FileSystem):
+        sandbox.mkfifo(Path("../named_pipe"))
+
+        assert not (sandbox.root / "../named_pipe").exists()
+        assert sandbox.problems
+
+    def test_create_symlink(self, sandbox: FileSystem):
+        sandbox.create_symlink(Path("target file"), Path("symlink"))
+
+        output_path = sandbox.root / "symlink"
+        assert not output_path.exists()
+        assert os.readlink(output_path) == "target file"
+        assert sandbox.problems == []
+
+    def test_create_symlink_absolute_paths(self, sandbox: FileSystem):
+        sandbox.write_bytes(Path("target file"), b"test content")
+        sandbox.create_symlink(Path("/target file"), Path("/symlink"))
+
+        output_path = sandbox.root / "symlink"
+        assert output_path.exists()
+        assert os.readlink(output_path) == "target file"
+        assert sandbox.problems == []
+
+    def test_create_symlink_absolute_paths_self_referenced(self, sandbox: FileSystem):
+        sandbox.mkdir(Path("/etc"))
+        sandbox.create_symlink(Path("/etc/passwd"), Path("/etc/passwd"))
+
+        output_path = sandbox.root / "etc/passwd"
+        assert not output_path.exists()
+        assert os.readlink(output_path) == "../etc/passwd"
+        assert sandbox.problems == []
+
+    def test_create_symlink_outside_sandbox(self, sandbox: FileSystem):
+        sandbox.create_symlink(Path("target file"), Path("../symlink"))
+
+        output_path = sandbox.root / "../symlink"
+        assert not os.path.lexists(output_path)
+        assert sandbox.problems
+
+    def test_create_symlink_path_traversal(
+        self, sandbox: FileSystem, sandbox_parent: Path
+    ):
+        """Document a remaining path traversal scenario through a symlink chain.
+
+        unblob.extractor.fix_symlinks() exists to cover up cases like this.
+        """
+        (sandbox_parent / "outer-secret").write_text("private key")
+
+        # The path traversal is possible because at the creation of "secret" "future" does not exist
+        # so it is not yet possible to determine if it will be a symlink to be allowed or not.
+        # When the order of the below 2 lines are changed, the path traversal is recognized and prevented.
+        sandbox.create_symlink(Path("future/../outer-secret"), Path("secret"))
+        sandbox.create_symlink(Path("."), Path("future"))
+
+        assert sandbox.problems == []
+        assert (sandbox.root / "secret").read_text() == "private key"
+
+    def test_create_hardlink(self, sandbox: FileSystem):
+        output_path = sandbox.root / "hardlink"
+        linked_file = sandbox.root / "file"
+        linked_file.write_bytes(b"")
+        sandbox.create_hardlink(Path("file"), Path("hardlink"))
+
+        assert output_path.stat().st_nlink == 2
+        assert output_path.stat().st_ino == linked_file.stat().st_ino
+        assert sandbox.problems == []
+
+    def test_create_hardlink_absolute_paths(self, sandbox: FileSystem):
+        output_path = sandbox.root / "hardlink"
+        linked_file = sandbox.root / "file"
+        linked_file.write_bytes(b"")
+        sandbox.create_hardlink(Path("/file"), Path("/hardlink"))
+
+        assert output_path.stat().st_nlink == 2
+        assert output_path.stat().st_ino == linked_file.stat().st_ino
+        assert sandbox.problems == []
+
+    def test_create_hardlink_outside_sandbox(self, sandbox: FileSystem):
+        output_path = sandbox.root / "../hardlink"
+        linked_file = sandbox.root / "file"
+        linked_file.write_bytes(b"")
+        sandbox.create_hardlink(Path("file"), Path("../hardlink"))
+
+        assert not os.path.lexists(output_path)
+        assert sandbox.problems

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,4 +1,5 @@
 import io
+from pathlib import Path
 from typing import List
 
 import pytest
@@ -14,11 +15,32 @@ from unblob.file_utils import (
     convert_int64,
     decode_multibyte_integer,
     get_endian,
+    is_safe_path,
     iterate_file,
     iterate_patterns,
     round_down,
     round_up,
 )
+
+
+@pytest.mark.parametrize(
+    "basedir, path, expected",
+    [
+        ("/lib/out", "/lib/out/file", True),
+        ("/lib/out", "file", True),
+        ("/lib/out", "dir/file", True),
+        ("/lib/out", "some/dir/file", True),
+        ("/lib/out", "some/dir/../file", True),
+        ("/lib/out", "some/dir/../../file", True),
+        ("/lib/out", "some/dir/../../../file", False),
+        ("/lib/out", "some/dir/../../../", False),
+        ("/lib/out", "some/dir/../../..", False),
+        ("/lib/out", "../file", False),
+        ("/lib/out", "/lib/out/../file", False),
+    ],
+)
+def test_is_safe_path(basedir, path, expected):
+    assert is_safe_path(Path(basedir), Path(path)) is expected
 
 
 @pytest.mark.parametrize(

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -15,6 +15,14 @@ from .logging import format_hex
 DEFAULT_BUFSIZE = shutil.COPY_BUFSIZE  # type: ignore
 
 
+def is_safe_path(basedir: Path, path: Path) -> bool:
+    try:
+        basedir.joinpath(path).resolve().relative_to(basedir.resolve())
+    except ValueError:
+        return False
+    return True
+
+
 class SeekError(ValueError):
     """Specific ValueError for File.seek."""
 
@@ -250,6 +258,15 @@ def iterate_file(
             break
 
         yield data
+
+
+def carve(carve_path: Path, file: File, start_offset: int, size: int):
+    """Extract part of a file."""
+    carve_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with carve_path.open("xb") as f:
+        for data in iterate_file(file, start_offset, size):
+            f.write(data)
 
 
 def stream_scan(scanner, file: File):

--- a/unblob/handlers/archive/tar.py
+++ b/unblob/handlers/archive/tar.py
@@ -7,7 +7,14 @@ from typing import Optional
 from structlog import get_logger
 
 from ...file_utils import OffsetFile, SeekError, decode_int, round_up, snull
-from ...models import Extractor, File, HexString, StructHandler, ValidChunk
+from ...models import (
+    Extractor,
+    ExtractResult,
+    File,
+    HexString,
+    StructHandler,
+    ValidChunk,
+)
 from ._safe_tarfile import SafeTarFile
 
 logger = get_logger()
@@ -88,6 +95,7 @@ class TarExtractor(Extractor):
     def extract(self, inpath: Path, outdir: Path):
         with contextlib.closing(SafeTarFile(inpath)) as tarfile:
             tarfile.extractall(outdir)
+        return ExtractResult(reports=tarfile.reports)
 
 
 class TarHandler(StructHandler):

--- a/unblob/models.py
+++ b/unblob/models.py
@@ -130,7 +130,7 @@ class ValidChunk(Chunk):
 class UnknownChunk(Chunk):
     r"""Gaps between valid chunks or otherwise unknown chunks.
 
-    Important for manual analysis, and analytical certanity: for example
+    Important for manual analysis, and analytical certainty: for example
     entropy, other chunks inside it, metadata, etc.
 
     These are not extracted, just logged for information purposes and further analysis,

--- a/unblob/models.py
+++ b/unblob/models.py
@@ -103,7 +103,7 @@ class ValidChunk(Chunk):
     handler: "Handler" = attr.ib(init=False, eq=False)
     is_encrypted: bool = attr.ib(default=False)
 
-    def extract(self, inpath: Path, outdir: Path):
+    def extract(self, inpath: Path, outdir: Path) -> Optional["ExtractResult"]:
         if self.is_encrypted:
             logger.warning(
                 "Encrypted file is not extracted",
@@ -112,7 +112,7 @@ class ValidChunk(Chunk):
             )
             raise ExtractError
 
-        self.handler.extract(inpath, outdir)
+        return self.handler.extract(inpath, outdir)
 
     def as_report(self, extraction_reports: List[Report]) -> ChunkReport:
         return ChunkReport(
@@ -154,8 +154,8 @@ class MultiFile(Blob):
 
     handler: "DirectoryHandler" = attr.ib(init=False, eq=False)
 
-    def extract(self, outdir: Path):
-        self.handler.extract(self.paths, outdir)
+    def extract(self, outdir: Path) -> Optional["ExtractResult"]:
+        return self.handler.extract(self.paths, outdir)
 
     def as_report(self, extraction_reports: List[Report]) -> MultiFileReport:
         return MultiFileReport(
@@ -253,13 +253,18 @@ class ExtractError(Exception):
         self.reports: Tuple[Report, ...] = reports
 
 
+@attr.define(kw_only=True)
+class ExtractResult:
+    reports: List[Report]
+
+
 class Extractor(abc.ABC):
     def get_dependencies(self) -> List[str]:
         """Return the external command dependencies."""
         return []
 
     @abc.abstractmethod
-    def extract(self, inpath: Path, outdir: Path):
+    def extract(self, inpath: Path, outdir: Path) -> Optional[ExtractResult]:
         """Extract the carved out chunk.
 
         Raises ExtractError on failure.
@@ -272,7 +277,7 @@ class DirectoryExtractor(abc.ABC):
         return []
 
     @abc.abstractmethod
-    def extract(self, paths: List[Path], outdir: Path):
+    def extract(self, paths: List[Path], outdir: Path) -> Optional[ExtractResult]:
         """Extract from a multi file path list.
 
         Raises ExtractError on failure.
@@ -381,7 +386,7 @@ class DirectoryHandler(abc.ABC):
     def calculate_multifile(self, file: Path) -> Optional[MultiFile]:
         """Calculate the MultiFile in a directory, using a file matched by the pattern as a starting point."""
 
-    def extract(self, paths: List[Path], outdir: Path):
+    def extract(self, paths: List[Path], outdir: Path) -> Optional[ExtractResult]:
         if self.EXTRACTOR is None:
             logger.debug("Skipping file: no extractor.", paths=paths)
             raise ExtractError
@@ -389,7 +394,7 @@ class DirectoryHandler(abc.ABC):
         # We only extract every blob once, it's a mistake to extract the same blob again
         outdir.mkdir(parents=True, exist_ok=False)
 
-        self.EXTRACTOR.extract(paths, outdir)
+        return self.EXTRACTOR.extract(paths, outdir)
 
 
 class Handler(abc.ABC):
@@ -414,7 +419,7 @@ class Handler(abc.ABC):
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         """Calculate the Chunk offsets from the File and the file type headers."""
 
-    def extract(self, inpath: Path, outdir: Path):
+    def extract(self, inpath: Path, outdir: Path) -> Optional[ExtractResult]:
         if self.EXTRACTOR is None:
             logger.debug("Skipping file: no extractor.", path=inpath)
             raise ExtractError
@@ -422,7 +427,7 @@ class Handler(abc.ABC):
         # We only extract every blob once, it's a mistake to extract the same blob again
         outdir.mkdir(parents=True, exist_ok=False)
 
-        self.EXTRACTOR.extract(inpath, outdir)
+        return self.EXTRACTOR.extract(inpath, outdir)
 
 
 class StructHandler(Handler):

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -403,7 +403,8 @@ class _DirectoryTask:
 
         extraction_reports = []
         try:
-            multi_file.extract(extract_dir)
+            if result := multi_file.extract(extract_dir):
+                extraction_reports.extend(result.reports)
         except ExtractError as e:
             extraction_reports.extend(e.reports)
         except Exception as exc:
@@ -522,7 +523,7 @@ class _FileTask:
             return report
         return None
 
-    def _extract_chunk(self, file, chunk: ValidChunk):
+    def _extract_chunk(self, file, chunk: ValidChunk):  # noqa: C901
         skip_carving = chunk.is_whole_file
         if skip_carving:
             inpath = self.task.path
@@ -554,7 +555,8 @@ class _FileTask:
 
         extraction_reports = []
         try:
-            chunk.extract(inpath, extract_dir)
+            if result := chunk.extract(inpath, extract_dir):
+                extraction_reports.extend(result.reports)
 
             if carved_path and not self.config.keep_extracted_chunks:
                 logger.debug("Removing extracted chunk", path=carved_path)

--- a/unblob/report.py
+++ b/unblob/report.py
@@ -244,3 +244,23 @@ class MultiFileReport(Report):
     name: str
     paths: List[Path]
     extraction_reports: List[Report]
+
+
+@attr.define(kw_only=True, frozen=True)
+class ExtractionProblem(Report):
+    """A non-fatal problem discovered during extraction.
+
+    A report like this still means, that the extraction was successful,
+    but there were problems that got resolved.
+    The output is expected to be complete, with the exception of
+    the reported path.
+
+    Examples
+    --------
+    - duplicate entries for certain archive formats (tar, zip)
+    - unsafe symlinks pointing outside of extraction directory
+    """
+
+    problem: str
+    resolution: str
+    path: Optional[str] = None

--- a/unblob/report.py
+++ b/unblob/report.py
@@ -264,3 +264,27 @@ class ExtractionProblem(Report):
     problem: str
     resolution: str
     path: Optional[str] = None
+
+    @property
+    def log_msg(self):
+        return f"{self.problem} {self.resolution}"
+
+    def log_with(self, logger):
+        logger.warning(self.log_msg, path=self.path)
+
+
+@attr.define(kw_only=True, frozen=True)
+class LinkExtractionProblem(ExtractionProblem):
+    link_path: str
+
+    def log_with(self, logger):
+        logger.warning(self.log_msg, path=self.path, link_path=self.link_path)
+
+
+@attr.define(kw_only=True, frozen=True)
+class SpecialFileExtractionProblem(ExtractionProblem):
+    mode: int
+    device: int
+
+    def log_with(self, logger):
+        logger.warning(self.log_msg, path=self.path, mode=self.mode, device=self.device)


### PR DESCRIPTION
Main changes are:
- `Extractor.extract` can optionally return an `ExtractionResult` which has a `reports` attribute.
- introduction of `Sandbox`,  which prevents out of extraction directory file system object creation/reference and records any such attempts
- support of problem reporting for `tar`, `romfs`, `yaffs`, `ipkg`, `hdr`, with most of them converted to use `Sandbox`


