### PR TITLE
fix(zip): handle ZIP64 files missing indicators of ZIP64.

### DIFF
--- a/unblob/handlers/archive/zip.py
+++ b/unblob/handlers/archive/zip.py
@@ -188,7 +188,8 @@ class ZIPHandler(StructHandler):
             if offset == end_of_central_directory_offset:
                 break
         else:
-            raise InvalidInputFormat("Missing EOCD record header in ZIP chunk.")
+            # if we can't find 32bit ZIP EOCD, we fall back to ZIP64
+            end_of_central_directory = self._parse_zip64(file, start_offset, offset)
 
         has_encrypted_files = self.has_encrypted_files(
             file, start_offset, end_of_central_directory


### PR DESCRIPTION
Sometimes large zip files created with 7z are missing indicators that they're ZIP64 (see `is_zip64()` implementation for details on heuristics we use to detect ZIP64).

Since we can't rely on our heuristics, we simply fallback to ZIP64 if we can't find ZIP32 EOCDs.