### PR TITLE
fix: overwrite report file rather than unlink it when -f option is set

### DIFF
--- a/unblob/processing.py
+++ b/unblob/processing.py
@@ -194,12 +194,12 @@ def prepare_report_file(config: ExtractionConfig, report_file: Optional[Path]) -
 
     if report_file.exists():
         if config.force_extract:
-            logger.warning("Removing existing report file", path=report_file)
+            logger.warning("Overwriting existing report file", path=report_file)
             try:
-                report_file.unlink()
+                report_file.write_text("")
             except OSError as e:
                 logger.error(
-                    "Can not remove existing report file",
+                    "Can not overwrite existing report file",
                     path=report_file,
                     msg=str(e),
                 )
@@ -209,15 +209,6 @@ def prepare_report_file(config: ExtractionConfig, report_file: Optional[Path]) -
                 "Report file exists and --force not specified", path=report_file
             )
             return False
-
-    # check that the report directory can be written to
-    try:
-        report_file.write_text("")
-        report_file.unlink()
-    except OSError as e:
-        logger.error("Can not create report file", path=report_file, msg=str(e))
-        return False
-
     return True
 
 


### PR DESCRIPTION
Since the introduction of landlock, we only have read-write permissions on the report and log files. We do not have the permission to unlink it, so we overwrite the content instead of unlinking the file.

This is what happens with the current code:

```
unblob -vvv --log unblob.log --report unblob.json -f -k -e /tmp/out /tmp/input/RAXE500-V1.2.13.100_2.0.54.zip 
2024-12-23 09:34.18 [debug    ] Logging configured             extract_root=. pid=126119 vebosity_level=3
2024-12-23 09:34.18 [info     ] Start processing file          file=/tmp/input/RAXE500-V1.2.13.100_2.0.54.zip pid=126119
2024-12-23 09:34.18 [info     ] Activated FS access restrictions; rules=[Read("/"), ReadWrite("/dev/shm"), ReadWrite("/tmp/out"), MakeDir("/tmp"), ReadWrite("unblob.log"), ReadWrite("unblob.json"), MakeReg(".")], status=FullyEnforced pid=126119
2024-12-23 09:34.18 [info     ] Removing extract dir           path=RAXE500-V1.2.13.100_2.0.54.zip_extract pid=126119
2024-12-23 09:34.18 [warning  ] Removing existing report file  path=unblob.json pid=126119
2024-12-23 09:34.18 [error    ] Can not remove existing report file msg=[Errno 13] Permission denied: 'unblob.json' path=unblob.json pid=126119
2024-12-23 09:34.18 [error    ] File not processed, as report could not be written file=/tmp/input/RAXE500-V1.2.13.100_2.0.54.zip pid=126119
```