### PR TITLE
feat(handler): add erofs filesystem & decompression handler

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -97,6 +97,7 @@ For compression formats, metadata cannot be preserved, as this information in mo
 | ---------------------- | ---------------------------------- | ----------------------------------------------- | ----------------------------------------------- |
 | Android sparse image   | ❌                                 | [filesystem/android/sparse.py][android-handler] | [`simg2img`][android-extractor]                 |
 | CRAMFS                 | ✅                                 | [filesystem/cramfs.py][cramfs-handler]          | [`7z`][cramfs-extractor]                        |
+| EROFS                  | ✅                                 | [filesystem/android/erofs.py][erofs-handler]    | [`fsck.erfos`][erofs-extractor]                 | 
 | ExtFS                  | ✅                                 | [filesystem/extfs.py][extfs-handler]            | [`debugfs`][extfs-extractor]                    |
 | FAT                    | ✅                                 | [filesystem/fat.py][fat-handler]                | [`7z`][fat-extractor]                           |
 | ISO9660                | ✅                                 | [filesystem/iso9660.py][iso9660-handler]        | [`7z`][iso9660-extractor]                       |
@@ -107,12 +108,14 @@ For compression formats, metadata cannot be preserved, as this information in mo
 | SquashFS v4 Big Endian | ✅                                 | [filesystem/squashfs.py][squashfs-handler]      | [`sasquatch-v4-be`][squashfs-v4-be-extractor]   |
 | UBI                    | ✅                                 | [filesystem/ubi.py][ubi-handler]                | [`ubireader_extract_images`][ubi-extractor]     |
 | UBIFS                  | ✅                                 | [filesystem/ubi.py][ubi-handler]                | [`ubireader_extract_files`][ubifs-extractor]    |
-| YAFFS (1, 2)           | ✅                                 | [filesystem/yaffs.py][yaffs-handler]            | [`YAFFSExtractor` custom code][yaffs-extractor]                   |
+| YAFFS (1, 2)           | ✅                                 | [filesystem/yaffs.py][yaffs-handler]            | [`YAFFSExtractor` custom code][yaffs-extractor] |
 
 [android-handler]: https://github.com/onekey-sec/unblob/blob/main/unblob/handlers/filesystem/android/sparse.py
 [android-extractor]: https://github.com/onekey-sec/unblob/blob/3008039881a0434deb75962e7999b7e35aca8271/unblob/handlers/filesystem/android/sparse.py#L61
 [cramfs-handler]: https://github.com/onekey-sec/unblob/blob/main/unblob/handlers/filesystem/cramfs.py
 [cramfs-extractor]: https://github.com/onekey-sec/unblob/blob/3008039881a0434deb75962e7999b7e35aca8271/unblob/handlers/filesystem/cramfs.py#L45
+[erofs-handler]: https://github.com/onekey-sec/unblob/blob/main/unblob/handlers/filesystem/android/erfos.py
+[erofs-extractor]: https://github.com/onekey-sec/unblob/blob/main/unblob/handlers/filesystem/android/erfos.py#L45
 [extfs-handler]: https://github.com/onekey-sec/unblob/blob/main/unblob/handlers/filesystem/extfs.py
 [extfs-extractor]: https://github.com/onekey-sec/unblob/blob/3008039881a0434deb75962e7999b7e35aca8271/unblob/handlers/filesystem/extfs.py#L68
 [fat-handler]: https://github.com/onekey-sec/unblob/blob/main/unblob/handlers/filesystem/fat.py

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -5,6 +5,7 @@ apt-get update
 apt-get install --no-install-recommends -y \
     android-sdk-libsparse-utils \
     curl \
+    erofs-utils \
     lz4 \
     lziprecover \
     lzop \

--- a/overlay.nix
+++ b/overlay.nix
@@ -8,42 +8,5 @@ final: prev:
     nativeCheckInputs = (super.nativeCheckInputs or [ ]) ++ [ final.which ];
   });
 
