### PR TITLE
lief: silence error log spam

### DIFF
--- a/unblob/handlers/executable/elf.py
+++ b/unblob/handlers/executable/elf.py
@@ -19,7 +19,7 @@ from unblob.file_utils import (
 )
 from unblob.models import HexString, StructHandler, ValidChunk
 
-lief.logging.set_level(lief.logging.LEVEL.ERROR)
+lief.logging.disable()
 
 logger = get_logger()
 


### PR DESCRIPTION
Since 0.15, the error logs got very chatty (search for `LIEF_ERR` in its code base).
E.g. the following log appears tens of thousands of times for an unsupported architecture:

    LIEF does not support relocation for 'ARC_COMPACT'

There are no logs for `CRITICAL` level, so there is nothing much we can do besides turning of logging.