### PR TITLE
Fix #724. build: Add darwin aarch64 to supported architectures

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
   outputs = { self, nixpkgs, filter, unblob-native, lzallright, pyperscan, sasquatch, ... }:
     let
       # System types to support.
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;

--- a/overlay.nix
+++ b/overlay.nix
@@ -12,6 +12,15 @@ final: prev:
       nativeCheckInputs = (super.nativeCheckInputs or [ ]) ++ [ final.which ];
     });
 
+  simg2img = prev.simg2img.overrideAttrs (super: {
+    postPatch = ''
+      substituteInPlace output_file.cpp \
+        --replace-fail \
+        'aligned_offset = offset & ~(4096 - 1);' \
+        'aligned_offset = offset & ~(sysconf(_SC_PAGESIZE) - 1);'
+    '';
+  });
+
   # Own package updated independently of nixpkgs
   jefferson = final.callPackage ./nix/jefferson { };
 


### PR DESCRIPTION
It seems like #741 only added M1 to the CI build but Nix still claimed the architecture as unsupported (cf. #724). This adds macOS on ARM to the Nix supported architectures (confirmed locally).