-  unblob =
-    let
-      pyproject_toml = (builtins.fromTOML (builtins.readFile ./pyproject.toml));
-      version = pyproject_toml.project.version;
-    in
-    (prev.unblob.override { e2fsprogs = final.e2fsprogs-nofortify; }).overridePythonAttrs (super: rec {
-      inherit version;
-
-      src = final.nix-filter {
-        root = ./.;
-        include = [
-          "Cargo.lock"
-          "Cargo.toml"
-          "pyproject.toml"
-          "python"
-          "rust"
-          "tests"
-          "README.md"
-        ];
-      };
-
-      dependencies = (super.dependencies or [ ]) ++ [ final.python3.pkgs.pyzstd ];
-
-      # remove this when packaging changes are upstreamed
-      cargoDeps = final.rustPlatform.importCargoLock {
-        lockFile = ./Cargo.lock;
-      };
-
-      nativeBuildInputs = with final.rustPlatform; [
-        cargoSetupHook
-        maturinBuildHook
-      ];
-
-      # override disabling of 'test_all_handlers[filesystem.extfs]' from upstream
-      pytestFlagsArray = [
-        "--no-cov"
-      ];
-    });
+  unblob = final.callPackage ./package.nix { };
 }

--- a/package.nix
+++ b/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   e2fsprogs-nofortify,
+  erofs-utils,
   jefferson,
   lz4,
   lziprecover,
@@ -24,6 +25,7 @@ let
   # These dependencies are only added to PATH
   runtimeDeps = [
     e2fsprogs-nofortify
+    erofs-utils
     jefferson
     lziprecover
     lzop

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,129 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  makeWrapper,
+  e2fsprogs-nofortify,
+  jefferson,
+  lz4,
+  lziprecover,
+  lzop,
+  p7zip,
+  nix-filter,
+  sasquatch,
+  sasquatch-v4be,
+  simg2img,
+  ubi_reader,
+  unar,
+  zstd,
+  versionCheckHook,
+  rustPlatform,
+}:
+
+let
+  # These dependencies are only added to PATH
+  runtimeDeps = [
+    e2fsprogs-nofortify
+    jefferson
+    lziprecover
+    lzop
+    p7zip
+    sasquatch
+    sasquatch-v4be
+    ubi_reader
+    simg2img
+    unar
+    zstd
+    lz4
+  ];
+  pyproject_toml = (builtins.fromTOML (builtins.readFile ./pyproject.toml));
+  version = pyproject_toml.project.version;
+in
+python3.pkgs.buildPythonApplication rec {
+  pname = "unblob";
+  pyproject = true;
+  disabled = python3.pkgs.pythonOlder "3.9";
+  inherit version;
+  src = nix-filter {
+    root = ./.;
+    include = [
+      "Cargo.lock"
+      "Cargo.toml"
+      "pyproject.toml"
+      "python"
+      "rust"
+      "tests"
+      "README.md"
+    ];
+  };
+
+  strictDeps = true;
+
+  build-system = with python3.pkgs; [ poetry-core ];
+
+  dependencies = with python3.pkgs; [
+    arpy
+    attrs
+    click
+    cryptography
+    dissect-cstruct
+    lark
+    lief.py
+    python3.pkgs.lz4 # shadowed by pkgs.lz4
+    plotext
+    pluggy
+    pyfatfs
+    pyperscan
+    python-magic
+    pyzstd
+    rarfile
+    rich
+    structlog
+    treelib
+    unblob-native
+  ];
+
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = ./Cargo.lock;
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+    makeWrapper
+  ];
+
+  # These are runtime-only CLI dependencies, which are used through
+  # their CLI interface
+  pythonRemoveDeps = [
+    "jefferson"
+    "ubi-reader"
+  ];
+
+  pythonImportsCheck = [ "unblob" ];
+
+  makeWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath runtimeDeps}"
+  ];
+
+  nativeCheckInputs =
+    with python3.pkgs;
+    [
+      pytestCheckHook
+      pytest-cov
+      versionCheckHook
+    ]
+    ++ runtimeDeps;
+
+  versionCheckProgramArg = "--version";
+
+  pytestFlagsArray = [
+    "--no-cov"
+  ];
+
+  passthru = {
+    # helpful to easily add these to a nix-shell environment
+    inherit runtimeDeps;
+  };
+
+}

--- a/python/unblob/handlers/__init__.py
+++ b/python/unblob/handlers/__init__.py
@@ -49,7 +49,7 @@ from .filesystem import (
     ubi,
     yaffs,
 )
