### PR TITLE
chore(renovate): do-not autoapprove lz4 updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
       "matchUpdateTypes": ["minor", "patch"],
       "autoApprove": true,
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["lz4"],
+      "prBodyNotes": ":warning: Check aarch64 compatibility :warning:",
+      "autoApprove": false
     }
   ],
   "nix": {


### PR DESCRIPTION
They currently don't provide aarhc64 wheels

https://github.com/python-lz4/python-lz4/pull/298