### PR TITLE
ci: do not try to push docker image to registry for forks

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -69,7 +69,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.output.tags }}
-          outputs: type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.DOCKER_IMAGE }},push-by-digest=true,name-canonical=true,push=${{ github.repository_owner == 'ONEKEY' && 'true' || 'false' }}
 
       - name: Docker container vulnerability scan
         id: scan


### PR DESCRIPTION
... It won't work

before this patch: https://github.com/vlaci/unblob/actions/runs/12636371588
after this patch: https://github.com/vlaci/unblob/actions/runs/12636664151