-from .filesystem.android import sparse
+from .filesystem.android import erofs, sparse
 
 BUILTIN_HANDLERS: Handlers = (
     cramfs.CramFSHandler,
@@ -118,6 +118,7 @@ BUILTIN_HANDLERS: Handlers = (
     engenius.EngeniusHandler,
     ecc.AutelECCHandler,
     uzip.UZIPHandler,
+    erofs.EROFSHandler,
 )
 
 BUILTIN_DIR_HANDLERS: DirectoryHandlers = (

--- a/python/unblob/handlers/filesystem/android/erofs.py
+++ b/python/unblob/handlers/filesystem/android/erofs.py
@@ -1,0 +1,76 @@
+import io
+from typing import Optional
+
+from unblob.extractors import Command
+from unblob.file_utils import (
+    Endian,
+    InvalidInputFormat,
+    snull,
+)
+from unblob.models import (
+    File,
+    HexString,
+    StructHandler,
+    ValidChunk,
+)
+
+C_DEFINITIONS = r"""
+    typedef struct erofs_handler{
+        uint32_t magic;
+        uint32_t crc32c;
+        uint32_t feature_compact;
+        uint8_t block_size_bs;
+        uint8_t sb_extslots;
+        uint16_t root_nid;
+        uint64_t inos;
+        uint64_t build_time;
+        uint32_t build_time_nsec;
+        uint32_t block_count;
+        uint32_t meta_blkaddr;
+        uint32_t xattr_blkaddr;
+        uint8_t uuid[16];
+        char volume_name[16];
+        uint32_t feature_incompact;
+        char reserved[44];
+    } erofs_handler_t;
+"""
+
+SUPERBLOCK_OFFSET = 0x400
+
+
+class EROFSHandler(StructHandler):
+    NAME = "erofs"
+    PATTERNS = [HexString("e2 e1 f5 e0")]  # Magic in little endian
+    HEADER_STRUCT = "erofs_handler_t"
+    C_DEFINITIONS = C_DEFINITIONS
+    EXTRACTOR = Command(
+        "fsck.erofs",
+        "--no-preserve",
+        "--extract={outdir}",
+        "{inpath}",
+    )
+    PATTERN_MATCH_OFFSET = -SUPERBLOCK_OFFSET
+
+    def is_valid_header(self, header) -> bool:
+        try:
+            snull(header.volume_name).decode("utf-8")
+        except UnicodeDecodeError:
+            return False
+        return (
+            header.block_count >= 1
+            and header.build_time > 0
+            and header.build_time_nsec > 0
+            and header.block_size_bs >= 9
+        )
+
+    def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
+        file.seek(start_offset + SUPERBLOCK_OFFSET, io.SEEK_SET)
+        header = self.parse_header(file, Endian.LITTLE)
+        if not self.is_valid_header(header):
+            raise InvalidInputFormat("Invalid erofs header.")
+
+        end_offset = (1 << header.block_size_bs) * header.block_count
+        return ValidChunk(
+            start_offset=start_offset,
+            end_offset=end_offset,
+        )

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ let
     ./flake.lock
     ./flake.nix
     ./overlay.nix
-    ./nix
+    ./package.nix
   ];
 
   lock = builtins.fromJSON (builtins.readFile ./flake.lock);

--- a/tests/integration/filesystem/android/erofs/__input__/foo.erofs.img
+++ b/tests/integration/filesystem/android/erofs/__input__/foo.erofs.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f400d3497501c6e68324868d88207aa9398888902414045f4ea498ff26bcdcd
+size 4096

--- a/tests/integration/filesystem/android/erofs/__input__/foo_padding.erofs.img
+++ b/tests/integration/filesystem/android/erofs/__input__/foo_padding.erofs.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7520d3fe98e5f5d25ccc4027321a561a125fbb413ecd83e935a8bc6b425b2aaf
+size 6144

--- a/tests/integration/filesystem/android/erofs/__output__/foo.erofs.img_extract/bar.txt
+++ b/tests/integration/filesystem/android/erofs/__output__/foo.erofs.img_extract/bar.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bfc3200f0152ab9e91e662afd75add3306131f670a1d71539f680c7acdb0a9f
+size 13

--- a/tests/integration/filesystem/android/erofs/__output__/foo.erofs.img_extract/notes/apple.pdf
+++ b/tests/integration/filesystem/android/erofs/__output__/foo.erofs.img_extract/notes/apple.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5430971d8e240c73eb25b24f0630328076dadf9986614f1d44a19b5ab90fc52a
+size 37

--- a/tests/integration/filesystem/android/erofs/__output__/foo_padding.erofs.img_extract/0-1024.padding
+++ b/tests/integration/filesystem/android/erofs/__output__/foo_padding.erofs.img_extract/0-1024.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef
+size 1024

--- a/tests/integration/filesystem/android/erofs/__output__/foo_padding.erofs.img_extract/1024-4096.erofs
+++ b/tests/integration/filesystem/android/erofs/__output__/foo_padding.erofs.img_extract/1024-4096.erofs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5dc7382e2247702f0e29e2e71fedfb464d2b930a439957fa7458882f7f7116d
+size 3072

--- a/tests/integration/filesystem/android/erofs/__output__/foo_padding.erofs.img_extract/1024-4096.erofs_extract/bar.txt
+++ b/tests/integration/filesystem/android/erofs/__output__/foo_padding.erofs.img_extract/1024-4096.erofs_extract/bar.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bfc3200f0152ab9e91e662afd75add3306131f670a1d71539f680c7acdb0a9f
+size 13

--- a/tests/integration/filesystem/android/erofs/__output__/foo_padding.erofs.img_extract/1024-4096.erofs_extract/notes/apple.pdf
+++ b/tests/integration/filesystem/android/erofs/__output__/foo_padding.erofs.img_extract/1024-4096.erofs_extract/notes/apple.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5430971d8e240c73eb25b24f0630328076dadf9986614f1d44a19b5ab90fc52a
+size 37

--- a/tests/integration/filesystem/android/erofs/__output__/foo_padding.erofs.img_extract/4096-6144.padding
+++ b/tests/integration/filesystem/android/erofs/__output__/foo_padding.erofs.img_extract/4096-6144.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5a00aa9991ac8a5ee3109844d84a55583bd20572ad3ffcd42792f3c36b183ad
+size 2048


### PR DESCRIPTION
feat(handler): add erofs filesystem & decompression handler

EROFS is a high-performance read-only filesystem originally developed by Huawei and now used extensively in AOSP. It offers features like compression (LZ4, LZMA), inline data, and reduced
storage overhead, making it ideal for read-only system images.

Create erofs file :
> mkfs.erofs -z[compressor, level (optional)] foo.erofs.img foo/

Extract erofs file:
> fsck.erofs --extract=foo_extracted/ foo.erofs.img

Key notes:
- First 1024 bytes are reserved for the boot loader
- Header starts at 0x400 with E0F5E1E2
- Header can be more than 128 bytes if extra slots provided
- File format in little endian
- There is no standarized file extension. The official documentation
uses ".erofs.img"
- Checksum is differ form verion to version

Header format :
>  4 bytes : Magic
>  4 bytes : Checksum, crc32c
>  4 byets : feature compact
>  1 byte  : Block size in bit shift
>  1 byte  : Super block extra slots (128 + sb_extslots * 16)
>  2 bytes : Root ID number
>  8 bytes : Total valid inodes
>  8 bytes : Built time
>  4 bytes : Built time nsec
>  4 bytes : Block count
>  4 bytes : Start block addr of metadata area
>  4 bytes : Start block of shared xattr area
> 16 bytes : UUID
> 16 bytes : Volume name
>  4 bytes : Feature incompact
>  2 bytes : Union of Compresion algorithm & LZ4 max distance
>  2 bytes : Extra device
>  2 bytes : Devt slotoff
>  1 byte  : Directory block size in bit shit
>  1 byte  : Number of ling xattr prefixes
>  8 bytes : NID of special packed inode
>  1 byte  : Reserved fir xattr name filter
> 23 bytes : Reserved (Most likely NULL bytes)
Unblob struct the header until the feature_incompact. The rest is labeled
as "reserved". Unblob parser the end offset by multiplying the block
size in bit shift with the block count. Since the checksum is not
consistent troughout the version, unblob matched on block count (at
least 1), printable volume name and if there is a build time.

[Sources]
https://elixir.bootlin.com/linux/v6.14-rc6/source/fs/erofs/erofs_fs.h
https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/erofs/erofs_fs.h?h=v6.6
https://erofs.docs.kernel.org/en/latest/core_ondisk.html
https://www.kernel.org/doc/html/latest/filesystems/erofs.html

