### PR TITLE
fix(report): adapt landlock passthrough for report file

### DIFF
--- a/python/unblob/processing.py
+++ b/python/unblob/processing.py
@@ -209,6 +209,11 @@ def prepare_report_file(config: ExtractionConfig, report_file: Optional[Path]) -
                 "Report file exists and --force not specified", path=report_file
             )
             return False
+    if not report_file.parent.exists():
+        logger.error(
+            "Trying to write report file to a non-existent directory", path=report_file
+        )
+        return False
     return True
 
 

--- a/python/unblob/sandbox.py
+++ b/python/unblob/sandbox.py
@@ -58,8 +58,7 @@ class Sandbox:
 
         if report_file:
             self.passthrough += [
-                AccessFS.read_write(report_file),
-                AccessFS.make_reg(report_file.parent),
+                AccessFS.read_write(report_file.parent),
             ]
 
     def run(self, callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:


### PR DESCRIPTION
Report writing only worked if the report was being written to a child location of the extract directory. This was a byproduct of setting rw permissions on the extraction directory.

It did not work when the report file was being written to a location that is unrelated to the extraction directory.

Fixed by requesting rw access to the report's file parent directory.

I tried to get smart by only allowing make_reg and read_write on the file, but it never fully worked because of file truncation and the fact that LANDLOCK_ACCESS_FS_TRUNCATE is only available since ABI version 3 in landlock.

Solves #1101 