### PR TITLE
fix(handler): improve zip64 detection

### DIFF
--- a/tests/integration/archive/zip/zip64/__input__/zip64-without-cd.zip
+++ b/tests/integration/archive/zip/zip64/__input__/zip64-without-cd.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4ea164d7b08ba3ee6dbea6808e7d5438ffbf317420e28d0c5e42b7090f42851
+size 126

--- a/tests/integration/archive/zip/zip64/__output__/zip64-without-cd.zip_extract/-
+++ b/tests/integration/archive/zip/zip64/__output__/zip64-without-cd.zip_extract/-
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6


### PR DESCRIPTION
We improve the zip64 detection by trying to parse the zip64 early. 
If the zip file contains a zip64 header, we are sure its a zip64. 
If it doesn't hold a zip64, we are sure its not a zip64 and we fall back to zip32. 

fixes #900