### PR TITLE
chore(doc): fix documentation inconsistencies and missing dependencies

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -95,7 +95,7 @@ dependencies. To install all required dependencies for development, you can run
 the following command:
 
 ```
-poetry install --with dev
+poetry install --with dev --all-extras
 ```
 
 Please note that it installs dependencies within the dedicated virtual

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -139,9 +139,9 @@ There is a handy `install-deps.sh` script included in the repository and PyPI pa
 4. We maintain a fork of e2fsprogs based on Debian upstream, with some security fixes. You can install it this way:
 
         curl -L -o libext2fs2_1.47.0-3.ok1.deb "https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/libext2fs2_1.47.0-3.ok1_$(dpkg --print-architecture).deb"
-        dpkg -i libext2fs2_1.47.0-3.ok1.deb
+        sudo dpkg -i libext2fs2_1.47.0-3.ok1.deb
         rm -f libext2fs2_1.47.0-3.ok1.deb
 
         curl -L -o e2fsprogs_1.47.0-3.ok1.deb "https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/e2fsprogs_1.47.0-3.ok1_$(dpkg --print-architecture).deb"
-        dpkg -i e2fsprogs_1.47.0-3.ok1.deb
+        sudo dpkg -i e2fsprogs_1.47.0-3.ok1.deb
         rm -f e2fsprogs_1.47.0-3.ok1.deb

--- a/unblob/install-deps.sh
+++ b/unblob/install-deps.sh
@@ -15,13 +15,13 @@ apt-get install --no-install-recommends -y \
     zstd
 
 curl -L -o sasquatch_1.0.deb "https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-4/sasquatch_1.0_$(dpkg --print-architecture).deb"
-dpkg -i sasquatch_1.0.deb
+sudo dpkg -i sasquatch_1.0.deb
 rm -f sasquatch_1.0.deb
 
 curl -L -o libext2fs2_1.47.0-3.ok1.deb "https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/libext2fs2_1.47.0-3.ok1_$(dpkg --print-architecture).deb"
-dpkg -i libext2fs2_1.47.0-3.ok1.deb
+sudo dpkg -i libext2fs2_1.47.0-3.ok1.deb
 rm -f libext2fs2_1.47.0-3.ok1.deb
 
 curl -L -o e2fsprogs_1.47.0-3.ok1.deb "https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok1/e2fsprogs_1.47.0-3.ok1_$(dpkg --print-architecture).deb"
-dpkg -i e2fsprogs_1.47.0-3.ok1.deb
+sudo dpkg -i e2fsprogs_1.47.0-3.ok1.deb
 rm -f e2fsprogs_1.47.0-3.ok1.deb


### PR DESCRIPTION
`sudo` was missing for both `dpkg` commands and I also added the option `--all-extras` in the development guide for `poetry install`