### PR TITLE
Improve support for safe symlink extraction

### DIFF
--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -423,7 +423,7 @@ class _FSPath:
 
 class _FSLink:
     def __init__(self, *, root: Path, src: Path, dst: Path) -> None:
-        self.dst = _FSPath(root=root, path=dst)
+        self.dst = _FSPath(root=root, path=root / src.parent / dst)
         self.src = _FSPath(root=root, path=src)
         self.is_safe = self.dst.is_safe and self.src.is_safe
 

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -574,12 +574,20 @@ class FileSystem:
             # but they are relocatable
             src = self._path_to_root(dst.parent) / chop_root(src)
 
-        safe_link = self._get_checked_link(src=dst.parent / src, dst=dst)
+        safe_link = self._get_checked_link(src=src, dst=dst)
 
         if safe_link:
-            dst = safe_link.dst.absolute_path
-            self._ensure_parent_dir(dst)
-            dst.symlink_to(src)
+            src = safe_link.src.absolute_path
+            self._ensure_parent_dir(src)
+            logger.debug(f"Creating symlink {src} -> {dst}")
+
+            # Create symlink at src pointing to dst
+            src.symlink_to(dst)
+
+            if not src.is_symlink():
+                self.record_problem(
+                    safe_link.format_report("Symlink creation failed.")
+                )
 
     def create_hardlink(self, src: Path, dst: Path):
         """Create a new hardlink dst to the existing file src."""

--- a/unblob/handlers/archive/_safe_tarfile.py
+++ b/unblob/handlers/archive/_safe_tarfile.py
@@ -82,7 +82,7 @@ class SafeTarFile:
                     "Absolute path as link target.",
                     "Converted to extraction relative path.",
                 )
-                tarinfo.linkname = f"./{tarinfo.linkname}"
+                tarinfo.linkname = f"{extract_root}/{tarinfo.linkname}"
 
             if not is_safe_path(
                 basedir=extract_root,

--- a/unblob/handlers/archive/_safe_tarfile.py
+++ b/unblob/handlers/archive/_safe_tarfile.py
@@ -83,9 +83,10 @@ class SafeTarFile:
                     "Converted to extraction relative path.",
                 )
                 tarinfo.linkname = f"./{tarinfo.linkname}"
+
             if not is_safe_path(
                 basedir=extract_root,
-                path=extract_root / tarinfo.linkname,
+                path=extract_root / Path(tarinfo.name).parent / tarinfo.linkname,
             ):
                 self.record_problem(
                     tarinfo,

--- a/unblob/handlers/archive/cpio.py
+++ b/unblob/handlers/archive/cpio.py
@@ -222,7 +222,7 @@ class CPIOParserBase:
                         self.file[entry.start_offset : entry.start_offset + entry.size]
                     ).decode("utf-8")
                 )
