### PR TITLE
feat(ci): use macos-14 in build-nix.

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -13,7 +13,7 @@ jobs:
             arch: x86_64-linux
           - os: ubuntu-latest
             arch: aarch64-linux
-          - os: macos-12
+          - os: macos-14
             arch: x86_64-darwin
           - os: macos-14
             arch: aarch64-darwin


### PR DESCRIPTION
macos-12 runner are getting phased out, time to update