### PR TITLE
chore(ci): tag merged docker image with version info.

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -131,6 +131,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
+            type=semver,pattern={{version}}
             type=sha
 
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
We're tagging the aarch64 and x86-64 container images with the version since 42155be6 but we forgot to tag the result of merging them in `merge-and-push-image` step.