### PR TITLE
fix(tests): run handlers integration tests in landlock sandbox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ paths = ["python/", "vulture_whitelist.py"]
 
 [tool.pyright]
 exclude = [
+  ".devenv",
   ".venv",
   "build",
 ]

--- a/python/unblob/testing.py
+++ b/python/unblob/testing.py
@@ -1,7 +1,6 @@
 import binascii
 import glob
 import io
-import platform
 import shlex
 import subprocess
 from pathlib import Path
@@ -17,7 +16,6 @@ from unblob.logging import configure_logger
 from unblob.models import ProcessResult
 from unblob.processing import ExtractionConfig
 from unblob.report import ExtractCommandFailedReport
-from unblob.sandbox import AccessFS, SandboxError, restrict_access
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -219,17 +217,3 @@ class _HexDumpToBin(Transformer):
             rv.write(line.data)
 
         return rv.getvalue()
-
-
-def is_sandbox_available():
-    is_sandbox_available = True
-
-    try:
-        restrict_access(AccessFS.read_write("/"))
-    except SandboxError:
-        is_sandbox_available = False
-
-    if platform.architecture == "x86_64" and platform.system == "linux":
-        assert is_sandbox_available, "Sandboxing should work at least on Linux-x86_64"
-
-    return is_sandbox_available

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import pytest
 from click.testing import CliRunner
 
 import unblob.cli
+from rust.test_sandbox import landlock_supported
 from unblob.extractors import Command
 from unblob.extractors.command import MultiFileCommand
 from unblob.handlers import BUILTIN_HANDLERS
@@ -18,7 +19,6 @@ from unblob.processing import (
     DEFAULT_SKIP_MAGIC,
     ExtractionConfig,
 )
-from unblob.testing import is_sandbox_available
 from unblob.ui import (
     NullProgressReporter,
     ProgressReporter,
@@ -431,7 +431,7 @@ def test_clear_skip_magics(
 
 
 @pytest.mark.skipif(
-    not is_sandbox_available(), reason="Sandboxing is only available on Linux"
+    not landlock_supported(), reason="Sandboxing is only available on Linux"
 )
 def test_sandbox_escape(tmp_path: Path):
     runner = CliRunner()

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 import pytest
 
+from rust.test_sandbox import landlock_supported
 from unblob.processing import ExtractionConfig
 from unblob.sandbox import Sandbox
-from unblob.testing import is_sandbox_available
 
 pytestmark = pytest.mark.skipif(
-    not is_sandbox_available(), reason="Sandboxing only works on Linux"
+    not landlock_supported(), reason="Sandboxing only works on Linux"
 )
 
 


### PR DESCRIPTION
Handlers tests were not previously run within the landlock sandbox, and even if it was they would have full access to the filesystem since our `is_sandbox_available()` was checking for landlock's API availability by requesting read-write access to '/'.

It's now fixed by:
- running `is_sandbox_available()` within its own thread, not to pollute the main thread
- run integration tests within the sandbox, one sandboxed thread per handler

The objective is to identify early any issues we may get into when running extraction within the sandbox.