### PR TITLE
Fix `is_valid_gzip` on empty file

### DIFF
--- a/tests/handlers/compression/test_gzip.py
+++ b/tests/handlers/compression/test_gzip.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+from unblob.handlers.compression.gzip import MultiVolumeGzipHandler
+
+
+def test_multivolume_is_valid_gzip_empty_file(tmp_path: Path):
+    empty = tmp_path / "empty"
+    empty.touch()
+    assert not MultiVolumeGzipHandler().is_valid_gzip(empty)

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -81,18 +81,6 @@ def fake_file() -> File:
     return File.from_bytes(b"0123456789abcdefghijklmnopqrst")
 
 
-class TestFile:
-    def test_file_from_empty_bytes(self):
-        with pytest.raises(InvalidInputFormat):
-            File.from_bytes(b"")
-
-    def test_file_from_empty_file(self, tmp_path):
-        file_path = tmp_path / "file"
-        file_path.touch()
-        with pytest.raises(InvalidInputFormat):
-            File.from_path(file_path)
-
-
 class TestStructParser:
     def test_parse_correct_endianness(self):
         test_content = b"\x01\x02\x03\x04"

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -81,6 +81,18 @@ def fake_file() -> File:
     return File.from_bytes(b"0123456789abcdefghijklmnopqrst")
 
 
+class TestFile:
+    def test_file_from_empty_bytes(self):
+        with pytest.raises(ValueError):  # noqa: PT011
+            File.from_bytes(b"")
+
+    def test_file_from_empty_file(self, tmp_path):
+        file_path = tmp_path / "file"
+        file_path.touch()
+        with pytest.raises(ValueError, match="cannot mmap an empty file"):
+            File.from_path(file_path)
+
+
 class TestStructParser:
     def test_parse_correct_endianness(self):
         test_content = b"\x01\x02\x03\x04"

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -45,6 +45,8 @@ class File(mmap.mmap):
 
     @classmethod
     def from_bytes(cls, content: bytes):
+        if not content:
+            raise ValueError("Can't create File from empty bytes.")
         m = cls(-1, len(content))
         m.write(content)
         m.seek(0)
@@ -53,6 +55,11 @@ class File(mmap.mmap):
 
     @classmethod
     def from_path(cls, path: Path, access=mmap.ACCESS_READ):
+        """Create File.
+
+        Needs a valid non-empty file,
+        raises ValueError on empty files.
+        """
         mode = "r+b" if access == mmap.ACCESS_WRITE else "rb"
         with path.open(mode) as base_file:
             m = cls(base_file.fileno(), 0, access=access)

--- a/unblob/file_utils.py
+++ b/unblob/file_utils.py
@@ -40,17 +40,11 @@ class SeekError(ValueError):
     """Specific ValueError for File.seek."""
 
 
-class InvalidInputFormat(Exception):
-    pass
-
-
 class File(mmap.mmap):
     access: int
 
     @classmethod
     def from_bytes(cls, content: bytes):
-        if not content:
-            raise InvalidInputFormat("Can't create File from empty bytes.")
         m = cls(-1, len(content))
         m.write(content)
         m.seek(0)
@@ -61,10 +55,7 @@ class File(mmap.mmap):
     def from_path(cls, path: Path, access=mmap.ACCESS_READ):
         mode = "r+b" if access == mmap.ACCESS_WRITE else "rb"
         with path.open(mode) as base_file:
-            try:
-                m = cls(base_file.fileno(), 0, access=access)
-            except ValueError as exc:
-                raise InvalidInputFormat from exc
+            m = cls(base_file.fileno(), 0, access=access)
             m.access = access
             return m
 
@@ -122,6 +113,10 @@ class OffsetFile:
 
     def tell(self):
         return self._file.tell() - self._offset
+
+
+class InvalidInputFormat(Exception):
+    pass
 
 
 class Endian(enum.Enum):

--- a/unblob/handlers/archive/sevenzip.py
+++ b/unblob/handlers/archive/sevenzip.py
@@ -107,11 +107,7 @@ class MultiVolumeSevenZipHandler(DirectoryHandler):
 
     def calculate_multifile(self, file: Path) -> Optional[MultiFile]:
         paths = sorted(
-            [
-                p
-                for p in file.parent.glob(f"{file.stem}.*")
-                if p.resolve().exists() and p.stat().st_size > 0
-            ]
+            [p for p in file.parent.glob(f"{file.stem}.*") if p.resolve().exists()]
         )
         if not paths:
             return None

--- a/unblob/handlers/compression/gzip.py
+++ b/unblob/handlers/compression/gzip.py
@@ -156,7 +156,12 @@ class MultiVolumeGzipHandler(DirectoryHandler):
     PATTERN = Glob("*.gz.*")
 
     def is_valid_gzip(self, path: Path) -> bool:
-        with File.from_path(path) as f:
+        try:
+            file = File.from_path(path)
+        except ValueError:
+            return False
+
+        with file as f:
             try:
                 fp = SingleMemberGzipReader(f)
                 if not fp.read_header():

--- a/unblob/handlers/compression/gzip.py
+++ b/unblob/handlers/compression/gzip.py
@@ -167,11 +167,7 @@ class MultiVolumeGzipHandler(DirectoryHandler):
 
     def calculate_multifile(self, file: Path) -> Optional[MultiFile]:
         paths = sorted(
-            [
-                p
-                for p in file.parent.glob(f"{file.stem}.*")
-                if p.resolve().exists() and p.stat().st_size > 0
-            ]
+            [p for p in file.parent.glob(f"{file.stem}.*") if p.resolve().exists()]
         )
 
         # we 'discard' paths that are not the first in the ordered list,


### PR DESCRIPTION
#787 was fixing the issue #786 not just at the location of the problem, but this reached the `File` class as well, modifying it to raise an unblob specific error, effectively aborting processing in a "well known manner".
I think this was wrong, and `File` worked as expected and was a rather generic class, and should remain so.
The fix also had changes in gzip and 7z handlers, ignoring empty files from the collected files, but that change was neither supported by tests nor explained - I think that was a redundant fix for the problem.

The root of the issue is not in the `File` class, but rather that the raised `ValueError` is not handled by the handler.

This MR reverts some changes and fixes only the failing function, covered with a test.