-                fs.create_symlink(src=link_path, dst=entry.path)
+                fs.create_symlink(src=entry.path, dst=link_path)
             elif (
                 stat.S_ISCHR(entry.mode)
                 or stat.S_ISBLK(entry.mode)


### PR DESCRIPTION
This PR aims to fix a few issues around symlink extraction discussed in #761. I don't think this PR is perfect, but I hope it's an improvement over the current state of things.

Now in #768 ~~954c1cd5a06bcdb52048fc23da44661c73c94f31 rewrites the logic to sanitize symlinks to be relative and kept within the extraction directory. This is done using the `os` module instead of `Pathlib` as Pathlib.resolve would fail if a symlink target was missing (which doesn't prevent us from safely converting it to a relative link). With this change I no longer see false positives around MaliciousSymlinks, instead symlinks are created safely within the extraction directory. If a relative symlink originally tried accessing a directory above its own root (i.e., `./bin/sh -> ../../../../../bin/bash`), we update the link so it remains within the extraction directory.~~

This may have just been an artifact of swapping src/dst? ~~bbe18c61eb4ee18c7c2acd0364dd84df446d5bf4 and 76c29fe745176a7fc4cb43e1ad5a267ac534a1a3 change how the `.dst` field of a symlink is calculated in file_utils and in _safe_tarfile - previously it was made by combining the extraction root with the symlink destination. This would lose critical information about the path of the symlink source. For example a symlink at `./sbin/shell -> ../bin/sh` is safely within the extraction directory while a symlink at `/shell -> ../bin/sh` is trying to go up too high.~~

Now in #770 ~~fc60755c1608822c26934c2e28df5055eebed5e7 fixes a bug where tarfile absolute symlinks would be improperly dropped which I observed with a system that had`/var/log -> /tmp`. 0e6e0265269392d2c27b2d954e18652db064a8cd fixes a bug with relative symlinks that I observed on a system that had `/var/tmp -> ../../tmp`~~

~~56617a332fb3da19a1092d934e95e3d1ffd43ee5 and 2ce66d6ed32e9448172beb82a20f9b406bcfd72b are trying to fix a mix up between symlink source and destination when calling `create_symlink`. I fixed the CPIO extractor but it looks like things may be [backwards in other extractors](https://github.com/onekey-sec/unblob/issues/761#issuecomment-1939201482) as well.~~

To test these changes, I created a CPIO archive with the following script:
```sh
#!/bin/bash

# Set up a temporary directory for our archive contents
WORKDIR=$(mktemp -d)
echo "Working directory: $WORKDIR"

# Create necessary directories and dummy file for symlink targets
mkdir -p "$WORKDIR/bin" "$WORKDIR/sbin" "$WORKDIR/usr/bin"
echo "This is BusyBox" > "$WORKDIR/bin/busybox"
echo "Dummy content" > "$WORKDIR/usr/bin/dummy"

# Descriptive names for symlink targets
# 1) Symlink in the same directory
ln -s busybox "$WORKDIR/bin/symlink_same_dir"

# 2) Symlink that points to a valid parent directory + file
ln -s ../bin/busybox "$WORKDIR/sbin/symlink_up_to_busybox"

# 3) Symlink with extra parent directories that would still be valid
ln -s ../../../bin/busybox "$WORKDIR/sbin/symlink_extra_up_to_busybox"

# 4) Absolute symlink to a file
ln -s /bin/busybox "$WORKDIR/bin/symlink_absolute"

# 5) Broken symlink (target does not exist)
ln -s non_existent_file "$WORKDIR/bin/symlink_broken"

# 6) Symlink pointing to another symlink (chained symlinks)
ln -s symlink_same_dir "$WORKDIR/bin/symlink_to_symlink"

# 7) Circular symlink (A -> B, B -> A)
ln -s symlink_circular_b "$WORKDIR/bin/symlink_circular_a"
ln -s symlink_circular_a "$WORKDIR/bin/symlink_circular_b"

# 8) Second symlink to busybox
ln -s busybox "$WORKDIR/bin/symlink_same_dir2"

# Navigate to the work directory
cd "$WORKDIR"

# Create the CPIO archive
find . | cpio -ov --format=newc > test_archive.cpio

# Move the archive to the current directory (assuming it's where the script is run)
mv test_archive.cpio "$OLDPWD"
cd "$OLDPWD"

# Clean up the working directory
rm -rf "$WORKDIR"
echo "Archive created: test_archive.cpio"
```

If I extract this with the head of unblob (d0f30869747957ccea6537a2fe6959f542e89a84) and run
`find ../test/test_archive.cpio_extract/ -type f,l -exec ls -al {} \;` I get:

```
-rw-r--r-- 1 root root 0 Feb 12 17:09 ../test/test_archive.cpio_extract/test_archive.cpio
lrwxrwxrwx 1 root root 17 Feb 12 17:09 ../test/test_archive.cpio_extract/bin/symlink_broken -> non_existent_file
-rw-r--r-- 1 root root 16 Feb 12 17:09 ../test/test_archive.cpio_extract/bin/busybox
lrwxrwxrwx 1 root root 7 Feb 12 17:09 ../test/test_archive.cpio_extract/bin/symlink_to_symlink -> busybox
lrwxrwxrwx 1 root root 7 Feb 12 17:09 ../test/test_archive.cpio_extract/bin/symlink_same_dir2 -> busybox
lrwxrwxrwx 1 root root 18 Feb 12 17:09 ../test/test_archive.cpio_extract/bin/symlink_circular_a -> symlink_circular_b
lrwxrwxrwx 1 root root 7 Feb 12 17:09 ../test/test_archive.cpio_extract/bin/symlink_same_dir -> busybox
lrwxrwxrwx 1 root root 7 Feb 12 17:09 ../test/test_archive.cpio_extract/bin/symlink_absolute -> busybox
-rw-r--r-- 1 root root 14 Feb 12 17:09 ../test/test_archive.cpio_extract/usr/bin/dummy
lrwxrwxrwx 1 root root 14 Feb 12 17:09 ../test/test_archive.cpio_extract/sbin/symlink_up_to_busybox -> ../bin/busybox
```

After applying the changes in this PR I get the following result with two additional (and expected) files extracted: `symlink_circular_b` and `symlink_extra_up_to_busybox`. All the files are still contained within the extraction directory.
```
-rw-r--r-- 1 root root 0 Feb 12 17:10 ../test/test_archive.cpio_extract/test_archive.cpio
lrwxrwxrwx 1 root root 18 Feb 12 17:10 ../test/test_archive.cpio_extract/bin/symlink_circular_b -> symlink_circular_a
lrwxrwxrwx 1 root root 17 Feb 12 17:10 ../test/test_archive.cpio_extract/bin/symlink_broken -> non_existent_file
-rw-r--r-- 1 root root 16 Feb 12 17:10 ../test/test_archive.cpio_extract/bin/busybox
lrwxrwxrwx 1 root root 16 Feb 12 17:10 ../test/test_archive.cpio_extract/bin/symlink_to_symlink -> symlink_same_dir
lrwxrwxrwx 1 root root 7 Feb 12 17:10 ../test/test_archive.cpio_extract/bin/symlink_same_dir2 -> busybox
lrwxrwxrwx 1 root root 18 Feb 12 17:10 ../test/test_archive.cpio_extract/bin/symlink_circular_a -> symlink_circular_b
lrwxrwxrwx 1 root root 7 Feb 12 17:10 ../test/test_archive.cpio_extract/bin/symlink_same_dir -> busybox
lrwxrwxrwx 1 root root 7 Feb 12 17:10 ../test/test_archive.cpio_extract/bin/symlink_absolute -> busybox
-rw-r--r-- 1 root root 14 Feb 12 17:10 ../test/test_archive.cpio_extract/usr/bin/dummy
lrwxrwxrwx 1 root root 14 Feb 12 17:10 ../test/test_archive.cpio_extract/sbin/symlink_extra_up_to_busybox -> ../bin/busybox
lrwxrwxrwx 1 root root 14 Feb 12 17:10 ../test/test_archive.cpio_extract/sbin/symlink_up_to_busybox -> ../bin/busybox
```