### PR TITLE
ci: fix setting up arm emulation on Ubuntu Noble

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -32,7 +32,7 @@ jobs:
         if: ${{ matrix.arch == 'aarch64-linux' }}
         run: |
           sudo apt update
-          sudo apt install -q -y qemu-system-aarch64 qemu-efi binfmt-support qemu-user-static
+          sudo apt install -q -y qemu-system-aarch64 qemu-efi-aarch64 binfmt-support qemu-user-static
           mkdir -p ~/.config/nix
           echo "system-features = aarch64-linux arm-linux" | sudo tee -a /etc/nix/nix.conf
       - uses: cachix/cachix-action@v15


### PR DESCRIPTION
The `qemu-efi` package is absent after upgrade.

Rollout is in progress:
https://github.com/actions/runner-images/issues/10636