### PR TITLE
fix(handler): introduce upper size limit for s_log_block_size

### DIFF
--- a/unblob/handlers/filesystem/extfs.py
+++ b/unblob/handlers/filesystem/extfs.py
@@ -84,6 +84,12 @@ class EXTHandler(StructHandler):
                 "ExtFS header major version too high", rev_level=header.s_rev_level
             )
             return False
+        if header.s_log_block_size > 6:
+            logger.debug(
+                "ExtFS header s_log_block_size is too large",
+                s_log_block_size=header.s_log_block_size,
+            )
+            return False
         return True
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:


### PR DESCRIPTION
The maximum block size limit on a 64bit system is `65536`.
When creating a fake filesystem with `mkfs.ext4` and setting the block size with `-b 65536`, the maximum value that `s_log_block_size` will reach is `6`.

Fixes : https://github.com/onekey-sec/unblob/issues/792