### PR TITLE
move e2fsprogs dependency to onekey maintained fork.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -140,3 +140,13 @@ There is a handy `install-deps.sh` script included in the repository and PyPI pa
        curl -L -o sasquatch_1.0_arm64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_arm64.deb
        sudo dpkg -i sasquatch_1.0_arm64.deb
        rm sasquatch_1.0_arm64.deb
+
+4. We maintain a fork of e2fsprogs based on Debian upstream, with some security fixes. You can install it this way:
+
+        curl -L -o libext2fs2_1.47.0-3.ok1_amd64.deb https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/libext2fs2_1.47.0-3.ok1_amd64.deb
+        dpkg -i libext2fs2_1.47.0-3.ok1_amd64.deb
+        rm -f libext2fs2_1.47.0-3.ok1_amd64.deb
+
+        curl -L -o e2fsprogs_1.47.0-3.ok1_amd64.deb https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/e2fsprogs_1.47.0-3.ok1_amd64.deb
+        dpkg -i e2fsprogs_1.47.0-3.ok1_amd64.deb
+        rm -f e2fsprogs_1.47.0-3.ok1_amd64.deb

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -132,21 +132,16 @@ There is a handy `install-deps.sh` script included in the repository and PyPI pa
 
 2.  If you need **squashfs support**, install sasquatch:
 
-        curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_amd64.deb
-        sudo dpkg -i sasquatch_1.0_amd64.deb
-        rm sasquatch_1.0_amd64.deb
-3. If you need **squashfs(arm64) support**, install sasquatch(arm64):
-
-       curl -L -o sasquatch_1.0_arm64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_arm64.deb
-       sudo dpkg -i sasquatch_1.0_arm64.deb
-       rm sasquatch_1.0_arm64.deb
+        curl -L -o sasquatch_1.0.deb "https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_$(dpkg --print-architecture).deb"
+        sudo dpkg -i sasquatch_1.0.deb
+        rm sasquatch_1.0.deb
 
 4. We maintain a fork of e2fsprogs based on Debian upstream, with some security fixes. You can install it this way:
 
-        curl -L -o libext2fs2_1.47.0-3.ok1_amd64.deb https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/libext2fs2_1.47.0-3.ok1_amd64.deb
-        dpkg -i libext2fs2_1.47.0-3.ok1_amd64.deb
-        rm -f libext2fs2_1.47.0-3.ok1_amd64.deb
+        curl -L -o libext2fs2_1.47.0-3.ok1.deb "https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/libext2fs2_1.47.0-3.ok1_$(dpkg --print-architecture).deb"
+        dpkg -i libext2fs2_1.47.0-3.ok1.deb
+        rm -f libext2fs2_1.47.0-3.ok1.deb
 
-        curl -L -o e2fsprogs_1.47.0-3.ok1_amd64.deb https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/e2fsprogs_1.47.0-3.ok1_amd64.deb
-        dpkg -i e2fsprogs_1.47.0-3.ok1_amd64.deb
-        rm -f e2fsprogs_1.47.0-3.ok1_amd64.deb
+        curl -L -o e2fsprogs_1.47.0-3.ok1.deb "https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/e2fsprogs_1.47.0-3.ok1_$(dpkg --print-architecture).deb"
+        dpkg -i e2fsprogs_1.47.0-3.ok1.deb
+        rm -f e2fsprogs_1.47.0-3.ok1.deb

--- a/overlay.nix
+++ b/overlay.nix
@@ -9,6 +9,12 @@ inputs: final: prev:
     (super: {
       pname = "e2fsprogs-nofortify";
       hardeningDisable = (super.hardeningDisable or [ ]) ++ [ "fortify3" ];
+
+      version = "1.47.0-3.ok1";
+      src = prev.fetchurl {
+        url = "https://github.com/onekey-sec/e2fsprogs/archive/refs/tags/v1.47.0-3.ok1.tar.gz";
+        hash = "sha256-fsLUySjAdgnRp5m405a4Egso+LXNLxR9Y7WHt8qAvFM=";
+      };
     });
 
   # Own package updated independently of nixpkgs

--- a/unblob/install-deps.sh
+++ b/unblob/install-deps.sh
@@ -18,3 +18,11 @@ apt-get install --no-install-recommends -y \
 curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_amd64.deb
 dpkg -i sasquatch_1.0_amd64.deb
 rm -f sasquatch_1.0_amd64.deb
+
+curl -L -o libext2fs2_1.47.0-3.ok1_amd64.deb https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/libext2fs2_1.47.0-3.ok1_amd64.deb
+dpkg -i libext2fs2_1.47.0-3.ok1_amd64.deb
+rm -f libext2fs2_1.47.0-3.ok1_amd64.deb
+
+curl -L -o e2fsprogs_1.47.0-3.ok1_amd64.deb https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/e2fsprogs_1.47.0-3.ok1_amd64.deb
+dpkg -i e2fsprogs_1.47.0-3.ok1_amd64.deb
+rm -f e2fsprogs_1.47.0-3.ok1_amd64.deb

--- a/unblob/install-deps.sh
+++ b/unblob/install-deps.sh
@@ -15,14 +15,14 @@ apt-get install --no-install-recommends -y \
     libmagic1 \
     zstd
 
-curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_amd64.deb
-dpkg -i sasquatch_1.0_amd64.deb
-rm -f sasquatch_1.0_amd64.deb
+curl -L -o sasquatch_1.0.deb "https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_$(dpkg --print-architecture).deb"
+dpkg -i sasquatch_1.0.deb
+rm -f sasquatch_1.0.deb
 
-curl -L -o libext2fs2_1.47.0-3.ok1_amd64.deb https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/libext2fs2_1.47.0-3.ok1_amd64.deb
-dpkg -i libext2fs2_1.47.0-3.ok1_amd64.deb
-rm -f libext2fs2_1.47.0-3.ok1_amd64.deb
+curl -L -o libext2fs2_1.47.0-3.ok1.deb "https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/libext2fs2_1.47.0-3.ok1_$(dpkg --print-architecture).deb"
+dpkg -i libext2fs2_1.47.0-3.ok1.deb
+rm -f libext2fs2_1.47.0-3.ok1.deb
 
-curl -L -o e2fsprogs_1.47.0-3.ok1_amd64.deb https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/e2fsprogs_1.47.0-3.ok1_amd64.deb
-dpkg -i e2fsprogs_1.47.0-3.ok1_amd64.deb
-rm -f e2fsprogs_1.47.0-3.ok1_amd64.deb
+curl -L -o e2fsprogs_1.47.0-3.ok1.deb "https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/e2fsprogs_1.47.0-3.ok1_$(dpkg --print-architecture).deb"
+dpkg -i e2fsprogs_1.47.0-3.ok1.deb
+rm -f e2fsprogs_1.47.0-3.ok1.deb


### PR DESCRIPTION
Move from default e2fsprogs to our maintained fork at https://github.com/onekey-sec/e2fsprogs/.

Latest release is https://github.com/onekey-sec/e2fsprogs/releases/tag/v1.47.0

Adjusted nix build, dependencies install script, and documentation.