### PR TITLE
fix(zlib): Limit zlib pattern at the start of the file

### DIFF
--- a/tests/integration/compression/zlib/__input__/sample.prefix.zlib
+++ b/tests/integration/compression/zlib/__input__/sample.prefix.zlib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9df2812c73d506e5bc4fae81223710d300c89993be73c43cf175112475628ef0
-size 39

--- a/tests/integration/compression/zlib/__output__/sample.prefix.zlib_extract/0-5.unknown
+++ b/tests/integration/compression/zlib/__output__/sample.prefix.zlib_extract/0-5.unknown
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4677942dfa3e74b5dea7484661a2485bb73ba422eb72d311fdb39372c019c615
-size 5

--- a/tests/integration/compression/zlib/__output__/sample.prefix.zlib_extract/5-39.zlib
+++ b/tests/integration/compression/zlib/__output__/sample.prefix.zlib_extract/5-39.zlib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:133a339cfd1651953db209cf44666f8a49e4364c4f1e5bf8be84e812f0f91c61
-size 34

--- a/tests/integration/compression/zlib/__output__/sample.prefix.zlib_extract/5-39.zlib_extract/zlib.uncompressed
+++ b/tests/integration/compression/zlib/__output__/sample.prefix.zlib_extract/5-39.zlib_extract/zlib.uncompressed
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d121ef4c4adf575b3c8f4c9f8d9e1a1887f1fe09bb718a33141a0bc6009d52d
-size 28

--- a/unblob/handlers/compression/zlib.py
+++ b/unblob/handlers/compression/zlib.py
@@ -8,7 +8,7 @@ from structlog import get_logger
 from unblob.handlers.archive.dmg import DMGHandler
 
 from ...file_utils import DEFAULT_BUFSIZE, InvalidInputFormat
-from ...models import Extractor, File, Handler, HexString, ValidChunk
+from ...models import Extractor, File, Handler, Regex, ValidChunk
 
 logger = get_logger()
 
@@ -28,10 +28,10 @@ class ZlibHandler(Handler):
     NAME = "zlib"
 
     PATTERNS = [
-        HexString("78 01"),  # low compression
-        HexString("78 9c"),  # default compression
-        HexString("78 da"),  # best compression
-        HexString("78 5e"),  # compressed
+        Regex(r"^\x78\x01"),  # low compression
+        Regex(r"^\x78\x9c"),  # default compression
+        Regex(r"^\x78\xda"),  # best compression
+        Regex(r"^\x78\x5e"),  # compressed
     ]
 
     EXTRACTOR = ZlibExtractor()


### PR DESCRIPTION
The zlib handler has a weak pattern, it can hog a lot of CPU time, we thus want to improve it's pattern by forcing it to match the start of the file only.

As a result, extraction can be much faster but might results in missed chunks. 