### PR TITLE
fix(ci): docker image tags fail if comment is present.

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -57,7 +57,6 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: |
-            # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
           outputs: type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 


### PR DESCRIPTION
Got the following error with this config:

```
ERROR: invalid tag "# set latest tag for default branch": invalid reference format
```

Will trigger the job manually to make sure it works.