### PR TITLE
processing: extract progress reporting from business logic

### DIFF
--- a/unblob/cli.py
+++ b/unblob/cli.py
@@ -26,6 +26,7 @@ from .processing import (
     ExtractionConfig,
     process_file,
 )
+from .ui import NullProgressReporter, RichConsoleProgressReporter
 
 logger = get_logger()
 
@@ -258,6 +259,9 @@ def cli(
         dir_handlers=dir_handlers,
         keep_extracted_chunks=keep_extracted_chunks,
         verbose=verbose,
+        progress_reporter=NullProgressReporter
+        if verbose
+        else RichConsoleProgressReporter,
     )
 
     logger.info("Start processing file", file=file)

--- a/unblob/ui.py
+++ b/unblob/ui.py
@@ -1,0 +1,57 @@
+from typing import Protocol
+
+from rich import progress
+from rich.style import Style
+
+from .models import TaskResult
+
+
+class ProgressReporter(Protocol):
+    def __enter__(self):
+        ...
+
+    def __exit__(self, _exc_type, _exc_value, _tb):
+        ...
+
+    def update(self, result: TaskResult):
+        ...
+
+
+class NullProgressReporter:
+    def __enter__(self):
+        pass
+
+    def __exit__(self, _exc_type, _exc_value, _tb):
+        pass
+
+    def update(self, result: TaskResult):
+        pass
+
+
+class RichConsoleProgressReporter:
+    def __init__(self):
+        self._progress = progress.Progress(
+            progress.TextColumn(
+                "Extraction progress: {task.percentage:>3.0f}%",
+                style=Style(color="#00FFC8"),
+            ),
+            progress.BarColumn(
+                complete_style=Style(color="#00FFC8"), style=Style(color="#002060")
+            ),
+        )
+        self._overall_progress_task = self._progress.add_task("Extraction progress:")
+
+    def __enter__(self):
+        self._progress.start()
+
+    def __exit__(self, _exc_type, _exc_value, _tb):
+        self._progress.remove_task(self._overall_progress_task)
+        self._progress.stop()
+
+    def update(self, result: TaskResult):
+        if (total := self._progress.tasks[0].total) is not None:
+            self._progress.update(
+                self._overall_progress_task,
+                advance=1,
+                total=total + len(result.subtasks),
+            )


### PR DESCRIPTION
While trying to update pyright, it started complaining about potentially unbound variables[^1]. These are not actual correctness issues, but signals some code smell due to conditionally configured variables.

The progress bar handling got extracted from `_process_task`, and got converted to a context manager, so its lifetime management became simpler. To eliminate if conditions sprinkled everywhere, a `NullProgressDisplay` is also added for the case where we want to do nothing.

[^1]:

    ```
    /home/vlaci/devel/git/github.com/onekey-sec/unblob/unblob/processing.py
      /home/vlaci/devel/git/github.com/onekey-sec/unblob/unblob/processing.py:163:36 - error: "progress_display" is possibly unbound (reportUnboundVariable)
      /home/vlaci/devel/git/github.com/onekey-sec/unblob/unblob/processing.py:164:13 - error: "progress_display" is possibly unbound (reportUnboundVariable)
      /home/vlaci/devel/git/github.com/onekey-sec/unblob/unblob/processing.py:165:17 - error: "overall_progress_task" is possibly unbound (reportUnboundVariable)
      /home/vlaci/devel/git/github.com/onekey-sec/unblob/unblob/processing.py:167:23 - error: "progress_display" is possibly unbound (reportUnboundVariable)
      /home/vlaci/devel/git/github.com/onekey-sec/unblob/unblob/processing.py:184:9 - error: "progress_display" is possibly unbound (reportUnboundVariable)
      /home/vlaci/devel/git/github.com/onekey-sec/unblob/unblob/processing.py:184:38 - error: "overall_progress_task" is possibly unbound (reportUnboundVariable)
      /home/vlaci/devel/git/github.com/onekey-sec/unblob/unblob/processing.py:185:9 - error: "progress_display" is possibly unbound (reportUnboundVariable)
    7 errors, 0 warnings, 0 informations
    ```