### PR TITLE
chore(dissect.cstruct): Make Unblob compatible with version 4.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1976,4 +1976,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "8c755ebc00fac7027ca3616675ecbec05547b8916c748b496bbdc3eccdbec6c8"
+content-hash = "805ec30a1ae7deccf071a84ef9e719a54e8071a8b39095a65f037083c1149a66"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.8"
 click = "^8.1.7"
-"dissect.cstruct" = "^2.0"
+"dissect.cstruct" = ">=2.0,<5.0"
 attrs = ">=23.1.0"
 structlog = ">=24.1.0"
 arpy = "^2.3.0"

--- a/unblob/logging.py
+++ b/unblob/logging.py
@@ -7,7 +7,14 @@ from pathlib import Path
 from typing import Any
 
 import structlog
-from dissect.cstruct import Instance, dumpstruct
+from dissect.cstruct import dumpstruct
+
+try:
+    # dissect.cstruct >= 4.0
+    from dissect.cstruct import Structure
+except ImportError:
+    # dissect.cstruct == 2.0
+    from dissect.cstruct import Instance as Structure
 
 
 def format_hex(value: int):
@@ -42,7 +49,7 @@ def _format_message(value: Any, extract_root: Path) -> Any:
             new_value = value
         return new_value.as_posix().encode("utf-8", errors="surrogateescape")
 
-    if isinstance(value, Instance):
+    if isinstance(value, Structure):
         return dumpstruct(value, output="string")
 
     if isinstance(value, int):


### PR DESCRIPTION
We cannot upgrade our requirement to 4.0, as it has no Python 3.8 support. The second-best thing we can do is to relax the dependency specification and make our logging code compatible with both versions. This is the only place we depend on runtime types.

In the next nix flake update, Nix builds will also use 4.0 version.

Fixes: #888