### PR TITLE
ci: enable required checks to run on merge queue groups

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -1,6 +1,7 @@
 name: "Nix"
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/check-mergeable.yml
+++ b/.github/workflows/check-mergeable.yml
@@ -2,8 +2,7 @@ name: Check branch status
 
 on:
   pull_request:
-    branches:
-      - "**"
+  merge_group:
 
 jobs:
   check_branch_history:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - '**'
+  merge_group:
 
 
 jobs:


### PR DESCRIPTION
Got fed-up by manually forcing approved PRs to get merged

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues