### PR TITLE
chore(deps): exclude lz4 4.4.3 which has build issues on aarch64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 
 [project]
 authors = [{ name = "ONEKEY", email = "support@onekey.com" }]
+
+# Operators supported: https://packaging.python.org/en/latest/specifications/version-specifiers/#id5
 dependencies = [
   "arpy>=2.3.0",
   "attrs>=23.1.0",
@@ -11,7 +13,7 @@ dependencies = [
   "jefferson>=0.4.5",
   "lark>=1.1.8",
   "lief>=0.16.1",
-  "lz4>=4.3.2",
+  "lz4>=4.3.2,!=4.4.3",        # 4.4.3 doesn't have aarch64 wheels https://github.com/python-lz4/python-lz4/pull/298
   "plotext>=4.2.0,<6.0",
   "pluggy>=1.3.0",
   "pyfatfs>=1.0.5",

--- a/uv.lock
+++ b/uv.lock
@@ -1545,7 +1545,7 @@ requires-dist = [
     { name = "jefferson", specifier = ">=0.4.5" },
     { name = "lark", specifier = ">=1.1.8" },
     { name = "lief", specifier = ">=0.16.1" },
-    { name = "lz4", specifier = ">=4.3.2" },
+    { name = "lz4", specifier = ">=4.3.2,!=4.4.3" },
     { name = "plotext", specifier = ">=4.2.0,<6.0" },
     { name = "pluggy", specifier = ">=1.3.0" },
     { name = "pyfatfs", specifier = ">=1.0.5" },


### PR DESCRIPTION
It has build issues on Ubuntu Noble for aarch64, so no wheels are published upstream:

         gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -Ilz4libs -I/opt/_internal/cpython-3.9.20/include/python3.9 -c lz4libs/lz4.c -o build/temp.linux-aarch64-cpython-39/lz4libs/lz4.o -O3 -Wall -Wundef
        gcc: internal compiler error: Segmentation fault signal terminated program cc1

We will see if the issue is fixed in future updates.