### PR TITLE
fix(docker): system-wide install of unblob within container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,10 @@ WORKDIR /data/output
 COPY unblob/install-deps.sh /
 RUN sh -xeu /install-deps.sh
 
-USER unblob
-ENV PATH="/home/unblob/.local/bin:${PATH}"
-
 # You MUST do a poetry build before to have the wheel to copy & install here (CI action will do this when building)
 COPY dist/*.whl /tmp/
 RUN pip --disable-pip-version-check install --upgrade pip
-RUN pip install /tmp/unblob*.whl
+RUN pip install /tmp/unblob*.whl --prefix /usr/local
 
+USER unblob
 ENTRYPOINT ["unblob"]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,6 +70,23 @@ Help on usage:
 docker run --rm --pull always ghcr.io/onekey-sec/unblob:latest --help
 ```
 
+⚠️  When you bind mount directories from the host in the container using the `-v` option, you must
+make sure that they are owned by the same `uid:gid` pair otherwise you'll get
+into permission issues.
+
+If you're on a multi-user Linux host (i.e. your $UID is > 1000), it's recommended you
+launch the container this way to map the container user's UID to yours:
+
+```console
+docker run \
+  --rm \
+  --pull always \
+  -u $UID:$GID
+  -v /path/to/extract-dir/on/host:/data/output \
+  -v /path/to/files/on/host:/data/input \
+ghcr.io/onekey-sec/unblob:latest /data/input/path/to/file
+```
+
 ## nix package
 
 unblob can be built and run using the [Nix](https://nixos.org) package manager.


### PR DESCRIPTION
Some users have issues with bind mounts and UID/GID mismatch between their host users and the container user that defaults to 1000.

We fix it by installing unblob system-wide within the container, making it available to any user within the container.

Users that want a one-to-one mapping of their host user to the container user can do so with the `-u` docker run parameter:

```
docker run -u $UID:$GID [...] ghcr.io/onekey-sec/unblob:latest
```

Resolve #971 