### PR TITLE
chore(nix): make sure ruff is runnable on NixOS

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 
 # https://devenv.sh/reference/options/
 {
@@ -24,4 +24,12 @@
       nvfetcher
     ]
     ++ unblob.runtimeDeps;
+
+  tasks = {
+    "venv:patchelf" = {
+      exec = "${lib.getExe pkgs.patchelf} --set-interpreter ${pkgs.stdenv.cc.bintools.dynamicLinker} $VIRTUAL_ENV/bin/ruff";
+      after = [ "devenv:python:poetry" ];
+      before = [ "devenv:enterShell" ];
+    };
+  };
 }


### PR DESCRIPTION
Before `devenv`'s been introduced, `autoPatchelfHook` made sure that external binaries are executable. `Devenv` has its own magic sauce that makes Python dependencies "just work", however `ruff` is not a python binary, so it needs special care.