### PR TITLE
devenv: fix overwriting read-only `.pth` file when dependencies change

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -182,11 +182,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1730287473,
-        "narHash": "sha256-6bMC/lXMcC4Cl2JrPC934h5/E6cBMQJExv4dK9/Oga8=",
+        "lastModified": 1731404779,
+        "narHash": "sha256-FXt/Quz1W9Uae6JhKAVEqM306H4dQk6wSINGBwRaW7g=",
         "owner": "vlaci",
         "repo": "devenv",
-        "rev": "385d38cfb6872e7f95cae30d94f7fc4afd23fd76",
+        "rev": "4caf75b37c5d633fde612cd52bb794bcbf75d24a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This update fixes the following error:

    --- devenv:python:poetry failed with error: Task exited with status: exit status: 1
    --- devenv:python:poetry stdout:
    0001.44: ~/devel/git/github.com/onekey-sec/unblob ~/devel/git/github.com/onekey-sec/unblob
    0000.23: Installing dependencies from lock file
    0000.07:
    0000.07: No dependencies to install or update
    0000.07:
    0000.07: Installing the current project: unblob (24.9.30)
    --- devenv:python:poetry stderr:
    0000.00: cp: cannot create regular file '.venv/lib/python3.12/site-packages/devenv.pth': Permission denied

We are creating a symlink to the nix-store instead of copying a read-only file.

---

Flake lock file updates:

• Updated input 'devenv':
    'github:vlaci/devenv/385d38cfb6872e7f95cae30d94f7fc4afd23fd76' (2024-10-30)
  → 'github:vlaci/devenv/4caf75b37c5d633fde612cd52bb794bcbf75d24a' (2024-11-12)