### PR TITLE
ci: build docker image for dependency updates

### DIFF
--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -51,6 +51,7 @@ jobs:
             type=sha
 
       - name: Set up QEMU
+        if: matrix.platform != 'linux/amd64'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx

--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -1,6 +1,7 @@
 name: Build Docker image
 
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -12,6 +13,7 @@ env:
 
 jobs:
   build-image:
+    if: github.event_name == 'push' || contains(github.event.*.labels.*.name, 'dependencies')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -109,7 +111,7 @@ jobs:
           retention-days: 1
 
   merge-and-push-image:
-    if: github.repository_owner == 'onekey-sec'
+    if: github.repository_owner == 'onekey-sec' && github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
       - build-image


### PR DESCRIPTION
This resolves a blind spot in PR tests. This build won't run when integrating though, but it is a good safety net for renovate PRs

An alternative for #1091 