### PR TITLE
Added missing requirements for Ubuntu 22.04 LTS

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -128,7 +128,7 @@ There is a handy `install-deps.sh` script included in the repository and PyPI pa
 1.  With your operating system package manager:  
     On Ubuntu 22.04, install extractors with APT:
 
-        sudo apt install android-sdk-libsparse-utils e2fsprogs p7zip-full unar zlib1g-dev liblzo2-dev lzop lziprecover libhyperscan-dev zstd
+        sudo apt install android-sdk-libsparse-utils e2fsprogs p7zip-full unar zlib1g-dev liblzo2-dev lzop lziprecover libhyperscan-dev zstd lz4
 
 2.  If you need **squashfs support**, install sasquatch:
 


### PR DESCRIPTION
I've installed unblob on my new machine and figure out that some dependencies are not already installed when i try to use unblob to open some firmwares. 
so i just added lz4 to the requirements 

after install unblob:
```bash
oru@oru:~$ unblob --show-external-dependencies
The following executables found installed, which are needed by unblob:
    7z                          ✓
    debugfs                     ✓
    jefferson                   ✓
    lz4                         ✗
    lziprecover                 ✓
    lzop                        ✓
    sasquatch                   ✓
    sasquatch-v4be              ✓
    simg2img                    ✓
    ubireader_extract_files     ✓
    ubireader_extract_images    ✓
    unar                        ✓
    zstd                        ✓
```
after adding `lz4` to the requirements:

```bash
oru@oru:~$ sudo apt install -y lz4 > /dev/null

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

oru@oru:~$ unblob --show-external-dependencies
The following executables found installed, which are needed by unblob:
    7z                          ✓
    debugfs                     ✓
    jefferson                   ✓
    lz4                         ✓
    lziprecover                 ✓
    lzop                        ✓
    sasquatch                   ✓
    sasquatch-v4be              ✓
    simg2img                    ✓
    ubireader_extract_files     ✓
    ubireader_extract_images    ✓
    unar                        ✓
    zstd                        ✓
oru@oru:~$
```

 


