### PR TITLE
Fix frame_content_size retrieval logic

### DIFF
--- a/tests/integration/compression/zstd/__input__/large_fcs.zstd
+++ b/tests/integration/compression/zstd/__input__/large_fcs.zstd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c6fc92dda937dd453b83c60f0d439c87a156d09888ede3d47201e13c26245e8
+size 26

--- a/tests/integration/compression/zstd/__output__/large_fcs.zstd_extract/zstd.uncompressed
+++ b/tests/integration/compression/zstd/__output__/large_fcs.zstd_extract/zstd.uncompressed
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cc43248c8a1245d2dc0d1e6a2fb9935d3506689bd8abd037f040af136dc0269
+size 65792

--- a/unblob/handlers/compression/zstd.py
+++ b/unblob/handlers/compression/zstd.py
@@ -29,7 +29,7 @@ class ZSTDHandler(Handler):
     def get_frame_header_size(self, frame_header_descriptor: int) -> int:
         single_segment = (frame_header_descriptor >> 5 & 1) & 0b1
         dictionary_id = frame_header_descriptor >> 0 & 0b11
-        frame_content_size = (frame_header_descriptor >> 6) & 0b1
+        frame_content_size = (frame_header_descriptor >> 6) & 0b11
         return (
             int(not single_segment)
             + DICT_ID_FIELDSIZE_MAP[dictionary_id]


### PR DESCRIPTION
According to [documentation](https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frame_header_descriptor) `Frame_Content_Size_flag` is a 2 bits value, not 1 bit as the current logic has.