### PR TITLE
Fix SafeTarFile symlinks extraction

### DIFF
--- a/tests/integration/archive/tar/__input__/symlinks.tar
+++ b/tests/integration/archive/tar/__input__/symlinks.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:152c7a03b3b3276f8a7527bfde01f26b0c4f2ae3f705a6deac0183d8bac2ba1c
+size 10240

--- a/tests/integration/archive/tar/__output__/absolute.tar_extract/absolute/absolute-symlink
+++ b/tests/integration/archive/tar/__output__/absolute.tar_extract/absolute/absolute-symlink
@@ -1,1 +1,1 @@
-absolute/absolute-file
+absolute-file

--- a/tests/integration/archive/tar/__output__/absolute.tar_extract/absolute/link_to_etc_shadow
+++ b/tests/integration/archive/tar/__output__/absolute.tar_extract/absolute/link_to_etc_shadow
@@ -1,1 +1,1 @@
-etc/shadow
+../etc/shadow

--- a/tests/integration/archive/tar/__output__/symlinks.tar_extract/test/bin/busybox
+++ b/tests/integration/archive/tar/__output__/symlinks.tar_extract/test/bin/busybox
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58eaf5a78d580f5dbd49d31a5b733094169b31bfdf49055b74bcac2877d8f58c
+size 7

--- a/tests/integration/archive/tar/__output__/symlinks.tar_extract/test/sbin/cp
+++ b/tests/integration/archive/tar/__output__/symlinks.tar_extract/test/sbin/cp
@@ -1,0 +1,1 @@
+../bin/busybox

--- a/tests/integration/archive/tar/__output__/symlinks.tar_extract/test/sbin/find
+++ b/tests/integration/archive/tar/__output__/symlinks.tar_extract/test/sbin/find
@@ -1,0 +1,1 @@
+../bin/busybox

--- a/tests/integration/archive/tar/__output__/symlinks.tar_extract/test/sbin/ln
+++ b/tests/integration/archive/tar/__output__/symlinks.tar_extract/test/sbin/ln
@@ -1,0 +1,1 @@
+../bin/busybox

--- a/tests/integration/archive/tar/__output__/symlinks.tar_extract/test/sbin/ls
+++ b/tests/integration/archive/tar/__output__/symlinks.tar_extract/test/sbin/ls
@@ -1,0 +1,1 @@
+../bin/busybox

--- a/tests/integration/archive/tar/__output__/symlinks.tar_extract/test/sbin/mv
+++ b/tests/integration/archive/tar/__output__/symlinks.tar_extract/test/sbin/mv
@@ -1,0 +1,1 @@
+../../bin/busybox

--- a/unblob/handlers/archive/_safe_tarfile.py
+++ b/unblob/handlers/archive/_safe_tarfile.py
@@ -83,10 +83,9 @@ class SafeTarFile:
                     "Converted to extraction relative path.",
                 )
                 tarinfo.linkname = f"./{tarinfo.linkname}"
-            if not is_safe_path(
-                basedir=extract_root,
-                path=extract_root / tarinfo.linkname,
-            ):
+
+            resolved_path = (extract_root / tarinfo.name).parent / tarinfo.linkname
+            if not is_safe_path(basedir=extract_root, path=resolved_path):
                 self.record_problem(
                     tarinfo,
                     "Traversal attempt through link path.",


### PR DESCRIPTION
Based on the work of @AndrewFasano in PR #770 this should fix most of the tar symlink extraction problems reported.

Related issue: #769 