### PR TITLE
fix(handler): increase tar handler debug log verbosity level.

### DIFF
--- a/unblob/handlers/archive/tar.py
+++ b/unblob/handlers/archive/tar.py
@@ -143,6 +143,7 @@ class _TarHandler(StructHandler):
                 "Invalid checksum format",
                 actual_last_2_bytes=header.chksum[6:8],
                 handler=self.NAME,
+                verbosity=3,
             )
             return None
         checksum = decode_int(header.chksum[:6], 8)


### PR DESCRIPTION
Follow-up to 5b9afc1

I only want to see it when `-vvv`.