### PR TITLE
fix(test): when run under old systems in devenv

### DIFF
--- a/tests/extractors/test_command.py
+++ b/tests/extractors/test_command.py
@@ -34,7 +34,14 @@ def test_command_templating_with_invalid_substitution(template):
 
 def test_command_execution(tmpdir: Path):
     outdir = PosixPath(tmpdir)
-    command = Command("sh", "-c", "> {outdir}/created")
+    # fmt: off
+    command = Command(
+        "python",
+        "-c",
+        "import pathlib\n"
+        "pathlib.Path('{outdir}/created').touch()",
+    )
+    # fmt: on
 
     command.extract(Path("foo"), outdir)
 
@@ -43,7 +50,14 @@ def test_command_execution(tmpdir: Path):
 
 def test_command_execution_failure(tmpdir: Path):
     outdir = PosixPath(tmpdir)
-    command = Command("sh", "-c", ">&1 echo -n stdout; >&2 echo -n stderr; false")
+    command = Command(
+        "python",
+        "-c",
+        "import sys\n"
+        "sys.stdout.write('stdout')\n"
+        "sys.stderr.write('stderr')\n"
+        "sys.exit(1)",
+    )
 
     with pytest.raises(ExtractError) as excinfo:
         command.extract(Path("input"), outdir)


### PR DESCRIPTION
The issue is twofold:
- `sh` can come in as a system binary, and it can be linked to on older libc
- Python when running under devenv has its `manylinux` support runtime binaries injected using `LD_PRELOAD`
- This forces system binaries to use the devenv shipped libc
- This causes an error, if old system binaries are loading new libc

To prevent the problem, use `Python` as a test binary, which is for sure linked to a good libc, making the tests more hermetic

Sample error:

    DEBUG    unblob.extractors.command:command.py:39 {'command': "sh -c '> /run/user/1000/pytest-of-kr/pytest-9/test_command_execution0/created'", 'event': 'Running extract command', 'level': 'debug', 'timestamp': '2024-10-18 13:30.03', 'pid': 31484}
    ERROR    unblob.extractors.command:command.py:67 {'severity': <Severity.WARNING: 'WARNING'>, 'command': "sh -c '> /run/user/1000/pytest-of-kr/pytest-9/test_command_execution0/created'", 'stdout': '', 'stderr': 'sh: symbol lookup error: /nix/store/s0dg13igw8mgzpvmxzd2njk1xwdv21a2-manylinux2014/lib/libc.so.6: undefined symbol: __tunable_is_initialized, version GLIBC_PRIVATE\n', 'exit_code': '0x7f', 'event': 'Extract command failed', 'level': 'error', 'timestamp': '2024-10-18 13:30.03', 'pid': 31484}

cc @e3krisztian 