### PR TITLE
fix(sandbox): add remove_dir permissions to sandbox

### DIFF
--- a/python/unblob/sandbox.py
+++ b/python/unblob/sandbox.py
@@ -51,6 +51,8 @@ class Sandbox:
             AccessFS.read_write("/dev/shm"),  # noqa: S108
             # Extracted contents
             AccessFS.read_write(config.extract_root),
+            AccessFS.remove_dir(config.extract_root),
+            AccessFS.remove_file(config.extract_root),
             AccessFS.make_dir(config.extract_root.parent),
             AccessFS.read_write(log_path),
             *extra_passthrough,


### PR DESCRIPTION
When an extraction directory is empty, unblob will try to delete it.

This can lead to PermissionError due to insufficient permissions within the sandbox.

this needs to land in unblob-native first: https://github.com/onekey-sec/unblob-native/pull/82