### PR TITLE
Devenv update

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1,6 +1,5 @@
 {
   config,
-  lib,
   pkgs,
   ...
 }:
@@ -22,6 +21,11 @@
         "--group"
         "dev"
       ];
+    };
+    # https://github.com/vlaci/devenv-extras
+    extras = {
+      auto-patchelf.enable = true;
+      clear-ldpath.enable = true;
     };
   };
   languages.rust.enable = true;
@@ -45,15 +49,6 @@
           exit 1
         fi
         ln -snf "${config.devenv.state}/venv" "${config.devenv.root}/.venv"
-      '';
-      after = [ "devenv:python:uv" ];
-      before = [ "devenv:enterShell" ];
-    };
-    "venv:patchelf" = {
-      exec = ''
-        for exe in taplo ruff; do
-          ${lib.getExe pkgs.patchelf} --set-interpreter ${pkgs.stdenv.cc.bintools.dynamicLinker} "${config.devenv.state}/venv/bin/$exe"
-        done
       '';
       after = [ "devenv:python:uv" ];
       before = [ "devenv:enterShell" ];

--- a/flake.lock
+++ b/flake.lock
@@ -2,66 +2,28 @@
   "nodes": {
     "cachix": {
       "inputs": {
-        "devenv": "devenv_2",
+        "devenv": [
+          "devenv"
+        ],
         "flake-compat": [
-          "devenv",
-          "flake-compat"
+          "devenv"
         ],
         "git-hooks": [
-          "devenv",
-          "pre-commit-hooks"
+          "devenv"
         ],
-        "nixpkgs": [
-          "devenv",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1726520618,
-        "narHash": "sha256-jOsaBmJ/EtX5t/vbylCdS7pWYcKGmWOKg4QKUzKr6dA=",
+        "lastModified": 1737621947,
+        "narHash": "sha256-8HFvG7fvIFbgtaYAY2628Tb89fA55nPm2jSiNs0/Cws=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "695525f9086542dfb09fde0871dbf4174abbf634",
+        "rev": "f65a3cd5e339c223471e64c051434616e18cc4f5",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "repo": "cachix",
-        "type": "github"
-      }
-    },
-    "cachix_2": {
-      "inputs": {
-        "devenv": "devenv_3",
-        "flake-compat": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "flake-compat"
-        ],
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "nixpkgs"
-        ],
-        "pre-commit-hooks": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "pre-commit-hooks"
-        ]
-      },
-      "locked": {
-        "lastModified": 1712055811,
-        "narHash": "sha256-7FcfMm5A/f02yyzuavJe06zLa9hcMHsagE28ADcmQvk=",
-        "owner": "cachix",
-        "repo": "cachix",
-        "rev": "02e38da89851ec7fec3356a5c04bc8349cae0e30",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
+        "ref": "latest",
         "repo": "cachix",
         "type": "github"
       }
@@ -69,94 +31,39 @@
     "devenv": {
       "inputs": {
         "cachix": "cachix",
-        "flake-compat": "flake-compat_2",
-        "nix": "nix_3",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "pre-commit-hooks": "pre-commit-hooks_2"
-      },
-      "locked": {
-        "lastModified": 1731404779,
-        "narHash": "sha256-FXt/Quz1W9Uae6JhKAVEqM306H4dQk6wSINGBwRaW7g=",
-        "owner": "vlaci",
-        "repo": "devenv",
-        "rev": "4caf75b37c5d633fde612cd52bb794bcbf75d24a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vlaci",
-        "ref": "python-wrapper",
-        "repo": "devenv",
-        "type": "github"
-      }
-    },
-    "devenv_2": {
-      "inputs": {
-        "cachix": "cachix_2",
-        "flake-compat": [
-          "devenv",
-          "cachix",
-          "flake-compat"
-        ],
-        "nix": "nix_2",
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "nixpkgs"
-        ],
-        "pre-commit-hooks": [
-          "devenv",
-          "cachix",
-          "git-hooks"
-        ]
-      },
-      "locked": {
-        "lastModified": 1723156315,
-        "narHash": "sha256-0JrfahRMJ37Rf1i0iOOn+8Z4CLvbcGNwa2ChOAVrp/8=",
-        "owner": "cachix",
-        "repo": "devenv",
-        "rev": "ff5eb4f2accbcda963af67f1a1159e3f6c7f5f91",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "devenv",
-        "type": "github"
-      }
-    },
-    "devenv_3": {
-      "inputs": {
-        "flake-compat": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "cachix",
-          "flake-compat"
-        ],
+        "flake-compat": "flake-compat",
+        "git-hooks": "git-hooks",
         "nix": "nix",
-        "nixpkgs": "nixpkgs",
-        "poetry2nix": "poetry2nix",
-        "pre-commit-hooks": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "cachix",
-          "pre-commit-hooks"
+        "nixpkgs": [
+          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1708704632,
-        "narHash": "sha256-w+dOIW60FKMaHI1q5714CSibk99JfYxm0CzTinYWr+Q=",
+        "lastModified": 1739362938,
+        "narHash": "sha256-maOZUVjYwQEICzzFUGy9UPekSEMLx9cdm8UWEDpf24A=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "2ee4450b0f4b95a1b90f2eb5ffea98b90e48c196",
+        "rev": "27276816caa1718f8b8e8d53d64cc18da059e101",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "python-rewrite",
         "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "devenv-extras": {
+      "locked": {
+        "lastModified": 1739382960,
+        "narHash": "sha256-R3uMsE8S5H5U/2zLK34mSYK7gQrVkiFAsv+89vfiB7A=",
+        "owner": "vlaci",
+        "repo": "devenv-extras",
+        "rev": "0cd66ae6f20f9ba0a9b169df5052efaf8e13083c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vlaci",
+        "repo": "devenv-extras",
         "type": "github"
       }
     },
@@ -178,22 +85,6 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
         "lastModified": 1696426674,
         "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
@@ -207,7 +98,7 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1733328505,
@@ -245,36 +136,28 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "git-hooks": {
       "inputs": {
-        "systems": "systems"
+        "flake-compat": [
+          "devenv"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
         "type": "github"
       }
     },
@@ -282,7 +165,7 @@
       "inputs": {
         "nixpkgs": [
           "devenv",
-          "pre-commit-hooks",
+          "git-hooks",
           "nixpkgs"
         ]
       },
@@ -318,101 +201,21 @@
     },
     "nix": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "cachix",
-          "devenv",
-          "nixpkgs"
-        ],
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1712911606,
-        "narHash": "sha256-BGvBhepCufsjcUkXnEEXhEVjwdJAwPglCC2+bInc794=",
-        "owner": "domenkozar",
-        "repo": "nix",
-        "rev": "b24a9318ea3f3600c1e24b4a00691ee912d4de12",
-        "type": "github"
-      },
-      "original": {
-        "owner": "domenkozar",
-        "ref": "devenv-2.21",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix-github-actions": {
-      "inputs": {
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "cachix",
-          "devenv",
-          "poetry2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1688870561,
-        "narHash": "sha256-4UYkifnPEw1nAzqqPOTL2MvWtm3sNGw1UTYTalkTcGY=",
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "rev": "165b1650b753316aa7f1787f3005a8d2da0f5301",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "type": "github"
-      }
-    },
-    "nix_2": {
-      "inputs": {
         "flake-compat": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "flake-compat"
-        ],
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "nixpkgs"
-        ],
-        "nixpkgs-regression": "nixpkgs-regression_2"
-      },
-      "locked": {
-        "lastModified": 1712911606,
-        "narHash": "sha256-BGvBhepCufsjcUkXnEEXhEVjwdJAwPglCC2+bInc794=",
-        "owner": "domenkozar",
-        "repo": "nix",
-        "rev": "b24a9318ea3f3600c1e24b4a00691ee912d4de12",
-        "type": "github"
-      },
-      "original": {
-        "owner": "domenkozar",
-        "ref": "devenv-2.21",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix_3": {
-      "inputs": {
-        "flake-compat": [
-          "devenv",
-          "flake-compat"
+          "devenv"
         ],
         "flake-parts": "flake-parts",
         "libgit2": "libgit2",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-23-11": "nixpkgs-23-11",
-        "nixpkgs-regression": "nixpkgs-regression_3",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "nixpkgs-23-11": [
+          "devenv"
+        ],
+        "nixpkgs-regression": [
+          "devenv"
+        ],
+        "pre-commit-hooks": [
+          "devenv"
+        ]
       },
       "locked": {
         "lastModified": 1727438425,
@@ -431,96 +234,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692808169,
-        "narHash": "sha256-x9Opq06rIiwdwGeK2Ykj69dNc2IvUH1fY55Wm7atwrE=",
+        "lastModified": 1739214665,
+        "narHash": "sha256-26L8VAu3/1YRxS8MHgBOyOM8xALdo6N0I04PgorE7UM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9201b5ff357e781bf014d0330d18555695df7ba8",
+        "rev": "64e75cd44acf21c7933d61d7721e812eac1b5a0a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-23-11": {
-      "locked": {
-        "lastModified": 1717159533,
-        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression_2": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression_3": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -557,117 +280,13 @@
         "type": "github"
       }
     },
-    "poetry2nix": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nix-github-actions": "nix-github-actions",
-        "nixpkgs": [
-          "devenv",
-          "cachix",
-          "devenv",
-          "cachix",
-          "devenv",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1692876271,
-        "narHash": "sha256-IXfZEkI0Mal5y1jr6IRWMqK8GW2/f28xJenZIPQqkY0=",
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "rev": "d5006be9c2c2417dafb2e2e5034d83fabd207ee3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "devenv",
-          "nix"
-        ],
-        "flake-utils": "flake-utils_2",
-        "gitignore": [
-          "devenv",
-          "nix"
-        ],
-        "nixpkgs": [
-          "devenv",
-          "nix",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "devenv",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1712897695,
-        "narHash": "sha256-nMirxrGteNAl9sWiOhoN5tIHyjBbVi5e2tgZUgZlK3Y=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "40e6053ecb65fcbf12863338a6dcefb3f55f1bf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks_2": {
-      "inputs": {
-        "flake-compat": [
-          "devenv",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "devenv",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
-      },
-      "locked": {
-        "lastModified": 1726745158,
-        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "devenv": "devenv",
+        "devenv-extras": "devenv-extras",
         "filter": "filter",
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_2",
         "nixpkgs": "nixpkgs_3"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,11 @@
     flake = false;
   };
   inputs.devenv = {
-    url = "github:vlaci/devenv/python-wrapper";
+    url = "github:cachix/devenv";
     inputs.nixpkgs.follows = "nixpkgs";
   };
+
+  inputs.devenv-extras.url = "github:vlaci/devenv-extras";
 
   nixConfig = {
     extra-substituters = [ "https://unblob.cachix.org" ];
@@ -24,6 +26,7 @@
       self,
       nixpkgs,
       devenv,
+      devenv-extras,
       filter,
       ...
     }@inputs:
@@ -109,6 +112,7 @@
           pkgs = nixpkgsFor.${system};
           modules = [
             ./devenv.nix
+            devenv-extras.devenvModules.default
           ];
         };
       });


### PR DESCRIPTION
Figured out a way to switch to upstream devenv version. Also, I've split out the compatibility ~~hacks~~ improvements to a separate repo reusable across projects.

Flake dependencies are simplified a lot, as the circular cachix <-> devenv dependencies have been solved upstream:

```
    • Updated input 'devenv':
        'github:vlaci/devenv/4caf75b37c5d633fde612cd52bb794bcbf75d24a' (2024-11-12)
      → 'github:cachix/devenv/6c987a8795eedea872afe4d1c1ac518d0c7f6db1' (2025-02-11)
    • Updated input 'devenv/cachix':
        'github:cachix/cachix/695525f9086542dfb09fde0871dbf4174abbf634' (2024-09-16)
      → 'github:cachix/cachix/f65a3cd5e339c223471e64c051434616e18cc4f5' (2025-01-23)
    • Updated input 'devenv/cachix/devenv':
        'github:cachix/devenv/ff5eb4f2accbcda963af67f1a1159e3f6c7f5f91' (2024-08-08)
      → follows 'devenv'
    • Removed input 'devenv/cachix/devenv/cachix'
    • Removed input 'devenv/cachix/devenv/cachix/devenv'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/flake-compat'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/nix'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/nix/flake-compat'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/nix/nixpkgs'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/nix/nixpkgs-regression'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/nixpkgs'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/poetry2nix'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/poetry2nix/flake-utils'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/poetry2nix/flake-utils/systems'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/poetry2nix/nix-github-actions'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/poetry2nix/nix-github-actions/nixpkgs'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/poetry2nix/nixpkgs'
    • Removed input 'devenv/cachix/devenv/cachix/devenv/pre-commit-hooks'
    • Removed input 'devenv/cachix/devenv/cachix/flake-compat'
    • Removed input 'devenv/cachix/devenv/cachix/nixpkgs'
    • Removed input 'devenv/cachix/devenv/cachix/pre-commit-hooks'
    • Removed input 'devenv/cachix/devenv/flake-compat'
    • Removed input 'devenv/cachix/devenv/nix'
    • Removed input 'devenv/cachix/devenv/nix/flake-compat'
    • Removed input 'devenv/cachix/devenv/nix/nixpkgs'
    • Removed input 'devenv/cachix/devenv/nix/nixpkgs-regression'
    • Removed input 'devenv/cachix/devenv/nixpkgs'
    • Removed input 'devenv/cachix/devenv/pre-commit-hooks'
    • Updated input 'devenv/cachix/flake-compat':
        follows 'devenv/flake-compat'
      → follows 'devenv'
    • Updated input 'devenv/cachix/git-hooks':
        follows 'devenv/pre-commit-hooks'
      → follows 'devenv'
    • Removed input 'devenv/cachix/devenv/pre-commit-hooks'
    • Updated input 'devenv/cachix/flake-compat':
        follows 'devenv/flake-compat'
      → follows 'devenv'
    • Updated input 'devenv/cachix/git-hooks':
        follows 'devenv/pre-commit-hooks'
      → follows 'devenv'
    • Updated input 'devenv/cachix/nixpkgs':
        follows 'devenv/nixpkgs'
      → 'github:NixOS/nixpkgs/64e75cd44acf21c7933d61d7721e812eac1b5a0a' (2025-02-10)
    • Added input 'devenv/git-hooks':
        'github:cachix/git-hooks.nix/9364dc02281ce2d37a1f55b6e51f7c0f65a75f17' (2025-01-21)
    • Added input 'devenv/git-hooks/flake-compat':
        follows 'devenv'
    • Added input 'devenv/git-hooks/gitignore':
        'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394' (2024-02-28)
    • Added input 'devenv/git-hooks/gitignore/nixpkgs':
        follows 'devenv/git-hooks/nixpkgs'
    • Added input 'devenv/git-hooks/nixpkgs':
        follows 'devenv/nixpkgs'
    • Updated input 'devenv/nix/flake-compat':
        follows 'devenv/flake-compat'
      → follows 'devenv'
    • Updated input 'devenv/nix/nixpkgs-23-11':
        'github:NixOS/nixpkgs/a62e6edd6d5e1fa0329b8653c801147986f8d446' (2024-05-31)
      → follows 'devenv'
    • Updated input 'devenv/nix/nixpkgs-regression':
        'github:NixOS/nixpkgs/215d4d0fd80ca5163643b03a33fde804a29cc1e2' (2022-01-24)
      → follows 'devenv'
    • Updated input 'devenv/nix/pre-commit-hooks':
        'github:cachix/pre-commit-hooks.nix/40e6053ecb65fcbf12863338a6dcefb3f55f1bf8' (2024-04-12)
      → follows 'devenv'
    • Removed input 'devenv/nix/pre-commit-hooks/flake-compat'
    • Removed input 'devenv/nix/pre-commit-hooks/flake-utils'
    • Removed input 'devenv/nix/pre-commit-hooks/gitignore'
    • Removed input 'devenv/nix/pre-commit-hooks/nixpkgs'
    • Removed input 'devenv/nix/pre-commit-hooks/nixpkgs-stable'
    • Removed input 'devenv/pre-commit-hooks'
    • Removed input 'devenv/pre-commit-hooks/flake-compat'
    • Removed input 'devenv/pre-commit-hooks/gitignore'
    • Removed input 'devenv/pre-commit-hooks/gitignore/nixpkgs'
    • Removed input 'devenv/pre-commit-hooks/nixpkgs'
    • Removed input 'devenv/pre-commit-hooks/nixpkgs-stable'
    • Added input 'devenv-extras':
        'github:vlaci/devenv-extras/9c47b8a3480bf7a38e1ef4b8cbfab78efbb6fc8a' (2025-02-12)
```