### PR TITLE
fix(ubi): add exception handler for SeekError

### DIFF
--- a/tests/integration/filesystem/ubi/ubi/__input__/orange.ubi.truncated.img
+++ b/tests/integration/filesystem/ubi/ubi/__input__/orange.ubi.truncated.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8dbf22935bc3b694e896c2a2ae922d76672c26a7a387449a475d63bfd087afe9
+size 3430400

--- a/tests/integration/filesystem/ubi/ubi/__output__/orange.ubi.truncated.img_extract/0-3407872.ubi
+++ b/tests/integration/filesystem/ubi/ubi/__output__/orange.ubi.truncated.img_extract/0-3407872.ubi
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08eebf3761a5722d486ce36acec62c0146d6b80bef006c2b6273def740b81d8b
+size 3407872

--- a/tests/integration/filesystem/ubi/ubi/__output__/orange.ubi.truncated.img_extract/0-3407872.ubi_extract/img-941083063_vol-configuration.ubifs
+++ b/tests/integration/filesystem/ubi/ubi/__output__/orange.ubi.truncated.img_extract/0-3407872.ubi_extract/img-941083063_vol-configuration.ubifs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f18265fb4d15e5af50245ffa8b7c62836ed0eb8aceb9e3856b145ea097994645
+size 2064384

--- a/tests/integration/filesystem/ubi/ubi/__output__/orange.ubi.truncated.img_extract/0-3407872.ubi_extract/img-941083063_vol-configuration.ubifs_extract/orange1.txt
+++ b/tests/integration/filesystem/ubi/ubi/__output__/orange.ubi.truncated.img_extract/0-3407872.ubi_extract/img-941083063_vol-configuration.ubifs_extract/orange1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26cf6bc4cd9bc86de0392173cfc2546c5ece07f79816999945bf33a1bd15c680
+size 1445004

--- a/tests/integration/filesystem/ubi/ubi/__output__/orange.ubi.truncated.img_extract/0-3407872.ubi_extract/img-941083063_vol-configuration.ubifs_extract/orange2.txt
+++ b/tests/integration/filesystem/ubi/ubi/__output__/orange.ubi.truncated.img_extract/0-3407872.ubi_extract/img-941083063_vol-configuration.ubifs_extract/orange2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e13517c0da9b7e065f2f816ae6cd2b4d8aae24c4b6a36b68320d6eb16e2d66d
+size 1445005

--- a/tests/integration/filesystem/ubi/ubi/__output__/orange.ubi.truncated.img_extract/0-3407872.ubi_extract/img-941083063_vol-rootfs.ubifs
+++ b/tests/integration/filesystem/ubi/ubi/__output__/orange.ubi.truncated.img_extract/0-3407872.ubi_extract/img-941083063_vol-rootfs.ubifs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d62c3a983b734754fe1b8420bc502ada8cef3868d364e25e5258414bcdd011f0
+size 1032192

--- a/tests/integration/filesystem/ubi/ubi/__output__/orange.ubi.truncated.img_extract/3407872-3430400.unknown
+++ b/tests/integration/filesystem/ubi/ubi/__output__/orange.ubi.truncated.img_extract/3407872-3430400.unknown
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991e478ff0b45569f77c8ce44a4d231ee8e75402539b64df52a9fa42540ff760
+size 22528

--- a/unblob/handlers/filesystem/ubi.py
+++ b/unblob/handlers/filesystem/ubi.py
@@ -81,7 +81,7 @@ class UBIFSHandler(StructHandler):
     """
     HEADER_STRUCT = "ubifs_sb_node_t"
 
-    EXTRACTOR = Command("ubireader_extract_files", "{inpath}", "-o", "{outdir}")
+    EXTRACTOR = Command("ubireader_extract_files", "{inpath}", "-w", "-o", "{outdir}")
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         endian = get_endian(file, self._BIG_ENDIAN_MAGIC)

--- a/unblob/handlers/filesystem/ubi.py
+++ b/unblob/handlers/filesystem/ubi.py
@@ -7,7 +7,7 @@ from structlog import get_logger
 
 from unblob.extractors import Command
 
-from ...file_utils import InvalidInputFormat, get_endian, iterate_patterns
+from ...file_utils import InvalidInputFormat, SeekError, get_endian, iterate_patterns
 from ...iter_utils import get_intervals
 from ...models import File, Handler, HexString, StructHandler, ValidChunk
 
@@ -137,8 +137,10 @@ class UBIHandler(Handler):
             first_bytes = file.read(len(self._UBI_EC_HEADER))
             if first_bytes == b"" or first_bytes != self._UBI_EC_HEADER:
                 break
-            file.seek(offset + peb_size)
-
+            try:
+                file.seek(offset + peb_size)
+            except SeekError:
+                break
         return offset
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:


### PR DESCRIPTION
This check is needed to exit the loop when the end of the file is reached.