### PR TITLE
fix(handlers): fix extfs handler for samples with spaces in their names.

### DIFF
--- a/unblob/handlers/filesystem/extfs.py
+++ b/unblob/handlers/filesystem/extfs.py
@@ -64,7 +64,7 @@ class EXTHandler(StructHandler):
 
     PATTERN_MATCH_OFFSET = -MAGIC_OFFSET
 
-    EXTRACTOR = Command("debugfs", "-R", "rdump / {outdir}", "{inpath}")
+    EXTRACTOR = Command("debugfs", "-R", 'rdump / "{outdir}"', "{inpath}")
 
     def valid_header(self, header) -> bool:
         if header.s_state not in [0x1, 0x2]:


### PR DESCRIPTION
The Command extractor definition for our extfs handler was defined so that a sample with space in its name would make debugfs go haywire since the path was not properly quoted.

- `debugfs -R 'rdump / a_sample_with_no_space.ext4_extract' sample.ext4` -> works
- `debugfs -R 'rdump / a sample with space.ext4_extract' sample.ext4` -> does not work

Fixed by quoting the output dir :)