### PR TITLE
ci: Run linear history check only on pull requests

### DIFF
--- a/.github/workflows/check-mergeable.yml
+++ b/.github/workflows/check-mergeable.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   check_branch_history:
+    # We need this job to be scheduled for merge groups as well, as it
+    # is a required status check for merging, but we can safely skip
+    # it...
+    if: ${{ github.event_name == 'pull_request' }}
     name: Check - Linear history
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
`GITHUB_BASE_REF` is not available for merge groups