### PR TITLE
chore(renovate): PyO3 packages are interdependent

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
       "matchUpdateTypes": ["minor", "patch"],
       "autoApprove": true,
       "automerge": true
+    },
+    {
+      "groupName": "PyO3",
+      "matchCategories": ["rust"],
+      "matchPackageNames": ["pyo3*"]
     }
   ],
   "nix": {


### PR DESCRIPTION
See issues with:

- https://github.com/onekey-sec/unblob/pull/1110
- https://github.com/onekey-sec/unblob/pull/1111