### PR TITLE
remove "Microsoft OOXML" from the default skip magic

### DIFF
--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -64,7 +64,6 @@ DEFAULT_SKIP_MAGIC = (
     "MS Windows icon resource",
     "Macromedia Flash data",
     "Microsoft Excel",
-    "Microsoft OOXML",
     "Microsoft PowerPoint",
     "Microsoft Word",
     "OpenDocument",


### PR DESCRIPTION
We've observed third-party libraries being shipped within OOXML containers. We don't want unblob to skip them.