### PR TITLE
fix(ci): use unique artifacts names

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: ${{ matrix.platform }}-digests
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
Not specifying a unique name for the artifact file would lead to the following error:

> Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

Fixed by specifying an artifact name that depends on the platform its been built for.