### PR TITLE
ci: fix docker registry permission

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -276,6 +276,8 @@ jobs:
     name: Build Docker image
     if: github.event_name == 'push' || contains(github.event.*.labels.*.name, 'dependencies')
     needs: [build_linux_wheels]
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
The default permission of the job has been restricted, so we need to opt-in for a higher permission level in the docker image builder job.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token