### PR TITLE
fix(models): adapt chunk's contains() definition.

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,30 +18,47 @@ class TestChunk:
     @pytest.mark.parametrize(
         "chunk1, chunk2, result",
         [
-            (
+            pytest.param(
                 Chunk(start_offset=0, end_offset=10),
                 Chunk(start_offset=1, end_offset=2),
                 True,
+                id="starts-after-ends-before",
             ),
-            (
+            pytest.param(
                 Chunk(start_offset=0, end_offset=10),
                 Chunk(start_offset=11, end_offset=12),
                 False,
+                id="starts-after-ends-after",
             ),
-            (
+            pytest.param(
                 Chunk(start_offset=0, end_offset=10),
                 Chunk(start_offset=15, end_offset=20),
                 False,
+                id="starts-after-ends-after",
             ),
-            (
+            pytest.param(
                 Chunk(start_offset=1, end_offset=2),
                 Chunk(start_offset=3, end_offset=5),
                 False,
+                id="starts-after-ends-after",
             ),
-            (
+            pytest.param(
                 Chunk(start_offset=0, end_offset=10),
                 Chunk(start_offset=1, end_offset=10),
                 True,
+                id="starts-after-ends-same",
+            ),
+            pytest.param(
+                Chunk(start_offset=0, end_offset=10),
+                Chunk(start_offset=0, end_offset=9),
+                True,
+                id="starts-same-ends-before",
+            ),
+            pytest.param(
+                Chunk(start_offset=0, end_offset=10),
+                Chunk(start_offset=0, end_offset=10),
+                False,
+                id="starts-same-ends-same",
             ),
         ],
     )

--- a/unblob/models.py
+++ b/unblob/models.py
@@ -87,6 +87,9 @@ class Chunk(Blob):
         return (
             self.start_offset < other.start_offset
             and self.end_offset >= other.end_offset
+        ) or (
+            self.start_offset <= other.start_offset
+            and self.end_offset > other.end_offset
         )
 
     def contains_offset(self, offset: int) -> bool:


### PR DESCRIPTION
We were considering that a chunk A contains a chunk B if chunk B start after chunk A and ends before or on the same offset than chunk A.

This caused issues with compressed DMG images where two handlers would rightfully identify two chunks:
- a bzip chunk starting at offset 0 and ending before the DMG plist
- a DMG chunk starting at offset 0 and ending after the DMG footer

We therefore adapted our definition of contains() where a contained chunk can start at the same offset but ends before, or start after the containing chunk but can end on the same offset.

Resolve #753 