### PR TITLE
fix(handler): add support for zip64 values in Central Directory Headers

### DIFF
--- a/tests/integration/archive/zip/zip64/__input__/colors.zip
+++ b/tests/integration/archive/zip/zip64/__input__/colors.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a59995571929d2047445ef9ead25ebe1560a6b52a8204ed342c72f8eb624bec9
+size 457

--- a/tests/integration/archive/zip/zip64/__input__/colors_garbage.zip
+++ b/tests/integration/archive/zip/zip64/__input__/colors_garbage.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cca8132ff6bf4a712056e15507643bb32ddd1283cf84d85157c9c2a299cf6749
+size 1481

--- a/tests/integration/archive/zip/zip64/__input__/zero_edited.zip
+++ b/tests/integration/archive/zip/zip64/__input__/zero_edited.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7321376ddcdde9617b95332c6c3b3e1e612fa352e18e8eb99faff7580e456ddc
+size 6252481

--- a/tests/integration/archive/zip/zip64/__output__/colors.zip_extract/blue.txt
+++ b/tests/integration/archive/zip/zip64/__output__/colors.zip_extract/blue.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0bee6616b5e5eae6799cb4525a884a82e7161614f11122bbdf4383b2ac05998
+size 5

--- a/tests/integration/archive/zip/zip64/__output__/colors.zip_extract/red.txt
+++ b/tests/integration/archive/zip/zip64/__output__/colors.zip_extract/red.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ace33171ce0acb6891e3cc311d75a97aa429d77c05cba600d49ed9652ed49de
+size 4

--- a/tests/integration/archive/zip/zip64/__output__/colors_garbage.zip_extract/0-1024.unknown
+++ b/tests/integration/archive/zip/zip64/__output__/colors_garbage.zip_extract/0-1024.unknown
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fdac534f308dcc7708b640a33ace78c5cffb61a90d425b07409f0b66056bee0
+size 1024

--- a/tests/integration/archive/zip/zip64/__output__/colors_garbage.zip_extract/1024-1481.zip
+++ b/tests/integration/archive/zip/zip64/__output__/colors_garbage.zip_extract/1024-1481.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a59995571929d2047445ef9ead25ebe1560a6b52a8204ed342c72f8eb624bec9
+size 457

--- a/tests/integration/archive/zip/zip64/__output__/colors_garbage.zip_extract/1024-1481.zip_extract/blue.txt
+++ b/tests/integration/archive/zip/zip64/__output__/colors_garbage.zip_extract/1024-1481.zip_extract/blue.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0bee6616b5e5eae6799cb4525a884a82e7161614f11122bbdf4383b2ac05998
+size 5

--- a/tests/integration/archive/zip/zip64/__output__/colors_garbage.zip_extract/1024-1481.zip_extract/red.txt
+++ b/tests/integration/archive/zip/zip64/__output__/colors_garbage.zip_extract/1024-1481.zip_extract/red.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ace33171ce0acb6891e3cc311d75a97aa429d77c05cba600d49ed9652ed49de
+size 4

--- a/tests/integration/archive/zip/zip64/__output__/zero_edited.zip_extract/zero
+++ b/tests/integration/archive/zip/zip64/__output__/zero_edited.zip_extract/zero
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1d13c5021fad1bbc1fd95d8597efd5822fa179b00df8dd3fa4d5eb9f73c78b2
+size 6252215


### PR DESCRIPTION
`ZIP64` is the standard that replaces zip, its designated to "fix" the 4gb size limit of zip.
In the format, it means that some values can be changed to FFFF, for example :
`offset_of_cd` or `central_directory_size` can be `0xFFFFFFFF`, indicating it's a zip64. 

Some time last week, some zip files were not being extracted, after analysis it seemed that their `central directory` also had FFFF values.

So in this PR, I added a new definition, `is_zip64_cd`, to check if the corresponding values indicate `zip64`

New integration tests are also added, we simply use `zip -fz` to create those zip64 files. 

Fixes #819
