### PR TITLE
add intel flashrom to magic skip list

### DIFF
--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -75,6 +75,7 @@ DEFAULT_SKIP_MAGIC = (
     "python",  # (e.g. python 2.7 byte-compiled)
     "Composite Document File V2 Document",
     "Windows Embedded CE binary image",
+    "Intel serial flash for PCH ROM",
 )
 
 


### PR DESCRIPTION
Add `Intel serial flash for PCH ROM` to the magic skip list as there is nothing meaningful to extract from it 