### PR TITLE
fix(permission): Ignore symlinks in fix_permission

### DIFF
--- a/tests/integration/filesystem/squashfs/squashfs_v4_le/__input__/bad_symlink.squashfs
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_le/__input__/bad_symlink.squashfs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c55f810260e48d4db63d02b92a0a07e0e8b04c46070a2f3ef1f2314eaab0d37
+size 4096

--- a/tests/integration/filesystem/squashfs/squashfs_v4_le/__output__/bad_symlink.squashfs_extract/badlink
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_le/__output__/bad_symlink.squashfs_extract/badlink
@@ -1,0 +1,1 @@
+etc/ssl/private/ssl-cert-snakeoil.key

--- a/unblob/extractor.py
+++ b/unblob/extractor.py
@@ -23,10 +23,10 @@ def carve_chunk_to_file(carve_path: Path, file: File, chunk: Chunk):
 
 
 def fix_permission(path: Path):
-    if not path.exists():
+    if path.is_symlink():
         return
 
-    if path.is_symlink():
+    if not path.exists():
         return
 
     mode = path.stat().st_mode


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/onekey-sec/unblob/commit/486bb91531d6d0f677f68e724675983f04ae1474 where symlink were not being ignored when they should have been 

Fixes #830 