### PR TITLE
fix(gzip): empty files are invalid and should not be parsed

### DIFF
--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -81,6 +81,18 @@ def fake_file() -> File:
     return File.from_bytes(b"0123456789abcdefghijklmnopqrst")
 
 
+class TestFile:
+    def test_file_from_empty_bytes(self):
+        with pytest.raises(InvalidInputFormat):
+            File.from_bytes(b"")
+
+    def test_file_from_empty_file(self, tmp_path):
+        file_path = tmp_path / "file"
+        file_path.touch()
+        with pytest.raises(InvalidInputFormat):
+            File.from_path(file_path)
+
+
 class TestStructParser:
     def test_parse_correct_endianness(self):
         test_content = b"\x01\x02\x03\x04"

--- a/unblob/handlers/archive/sevenzip.py
+++ b/unblob/handlers/archive/sevenzip.py
@@ -107,7 +107,11 @@ class MultiVolumeSevenZipHandler(DirectoryHandler):
 
     def calculate_multifile(self, file: Path) -> Optional[MultiFile]:
         paths = sorted(
-            [p for p in file.parent.glob(f"{file.stem}.*") if p.resolve().exists()]
+            [
+                p
+                for p in file.parent.glob(f"{file.stem}.*")
+                if p.resolve().exists() and p.stat().st_size > 0
+            ]
         )
         if not paths:
             return None

--- a/unblob/handlers/compression/gzip.py
+++ b/unblob/handlers/compression/gzip.py
@@ -167,7 +167,11 @@ class MultiVolumeGzipHandler(DirectoryHandler):
 
     def calculate_multifile(self, file: Path) -> Optional[MultiFile]:
         paths = sorted(
-            [p for p in file.parent.glob(f"{file.stem}.*") if p.resolve().exists()]
+            [
+                p
+                for p in file.parent.glob(f"{file.stem}.*")
+                if p.resolve().exists() and p.stat().st_size > 0
+            ]
         )
 
         # we 'discard' paths that are not the first in the ordered list,


### PR DESCRIPTION
Passing an empty file into `File.from_path` leads to an error that an empty file cannot be mmaped.

This could also be implemented in the from_path method, but I thought the `is_valid` method made since because an empty file isn't a valid gzip.

Fixes #786