### PR TITLE
fix(processing): adapt is_padding to fix potential MemoryError

### DIFF
--- a/python/unblob/processing.py
+++ b/python/unblob/processing.py
@@ -462,7 +462,18 @@ class _DirectoryTask:
 
 
 def is_padding(file: File, chunk: UnknownChunk):
-    return len(set(file[chunk.start_offset : chunk.end_offset])) == 1
+    chunk_bytes = set()
+
+    for small_chunk in iterate_file(
+        file, chunk.start_offset, chunk.end_offset - chunk.start_offset
+    ):
+        chunk_bytes.update(small_chunk)
+
+        # early return optimization
+        if len(chunk_bytes) > 1:
+            return False
+
+    return len(chunk_bytes) == 1
 
 
 def process_patterns(


### PR DESCRIPTION
If an unknown chunk is larger than available RAM on the system where unblob is run, the previous is_padding implementation could lead to `MemoryError` as it tries to load everything in memory.

Fixed by iterating over the unknown chunk with `iterate_file` and using `all()` so we break as soon as we have different bytes.