### PR TITLE
SafeTarfile: Update relative symlinks instead of dropping

### DIFF
--- a/unblob/handlers/archive/_safe_tarfile.py
+++ b/unblob/handlers/archive/_safe_tarfile.py
@@ -112,7 +112,7 @@ class SafeTarFile:
                 )
 
             # The symlink will point to our relative target (may be updated below if unsafe)
-            tarinfo.linkname = rel_target
+            tarinfo.linkname = rel_target.as_posix()
             logger.info(
                 "Link target is relative", linkname=tarinfo.linkname, name=tarinfo.name
             )
@@ -160,7 +160,7 @@ class SafeTarFile:
                 # Prepend placeholder directories before rel_target to get a valid path
                 # within extract_root. This is the relative version of resolved_path.
                 rel_target = Path("/".join(["placeholder"] * drop_count)) / rel_target
-                tarinfo.linkname = rel_target
+                tarinfo.linkname = rel_target.as_posix()
 
             logger.debug("Creating symlink", points_to=resolved_path, name=tarinfo.name)
 


### PR DESCRIPTION
This is a partial fix for #769. With this change, 172 of the 173 missing symlinks are correctly extracted

If I rebase this on top of #768 then the final symlink is extracted correctly (`/mnt/mtd/ubifs_app -> ubifs_app`).

While this fixes the bug, I'm not positive my path handling is correct/secure for all possible symlinks.