### PR TITLE
chore(sandbox): export `AccessFS` constants

### DIFF
--- a/python/unblob/sandbox.py
+++ b/python/unblob/sandbox.py
@@ -8,7 +8,9 @@ from typing import Callable, Optional, TypeVar
 from structlog import get_logger
 
 from unblob._rust.sandbox import (
-    AccessFS,
+    AccessFS as AccessFS,
+)
+from unblob._rust.sandbox import (
     SandboxError,
     restrict_access,
 )


### PR DESCRIPTION
Library users need it. Let's give it a better canonical place than `unblob._rust.sandbox`.

As `unblob` is a py.typed package, importing from non-exported locations are flagged by type checkers.