### PR TITLE
fix(extractor): improve post-extraction permission fixing.

### DIFF
--- a/unblob/extractor.py
+++ b/unblob/extractor.py
@@ -11,6 +11,9 @@ from .report import MaliciousSymlinkRemoved
 
 logger = get_logger()
 
+FILE_PERMISSION_MASK = 0o644
+DIR_PERMISSION_MASK = 0o775
+
 
 def carve_chunk_to_file(carve_path: Path, file: File, chunk: Chunk):
     """Extract valid chunk to a file, which we then pass to another tool to extract it."""
@@ -19,13 +22,20 @@ def carve_chunk_to_file(carve_path: Path, file: File, chunk: Chunk):
 
 
 def fix_permission(path: Path):
+    if not path.exists():
+        return
+
     if path.is_symlink():
         return
 
+    mode = path.stat().st_mode
+
     if path.is_file():
-        path.chmod(0o644)
+        mode |= FILE_PERMISSION_MASK
     elif path.is_dir():
-        path.chmod(0o775)
+        mode |= DIR_PERMISSION_MASK
+
+    path.chmod(mode)
 
 
 def is_recursive_link(path: Path) -> bool:


### PR DESCRIPTION
Previously, the `fix_permission` function was arbitrarily setting the permission 0o644 (`rw-r--r--`) to files and 0o755 (`rwxr-xr-x`) to directories. This was done to allow unblob to recurse into directories and read files within them in order to continue the extraction.

However, this pose a problem since unblob users may want to keep the original permissions, such as the executable flag.

We're now applying permission masks to the original permission so that we make sure unblob can work while keeping the permission attributes unblob users want to keep.

We also expanded coverage of fix_permission by covering all possible permissions permutations for files and directories.

Related to #645 