### PR TITLE
add docker container scanning with grype.

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -61,6 +61,20 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
+      - name: Docker container vulnerability scan
+        id: scan
+        uses: anchore/scan-action@v3
+        with:
+          image: ${{ env.DOCKER_IMAGE }}
+          fail-build: true
+          severity-cutoff: critical
+          only-fixed: true
+
+      - name: Upload SARIF report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+
       - name: Check unblob - help
         run: docker run --rm ${{ env.DOCKER_IMAGE }}:latest --help
 


### PR DESCRIPTION
Resolve #409 by introducing docker image scan with Grype using dedicated [Github Action](https://github.com/marketplace/actions/anchore-container-scan).

The build only fails if it finds high or critical severity issues with a fix available. All identified issues are reported using SARIF to Github Code Scanning so maintainers have visibility and can decide whether something needs to be fixed (similar to what's already happening with Dependabot).