### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -453,7 +453,7 @@ jobs:
           subject-path: dist/*
 
       - name: Publish to PyPI
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') }} || (github.event_name == 'workflow_dispatch' && github.event.inputs.test_release)
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_release && secrets.TEST_PYPI_API_TOKEN || secrets.POETRY_PYPI_TOKEN_PYPI }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -443,7 +443,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          pattern: wheel-*
+          pattern: wheels-*
           path: dist
           merge-multiple: true
 


### PR DESCRIPTION
There was an embarrassing typo :facepalm: 

Working release on test.pypi.org:
https://github.com/onekey-sec/unblob/actions/runs/13141599655/job/36670318634