### PR TITLE
fix(ci): adjust container scan fail-build parameter.

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -76,7 +76,7 @@ jobs:
         uses: anchore/scan-action@v4
         with:
           image: ${{ env.DOCKER_IMAGE }}
-          fail-build: true
+          fail-build: false
           severity-cutoff: critical
           only-fixed: true
 


### PR DESCRIPTION
Failing the build does not really help since we're highly dependent on Debian maintainers to publish fixes, which means it would block Docker image releases until a fix is available in upstream Debian (we're using python3.8-slim Docker image, which itself is based on bookworm-slim).

The bug that's currently failing the build
(https://nvd.nist.gov/vuln/detail/CVE-2024-45490) is not critical considering our use case.

Also, not failing the build allows the action to finish and push the SARIF results to Github Security panel so we can have a look and be notified. It's not like it's going away.