### PR TITLE
fix(fs): duplicate entries handling in FileSystem API.

### DIFF
--- a/tests/integration/archive/cpio/cpio_binary/__input__/duplicate_entries.cpio
+++ b/tests/integration/archive/cpio/cpio_binary/__input__/duplicate_entries.cpio
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fab950a545cff6286c14c8736f532a1204c217de2e1a32f66e83655c7196a7ab
+size 1024

--- a/tests/integration/archive/cpio/cpio_binary/__output__/duplicate_entries.cpio_extract/colors/blue
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/duplicate_entries.cpio_extract/colors/blue
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0bee6616b5e5eae6799cb4525a884a82e7161614f11122bbdf4383b2ac05998
+size 5

--- a/tests/integration/archive/cpio/cpio_binary/__output__/duplicate_entries.cpio_extract/colors/blue.txt
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/duplicate_entries.cpio_extract/colors/blue.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b946a10c9133c481c9c95234cb8d61a5c063388721f22021ff30363e1bfaa3b0
+size 13

--- a/tests/integration/archive/cpio/cpio_binary/__output__/duplicate_entries.cpio_extract/colors/orange.txt
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/duplicate_entries.cpio_extract/colors/orange.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6afd32ccf0462f3660d9fe54596a8c519d9478619c9798bc56bec0ba3ac1a7a3
+size 15

--- a/tests/integration/archive/cpio/cpio_binary/__output__/duplicate_entries.cpio_extract/colors/purple
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/duplicate_entries.cpio_extract/colors/purple
@@ -1,0 +1,1 @@
+purple.txt

--- a/tests/integration/archive/cpio/cpio_binary/__output__/duplicate_entries.cpio_extract/colors/purple.txt
+++ b/tests/integration/archive/cpio/cpio_binary/__output__/duplicate_entries.cpio_extract/colors/purple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:596157e5858a0c647af6a4f55945b9c09ed70dc3f5d0e3db248ea5d5136e8ad3
+size 7

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -628,7 +628,7 @@ class FileSystem:
 
     def unlink(self, path):
         """Delete file within extraction path."""
-        logger.debug("unlink file", file_path=path)
+        logger.debug("unlink file", file_path=path, _verbosity=3)
         safe_path = self._get_extraction_path(path, "unlink")
 
         safe_path.unlink(missing_ok=True)

--- a/unblob/handlers/archive/cpio.py
+++ b/unblob/handlers/archive/cpio.py
@@ -210,6 +210,11 @@ class CPIOParserBase:
             if entry.path.name in ("", "."):
                 continue
 
+            # There are cases where CPIO archives have duplicated entries
+            # We then unlink the files to overwrite them and avoid an error.
+            if not stat.S_ISDIR(entry.mode):
+                fs.unlink(entry.path)
+
             if stat.S_ISREG(entry.mode):
                 fs.carve(entry.path, self.file, entry.start_offset, entry.size)
             elif stat.S_ISDIR(entry.mode):


### PR DESCRIPTION
Early draft to take care of archives and filesystems holding duplicate entries.

We need to decide on a strategy when that happens:
- overwrite the previous entry with the new one ? (overwrite)
- do not overwrite the previous entry with the new one ? (skip)
- write the file with a new suffix (e.g. `.1` à la wget) ? (rewrite)

Do we want to compare hashes before creating a renamed entry or not ?

What happens if we have triplicate or quadruplicate entries ?


Resolve #754