### PR TITLE
devenv: remove `LD_LIBRARY_PATH` hack from running python environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -182,11 +182,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1728033307,
-        "narHash": "sha256-7+qCx/he1iiDbF7gA9AAAmmKvEvzRoSl8HCtNHkaTgw=",
+        "lastModified": 1730287473,
+        "narHash": "sha256-6bMC/lXMcC4Cl2JrPC934h5/E6cBMQJExv4dK9/Oga8=",
         "owner": "vlaci",
         "repo": "devenv",
-        "rev": "5186fecbe2835ac45018ea4940388f8523bf1624",
+        "rev": "385d38cfb6872e7f95cae30d94f7fc4afd23fd76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
To completely elliminate issues like those which came up in #987 

Flake lock file updates:

• Updated input 'devenv':
    'github:vlaci/devenv/5186fecbe2835ac45018ea4940388f8523bf1624' (2024-10-04)
  → 'github:vlaci/devenv/953a526754c5ff5e64ab6925c4388b26ae2c45c6' (2024-10-30)

From the related PR[^1] in `devenv`:

Injecting `LD_LIBRARY_PATH` to the Python runtime environment is great to bypass the need of having to patch non-nix binaries loaded into that environment, however it breaks down, when Python executes any other program not compiled for the given Nix system, e.g. a shell script via `subprocess`.

To work this around, `devenv` will inject a `pth`[^2] file to the virtual environment it creates, which mangles the `LD_LIBRARY_PATH` variable, undoing any changes to it made by `devenv` but preserving changes from other sources.

[^1]: https://github.com/cachix/devenv/pull/1562
[^2]: https://docs.python.org/3/library/site.html