### PR TITLE
CI: do not build and publish Docker images on PRs from dependabot.

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - '**'
 
 env:
   DOCKER_IMAGE: ghcr.io/onekey-sec/unblob


### PR DESCRIPTION
Dependabot does not possess the required privileges to push to our Docker registry, so there's no point building and pushing the image at that point.