### PR TITLE
Export rust types

### DIFF
--- a/python/unblob/__init__.py
+++ b/python/unblob/__init__.py
@@ -1,0 +1,1 @@
+from unblob._rust import math_tools as math_tools

--- a/python/unblob/processing.py
+++ b/python/unblob/processing.py
@@ -10,7 +10,7 @@ import magic
 import plotext as plt
 from structlog import get_logger
 
-from unblob._rust import math_tools as mt
+from unblob import math_tools as mt
 from unblob.handlers import BUILTIN_DIR_HANDLERS, BUILTIN_HANDLERS, Handlers
 
 from .extractor import carve_unknown_chunk, carve_valid_chunk, fix_extracted_directory

--- a/python/unblob/sandbox.py
+++ b/python/unblob/sandbox.py
@@ -7,17 +7,20 @@ from typing import Callable, Optional, TypeVar
 
 from structlog import get_logger
 
-from unblob._rust.sandbox import (
-    AccessFS,
-    SandboxError,
-    restrict_access,
-)
-
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
 else:
     from typing_extensions import ParamSpec
 
+from unblob._rust.sandbox import (
+    AccessFS as AccessFS,
+)
+from unblob._rust.sandbox import (
+    SandboxError as SandboxError,
+)
+from unblob._rust.sandbox import (
+    restrict_access as restrict_access,
+)
 from unblob.processing import ExtractionConfig
 
 logger = get_logger()

--- a/python/unblob/testing.py
+++ b/python/unblob/testing.py
@@ -12,12 +12,12 @@ from lark.lark import Lark
 from lark.visitors import Discard, Transformer
 from pytest_cov.embed import cleanup_on_sigterm
 
-from unblob._rust.sandbox import AccessFS, SandboxError, restrict_access
 from unblob.finder import build_hyperscan_database
 from unblob.logging import configure_logger
 from unblob.models import ProcessResult
 from unblob.processing import ExtractionConfig
 from unblob.report import ExtractCommandFailedReport
+from unblob.sandbox import AccessFS, SandboxError, restrict_access
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
Given them a nice canonical place to import them from. Both internally and for external consumers of unblob API.