### PR TITLE
bump version to 24.12.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "unblob"
-version = "24.11.13"
+version = "24.12.4"
 description = "Extract files from any kind of container formats"
 authors = ["ONEKEY <support@onekey.com>"]
 license = "MIT"


### PR DESCRIPTION
Final release with 3.8 support before we merge https://github.com/onekey-sec/unblob/pull/1008 in.