### PR TITLE
fix(cpio): fixed checksum calculation to handle 4 byte overflows

### DIFF
--- a/unblob/handlers/archive/cpio.py
+++ b/unblob/handlers/archive/cpio.py
@@ -368,8 +368,7 @@ class PortableASCIIWithCRCParser(PortableASCIIParser):
 
         for chunk in iterate_file(self.file, start_offset, file_size):
             calculated_checksum += sum(bytearray(chunk))
-
-        return header_checksum == calculated_checksum
+        return header_checksum == calculated_checksum & 0xFF_FF_FF_FF
 
 
 class _CPIOExtractorBase(Extractor):


### PR DESCRIPTION
Checksum stored in the header is always 4 bytes in length, so when we calculate the checksum, we need to sure that we only consider the 4bytes part and ommit the overflown part.