### PR TITLE
Report carve

### DIFF
--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -95,6 +95,7 @@ class ExtractionConfig:
     process_num: int = DEFAULT_PROCESS_NUM
     keep_extracted_chunks: bool = False
     extract_suffix: str = "_extract"
+    carve_suffix: str = "_extract"
     handlers: Handlers = BUILTIN_HANDLERS
     dir_handlers: DirectoryHandlers = BUILTIN_DIR_HANDLERS
     verbose: int = 1
@@ -584,7 +585,7 @@ class _FileTask:
                 CarveReport.from_chunk(self.task.path, inpath, chunk)
             )
 
-            extract_dir = self.carve_dir / (inpath.name + self.config.extract_suffix)
+            extract_dir = self.carve_dir / (inpath.name + self.config.carve_suffix)
             carved_path = inpath
 
         if extract_dir.exists():

--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -34,6 +34,7 @@ from .models import (
 from .pool import make_pool
 from .report import (
     CalculateMultiFileExceptionReport,
+    CarveReport,
     EntropyReport,
     ExtractDirectoryExistsReport,
     FileMagicReport,
@@ -579,6 +580,10 @@ class _FileTask:
             carved_path = None
         else:
             inpath = carve_valid_chunk(self.carve_dir, file, chunk)
+            self.result.add_report(
+                CarveReport.from_chunk(self.task.path, inpath, chunk)
+            )
+
             extract_dir = self.carve_dir / (inpath.name + self.config.extract_suffix)
             carved_path = inpath
 

--- a/unblob/report.py
+++ b/unblob/report.py
@@ -236,6 +236,29 @@ class UnknownChunkReport(Report):
     entropy: Optional[EntropyReport]
 
 
+@attr.define(kw_only=True, frozen=True)
+class CarveReport(Report):
+    """Describes a successful carving operation."""
+
+    carved_from: Path
+    carved_to: Path
+    start_offset: int
+    end_offset: int
+    handler_name: str
+
+    @classmethod
+    def from_chunk(
+        cls, carved_from: Path, carved_to: Path, chunk: "ValidChunk"  # noqa: F821
+    ):
+        return cls(
+            carved_from=carved_from,
+            carved_to=carved_to,
+            start_offset=chunk.start_offset,
+            end_offset=chunk.end_offset,
+            handler_name=chunk.handler.NAME,
+        )
+
+
 @final
 @attr.define(kw_only=True, frozen=True)
 class MultiFileReport(Report):


### PR DESCRIPTION
* Adds a new report type of CarveReport and reports when files are carved to fix #554 
* Changes the directory suffix used by carve to be `_carve` by default to fix #326 


I really wanted to change carving to generate a subtask where there's a task for the original file being processed that has subtasks for each carved file. Then each carved file is another task that generates subtasks for the extraction. But I couldn't find a sane way to do this - would love any feedback or help with it if y'all think that's a better way to approach this.

