### PR TITLE
fix(ci): tag Docker image as latest if built from default branch.

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -56,6 +56,9 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
           outputs: type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Docker container vulnerability scan


### PR DESCRIPTION
Github action will only tag the build as 'latest' if your default branch is named `master`. Needs to be set explicitly is you're running from `main` like us.

For more information see https://github.com/docker/metadata-action#latest-tag