### PR TITLE
Automated generation of handlers documentation

### DIFF
--- a/.just/doc.just
+++ b/.just/doc.just
@@ -1,0 +1,58 @@
+set working-directory := ".."
+
+# mkdocs defaults
+site-directory := "./site"
+dev-address := "localhost:8000"
+
+## Help
+help: (_mod_help source_file())
+
+_mod_help justfile:
+    @{{ just_executable() }} -f {{ justfile }} --list --unsorted
+
+## Logging
+_info message:
+    @printf "{{BOLD}}--> {{message}}{{NORMAL}}\n"
+
+_success message="Task finished successfully":
+    @printf "{{GREEN}}--> ✔ {{message}}{{NORMAL}}\n"
+
+_error message:
+    @printf "{{RED}}--> ✘ {{message}}{{NORMAL}}\n"
+
+# Prints this help
+
+_install_dependencies: (_info "Installing documentation related dependencies") && (_success "Documentation related dependencies are installed")
+    uv sync --frozen --all-extras --group docs
+
+# Build documentation to html
+build *mkdocs-args: _install_dependencies (_info "Building documentation") && (_success "Documentation built to " + site-directory + " directory")
+    uv run mkdocs build -q --site-dir {{ site-directory }} {{ mkdocs-args }}
+
+# Open documentation in browser
+open *mkdocs-args: _install_dependencies (_info "Running mkdocs server listening at " + dev-address + ". Press CTRL-C to exit")
+    uv run mkdocs serve -q --dev-addr {{ dev-address }} --open {{ mkdocs-args }}
+
+# Generate Handler markdowns
+generate-handlers-doc:
+    #!/usr/bin/env python
+    from pathlib import Path
+
+    from unblob.doc import generate_markdown
+    from unblob.handlers import BUILTIN_HANDLERS
+
+    FORMAT_TABLE_HEADERS = """| Format        | Type                                 | Fully supported?    |\n| :------------ | :----------------------------------- | :-----------------: |\n"""
+
+    sorted_handlers = sorted(BUILTIN_HANDLERS, key=lambda handler_class: handler_class.NAME)
+    handlers_path = Path("docs/handlers.md")
+    print(f"Generating: {handlers_path}")
+    with handlers_path.open("w") as f:
+        f.write(FORMAT_TABLE_HEADERS)
+
+        for handler_class in sorted_handlers:
+            support_icon = "octicons-check-16" if handler_class.DOC.fully_supported else "octicons-alert-fill-12"
+            f.write(f"""| [`{handler_class.DOC.name.upper()}`](#{handler_class.DOC.name.replace(" ", "-").lower()}) | {handler_class.DOC.handler_type.name} | :{support_icon}: |\n""")
+
+        for handler_class in sorted_handlers:
+            content = generate_markdown(handler_class.DOC)
+            f.write("\n" + content)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
       - id: check-json
       - id: check-toml
       - id: check-yaml
+        args: ['--unsafe']
       - id: check-added-large-files
 
   - repo: local

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -1,0 +1,1451 @@
+| Format        | Type                                 | Fully supported?    |
+| :------------ | :----------------------------------- | :-----------------: |
+| [`AR`](#ar) | ARCHIVE | :octicons-check-16: |
+| [`ARC`](#arc) | ARCHIVE | :octicons-check-16: |
+| [`ARJ`](#arj) | ARCHIVE | :octicons-check-16: |
+| [`HP BDL`](#hp-bdl) | ARCHIVE | :octicons-check-16: |
+| [`INSTAR BNEG`](#instar-bneg) | ARCHIVE | :octicons-check-16: |
+| [`BZIP2`](#bzip2) | COMPRESSION | :octicons-check-16: |
+| [`CAB`](#cab) | ARCHIVE | :octicons-check-16: |
+| [`NETGEAR CHK`](#netgear-chk) | ARCHIVE | :octicons-check-16: |
+| [`COMPRESS`](#compress) | COMPRESSION | :octicons-check-16: |
+| [`CPIO_BINARY`](#cpio_binary) | ARCHIVE | :octicons-check-16: |
+| [`CPIO_PORTABLE_ASCII`](#cpio_portable_ascii) | ARCHIVE | :octicons-check-16: |
+| [`CPIO_PORTABLE_ASCII_CRC`](#cpio_portable_ascii_crc) | ARCHIVE | :octicons-check-16: |
+| [`CPIO_PORTABLE_OLD_ASCII`](#cpio_portable_old_ascii) | ARCHIVE | :octicons-check-16: |
+| [`CRAMFS`](#cramfs) | FILESYSTEM | :octicons-check-16: |
+| [`DMG`](#dmg) | ARCHIVE | :octicons-check-16: |
+| [`AUTEL ECC`](#autel-ecc) | ARCHIVE | :octicons-check-16: |
+| [`ELF32`](#elf32) | EXECUTABLE | :octicons-check-16: |
+| [`ELF64`](#elf64) | EXECUTABLE | :octicons-check-16: |
+| [`D-LINK ENCRPTED_IMG`](#d-link-encrpted_img) | ARCHIVE | :octicons-check-16: |
+| [`ENGENIUS`](#engenius) | ARCHIVE | :octicons-alert-fill-12: |
+| [`EROFS`](#erofs) | FILESYSTEM | :octicons-check-16: |
+| [`EXTFS`](#extfs) | FILESYSTEM | :octicons-check-16: |
+| [`FAT`](#fat) | FILESYSTEM | :octicons-check-16: |
+| [`GZIP`](#gzip) | COMPRESSION | :octicons-check-16: |
+| [`XIAOMI HDR1`](#xiaomi-hdr1) | ARCHIVE | :octicons-check-16: |
+| [`XIAOMI HDR2`](#xiaomi-hdr2) | ARCHIVE | :octicons-check-16: |
+| [`INSTAR HD`](#instar-hd) | ARCHIVE | :octicons-check-16: |
+| [`HP IPKG`](#hp-ipkg) | ARCHIVE | :octicons-check-16: |
+| [`ISO9660`](#iso9660) | FILESYSTEM | :octicons-check-16: |
+| [`JFFS2_NEW`](#jffs2_new) | FILESYSTEM | :octicons-check-16: |
+| [`JFFS2_OLD`](#jffs2_old) | FILESYSTEM | :octicons-check-16: |
+| [`LZ4`](#lz4) | COMPRESSION | :octicons-check-16: |
+| [`LZ4 LEGACY`](#lz4-legacy) | COMPRESSION | :octicons-check-16: |
+| [`LZ4 SKIPPABLE`](#lz4-skippable) | COMPRESSION | :octicons-check-16: |
+| [`LZH`](#lzh) | COMPRESSION | :octicons-check-16: |
+| [`LZIP`](#lzip) | COMPRESSION | :octicons-check-16: |
+| [`LZMA`](#lzma) | COMPRESSION | :octicons-check-16: |
+| [`LZO`](#lzo) | COMPRESSION | :octicons-check-16: |
+| [`NTFS`](#ntfs) | FILESYSTEM | :octicons-check-16: |
+| [`QNAP NAS`](#qnap-nas) | ARCHIVE | :octicons-check-16: |
+| [`RAR`](#rar) | ARCHIVE | :octicons-alert-fill-12: |
+| [`ROMFS`](#romfs) | FILESYSTEM | :octicons-check-16: |
+| [`SEVENZIP`](#sevenzip) | ARCHIVE | :octicons-check-16: |
+| [`D-LINK SHRS`](#d-link-shrs) | ARCHIVE | :octicons-check-16: |
+| [`ANDROID SPARSE IMAGE`](#android-sparse-image) | FILESYSTEM | :octicons-check-16: |
+| [`SQUASHFS_V1`](#squashfs_v1) | FILESYSTEM | :octicons-check-16: |
+| [`SQUASHFS_V2`](#squashfs_v2) | FILESYSTEM | :octicons-check-16: |
+| [`SQUASHFS_V3`](#squashfs_v3) | FILESYSTEM | :octicons-check-16: |
+| [`SQUASHFS_V3_BROADCOM`](#squashfs_v3_broadcom) | FILESYSTEM | :octicons-check-16: |
+| [`SQUASHFS_V3_DDWRT`](#squashfs_v3_ddwrt) | FILESYSTEM | :octicons-check-16: |
+| [`SQUASHFS_V3_NONSTANDARD`](#squashfs_v3_nonstandard) | FILESYSTEM | :octicons-check-16: |
+| [`SQUASHFS_V4_BE`](#squashfs_v4_be) | FILESYSTEM | :octicons-check-16: |
+| [`SQUASHFS_V4_LE`](#squashfs_v4_le) | FILESYSTEM | :octicons-check-16: |
+| [`STUFFIT`](#stuffit) | ARCHIVE | :octicons-check-16: |
+| [`STUFFIT5`](#stuffit5) | ARCHIVE | :octicons-check-16: |
+| [`TAR_USTAR`](#tar_ustar) | ARCHIVE | :octicons-check-16: |
+| [`TAR_UNIX`](#tar_unix) | ARCHIVE | :octicons-check-16: |
+| [`NETGEAR TRX V1`](#netgear-trx-v1) | ARCHIVE | :octicons-check-16: |
+| [`NETGEAR TRX V2`](#netgear-trx-v2) | ARCHIVE | :octicons-check-16: |
+| [`UBI`](#ubi) | FILESYSTEM | :octicons-check-16: |
+| [`UBIFS`](#ubifs) | FILESYSTEM | :octicons-check-16: |
+| [`UZIP`](#uzip) | COMPRESSION | :octicons-check-16: |
+| [`XZ`](#xz) | COMPRESSION | :octicons-check-16: |
+| [`YAFFS`](#yaffs) | FILESYSTEM | :octicons-check-16: |
+| [`ZIP`](#zip) | ARCHIVE | :octicons-alert-fill-12: |
+| [`ZLIB`](#zlib) | COMPRESSION | :octicons-check-16: |
+| [`ZSTD`](#zstd) | COMPRESSION | :octicons-check-16: |
+
+## ar
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Handles Unix AR (archive) files, which are used to store multiple files in a single archive with a simple header format.
+
+        ---
+
+        - **Handler type:** Archive
+        
+
+    === "References"
+
+        - [Unix AR File Format Documentation](https://en.wikipedia.org/wiki/Ar_(Unix)){ target="_blank" }
+
+
+
+
+## arc
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Handles ARC archive files, which are legacy archive formats used to store multiple files with metadata such as file size, creation date, and CRC.
+
+        ---
+
+        - **Handler type:** Archive
+        
+
+    === "References"
+
+        - [ARC File Format Documentation](https://en.wikipedia.org/wiki/ARC_(file_format)){ target="_blank" }
+
+
+
+
+## arj
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Handles ARJ archive files, which are legacy compressed archive formats used to store multiple files with metadata such as file size, creation date, and CRC.
+
+        ---
+
+        - **Handler type:** Archive
+        
+
+    === "References"
+
+        - [ARJ File Format Documentation](https://docs.fileformat.com/compression/arj/){ target="_blank" }
+        - [ARJ Technical Information](https://github.com/tripsin/unarj/blob/master/UNARJ.H#L203){ target="_blank" }
+
+
+
+
+## HP BDL
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        The HP BDL format is a firmware archive containing a custom header and a table of contents that specifies offsets and sizes of embedded firmware components. It includes metadata such as release, brand, device ID, version, and revision.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** HP
+
+    === "References"
+
+        - [hpbdl](https://github.com/tylerwhall/hpbdl){ target="_blank" }
+
+
+
+
+## Instar BNEG
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        BNEG firmware files consist of a custom header followed by two partitions containing firmware components. The header specifies metadata such as magic value, version, and partition sizes.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Instar
+
+    === "References"
+
+
+
+
+
+
+## bzip2
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        The bzip2 format is a block-based compression format that uses the Burrows-Wheeler transform and Huffman coding for high compression efficiency. Each stream starts with a header and consists of one or more compressed blocks, ending with a footer containing a checksum.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [bzip2 File Format Documentation](https://sourceware.org/bzip2/manual/manual.html){ target="_blank" }
+        - [bzip2 Technical Specification](https://en.wikipedia.org/wiki/Bzip2){ target="_blank" }
+
+
+
+
+## cab
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Handles Microsoft Cabinet (CAB) archive files, which are used for compressed file storage and software installation.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Microsoft
+
+    === "References"
+
+        - [Microsoft Cabinet File Format Documentation](https://en.wikipedia.org/wiki/Cabinet_(file_format)){ target="_blank" }
+        - [Ubuntu Manual - cabextract](https://manpages.ubuntu.com/manpages/focal/man1/cabextract.1.html){ target="_blank" }
+
+
+
+
+## Netgear CHK
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Netgear CHK firmware files consist of a custom header containing metadata and checksums, followed by kernel and root filesystem partitions. The header includes fields for partition sizes, checksums, and a board identifier.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Netgear
+
+    === "References"
+
+        - [CHK Image Format Image Builder Tool for the R7800 Series](https://github.com/Getnear/R7800/blob/master/tools/firmware-utils/src/mkchkimg.c){ target="_blank" }
+
+
+
+
+## compress
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Unix compress files use the Lempel-Ziv-Welch (LZW) algorithm for data compression and are identified by a 2-byte magic number (0x1F 0x9D). This format supports optional block compression and variable bit lengths ranging from 9 to 16 bits.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [Unix Compress File Format Documentation](https://fuchsia.googlesource.com/third_party/wuffs/+/HEAD/std/lzw/README.md){ target="_blank" }
+        - [LZW Compression Algorithm](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Welch){ target="_blank" }
+
+
+
+
+## cpio_binary
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        CPIO (Copy In, Copy Out) is an archive file format used for bundling files and directories along with their metadata. It is commonly used in Unix-like systems for creating backups or transferring files, and supports various encoding formats including binary and ASCII.
+
+        ---
+
+        - **Handler type:** Archive
+        
+
+    === "References"
+
+        - [GNU CPIO Manual](https://www.gnu.org/software/cpio/manual/cpio.html){ target="_blank" }
+
+
+
+
+## cpio_portable_ascii
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        CPIO (Copy In, Copy Out) is an archive file format used for bundling files and directories along with their metadata. It is commonly used in Unix-like systems for creating backups or transferring files, and supports various encoding formats including binary and ASCII.
+
+        ---
+
+        - **Handler type:** Archive
+        
+
+    === "References"
+
+        - [GNU CPIO Manual](https://www.gnu.org/software/cpio/manual/cpio.html){ target="_blank" }
+
+
+
+
+## cpio_portable_ascii_crc
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        CPIO (Copy In, Copy Out) is an archive file format used for bundling files and directories along with their metadata. It is commonly used in Unix-like systems for creating backups or transferring files, and supports various encoding formats including binary and ASCII.
+
+        ---
+
+        - **Handler type:** Archive
+        
+
+    === "References"
+
+        - [GNU CPIO Manual](https://www.gnu.org/software/cpio/manual/cpio.html){ target="_blank" }
+
+
+
+
+## cpio_portable_old_ascii
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        CPIO (Copy In, Copy Out) is an archive file format used for bundling files and directories along with their metadata. It is commonly used in Unix-like systems for creating backups or transferring files, and supports various encoding formats including binary and ASCII.
+
+        ---
+
+        - **Handler type:** Archive
+        
+
+    === "References"
+
+        - [GNU CPIO Manual](https://www.gnu.org/software/cpio/manual/cpio.html){ target="_blank" }
+
+
+
+
+## cramfs
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        CramFS is a lightweight, read-only file system format designed for simplicity and efficiency in embedded systems. It uses zlib compression for file data and stores metadata in a compact, contiguous structure.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [CramFS Documentation](https://web.archive.org/web/20160304053532/http://sourceforge.net/projects/cramfs/){ target="_blank" }
+        - [CramFS Wikipedia](https://en.wikipedia.org/wiki/Cramfs){ target="_blank" }
+
+
+
+
+## dmg
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Apple Disk Image (DMG) files are commonly used on macOS for software distribution and disk image storage.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Apple
+
+    === "References"
+
+        - [Apple Disk Image Format Documentation](http://newosxbook.com/DMG.html){ target="_blank" }
+
+
+
+
+## Autel ECC
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Autel ECC files consist of a custom header followed by encrypted data blocks. The header includes metadata such as magic bytes, file size, and copyright information.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Autel
+
+    === "References"
+
+        - [Autel ECC Decryption Script (Sector7)](https://gist.github.com/sector7-nl/3fc815cd2497817ad461bfbd393294cb){ target="_blank" }
+
+
+
+
+## elf32
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        The 32-bit ELF (Executable and Linkable Format) is a binary file format used for executables, object code, shared libraries, and core dumps. It supports 32-bit addressing and includes headers for program and section information.
+
+        ---
+
+        - **Handler type:** Executable
+        
+
+    === "References"
+
+        - [ELF File Format Specification](https://refspecs.linuxfoundation.org/elf/elf.pdf){ target="_blank" }
+        - [ELF Wikipedia](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format){ target="_blank" }
+
+
+
+
+## elf64
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        The 64-bit ELF (Executable and Linkable Format) is a binary file format used for executables, shared libraries, and core dumps. It supports 64-bit addressing and includes headers for program and section information.
+
+        ---
+
+        - **Handler type:** Executable
+        
+
+    === "References"
+
+        - [ELF File Format Specification](https://refspecs.linuxfoundation.org/elf/elf.pdf){ target="_blank" }
+        - [ELF Wikipedia](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format){ target="_blank" }
+
+
+
+
+## D-Link encrpted_img
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        A binary format used by D-Link to store encrypted firmware or data. It consists of a custom 12-byte magic header followed by the encrypted payload.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** D-Link
+
+    === "References"
+
+        - [How-To: Extracting Decryption Keys for D-Link](https://www.onekey.com/resource/extracting-decryption-keys-dlink){ target="_blank" }
+
+
+
+
+## engenius
+
+!!! warning "Partially supported"
+
+    === "Description"
+
+        Engenius firmware files contain a custom header with metadata, followed by encrypted data using an XOR cipher. The header includes fields like version, model, and length, which are essential for decryption and extraction.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Engenius
+
+    === "References"
+
+        - [enfringement - Tools for working with EnGenius WiFi hardware.](https://github.com/ryancdotorg/enfringement){ target="_blank" }
+
+    === "Limitations"
+
+        - Does not support all firmware versions.
+
+
+## erofs
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        EROFS (Enhanced Read-Only File System) is a lightweight, high-performance file system designed for read-only use cases, commonly used in Android and Linux. It features compression support, metadata efficiency, and a fixed superblock structure starting at offset 0x400.
+
+        ---
+
+        - **Handler type:** FileSystem
+        - **Vendor:** Google
+
+    === "References"
+
+        - [EROFS Documentation](https://www.kernel.org/doc/html/latest/filesystems/erofs.html){ target="_blank" }
+        - [EROFS Wikipedia](https://en.wikipedia.org/wiki/Enhanced_Read-Only_File_System){ target="_blank" }
+
+
+
+
+## extfs
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        ExtFS (Ext2/Ext3/Ext4) is a family of journaling file systems commonly used in Linux-based operating systems. It supports features like large file sizes, extended attributes, and journaling for improved reliability.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [Ext4 Documentation](https://www.kernel.org/doc/html/latest/filesystems/ext4/index.html){ target="_blank" }
+        - [ExtFS Wikipedia](https://en.wikipedia.org/wiki/Ext4){ target="_blank" }
+
+
+
+
+## fat
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        FAT (File Allocation Table) is a file system format used for organizing and managing files on storage devices, supporting FAT12, FAT16, and FAT32 variants. It uses a table to map file clusters, enabling efficient file storage and retrieval.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [FAT Wikipedia](https://en.wikipedia.org/wiki/File_Allocation_Table){ target="_blank" }
+
+
+
+
+## gzip
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        GZIP is a compressed file format that uses the DEFLATE algorithm and includes metadata such as original file name and modification time. It is commonly used for efficient file storage and transfer.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [GZIP File Format Specification](https://datatracker.ietf.org/doc/html/rfc1952){ target="_blank" }
+        - [GZIP Wikipedia](https://en.wikipedia.org/wiki/Gzip){ target="_blank" }
+
+
+
+
+## Xiaomi HDR1
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Xiaomi HDR1 firmware files feature a custom header containing metadata, CRC32 checksum, and blob offsets for embedded data. These files are used in Xiaomi devices for firmware updates.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Xiaomi
+
+    === "References"
+
+
+
+
+
+
+## Xiaomi HDR2
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Xiaomi HDR2 firmware files feature a custom header with metadata, CRC32 checksum, and blob offsets for embedded data. These files also include additional fields for device ID and region information.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Xiaomi
+
+    === "References"
+
+
+
+
+
+
+## Instar HD
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Instar HD firmware files are modified ZIP archives with non-standard local file headers, central directory headers, and end-of-central-directory records. These modifications include custom magic bytes to differentiate them from standard ZIP files.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Instar
+
+    === "References"
+
+
+
+
+
+
+## HP IPKG
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        HP IPKG firmware archives consist of a custom header, followed by a table of contents and file entries. Each entry specifies metadata such as file name, offset, size, and CRC32 checksum.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** HP
+
+    === "References"
+
+        - [hpbdl](https://github.com/tylerwhall/hpbdl){ target="_blank" }
+
+
+
+
+## iso9660
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        ISO 9660 is a file system standard for optical disc media, defining a volume descriptor structure and directory hierarchy. It is widely used for CD-ROMs and supports cross-platform compatibility.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [ISO 9660 Specification](https://wiki.osdev.org/ISO_9660){ target="_blank" }
+        - [ISO 9660 Wikipedia](https://en.wikipedia.org/wiki/ISO_9660){ target="_blank" }
+
+
+
+
+## jffs2_new
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        JFFS2 (Journaling Flash File System version 2) is a log-structured file system for flash memory devices, using an older magic number to identify its nodes. It organizes data into nodes with headers containing metadata and CRC checks for integrity.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [JFFS2 Documentation](https://sourceware.org/jffs2/){ target="_blank" }
+        - [JFFS2 Wikipedia](https://en.wikipedia.org/wiki/JFFS2){ target="_blank" }
+
+
+
+
+## jffs2_old
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        JFFS2 (Journaling Flash File System version 2) is a log-structured file system for flash memory devices, using an older magic number to identify its nodes. It organizes data into nodes with headers containing metadata and CRC checks for integrity.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [JFFS2 Documentation](https://sourceware.org/jffs2/){ target="_blank" }
+        - [JFFS2 Wikipedia](https://en.wikipedia.org/wiki/JFFS2){ target="_blank" }
+
+
+
+
+## LZ4
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        LZ4 is a high-speed lossless compression algorithm designed for real-time data compression with minimal memory usage.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [LZ4 Frame Format Documentation](https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md){ target="_blank" }
+        - [LZ4 Wikipedia](https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)){ target="_blank" }
+
+
+
+
+## LZ4 Legacy
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        LZ4 legacy format is an older framing format used prior to the LZ4 Frame specification, featuring a simpler structure and no support for skippable frames or extensive metadata. Unlike the default LZ4 Frame format, it lacks built-in checksums, versioning, or block independence flags, making it less robust and primarily used for backward compatibility.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [LZ4 Frame Format Documentation](https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md){ target="_blank" }
+        - [LZ4 Wikipedia](https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)){ target="_blank" }
+
+
+
+
+## LZ4 Skippable
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        LZ4 skippable format is designed to encapsulate arbitrary data within an LZ4 stream allowing compliant parsers to skip over it safely. This format does not contain compressed data itself but is often used for embedding metadata or non-LZ4 content alongside standard frames.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [LZ4 Frame Format Documentation](https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md){ target="_blank" }
+        - [LZ4 Wikipedia](https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)){ target="_blank" }
+
+
+
+
+## lzh
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        LZH is a legacy archive format that uses various compression methods such as '-lh0-' and '-lh5-'. It was widely used in Japan and on older systems for compressing and archiving files.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [LZH Compression Format](https://en.wikipedia.org/wiki/LHA_(file_format)){ target="_blank" }
+
+
+
+
+## lzip
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Lzip is a lossless compressed file format based on the LZMA algorithm. It features a simple header, CRC-checked integrity, and efficient compression for large files.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [Lzip File Format Documentation](https://www.nongnu.org/lzip/manual/lzip_manual.html){ target="_blank" }
+        - [Lzip Wikipedia](https://en.wikipedia.org/wiki/Lzip){ target="_blank" }
+
+
+
+
+## lzma
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        LZMA is a compression format based on the Lempel-Ziv-Markov chain algorithm, offering high compression ratios and efficient decompression. It is commonly used in standalone .lzma files and embedded in other formats like 7z.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [LZMA File Format Documentation](https://tukaani.org/xz/lzma.txt){ target="_blank" }
+        - [LZMA Wikipedia](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm){ target="_blank" }
+
+
+
+
+## lzo
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        LZO is a data compression format featuring a simple header structure and optional checksum verification. It is optimized for fast decompression and supports various compression levels and flags for additional metadata.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [LZO File Format Documentation](http://www.lzop.org/){ target="_blank" }
+        - [LZO Wikipedia](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Oberhumer){ target="_blank" }
+
+
+
+
+## ntfs
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        NTFS (New Technology File System) is a proprietary file system developed by Microsoft, featuring metadata support, advanced data structures, and journaling for reliability. It is commonly used in Windows operating systems for efficient storage and retrieval of files.
+
+        ---
+
+        - **Handler type:** FileSystem
+        - **Vendor:** Microsoft
+
+    === "References"
+
+        - [NTFS Wikipedia](https://en.wikipedia.org/wiki/NTFS){ target="_blank" }
+
+
+
+
+## QNAP NAS
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        QNAP NAS firmware files consist of a custom header, encrypted data sections, and a footer marking the end of the encrypted stream. The header contains metadata such as device ID, firmware version, and encryption details.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** QNAP
+
+    === "References"
+
+
+
+
+
+
+## rar
+
+!!! warning "Partially supported"
+
+    === "Description"
+
+        RAR archive files are commonly used for compressed data storage. They can contain multiple files and directories, and support various compression methods.
+
+        ---
+
+        - **Handler type:** Archive
+        
+
+    === "References"
+
+        - [RAR 4.x File Format Documentation](https://codedread.github.io/bitjs/docs/unrar.html){ target="_blank" }
+        - [RAR 5.x File Format Documentation](https://www.rarlab.com/technote.htm#rarsign){ target="_blank" }
+
+    === "Limitations"
+
+        - Does not support encrypted RAR files.
+
+
+## romfs
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        RomFS is a simple, space-efficient, read-only file system format designed for embedded systems. It features 16-byte alignment, minimal metadata overhead, and supports basic file types like directories, files, symlinks, and devices.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [RomFS Documentation](https://www.kernel.org/doc/html/latest/filesystems/romfs.html){ target="_blank" }
+        - [RomFS Wikipedia](https://en.wikipedia.org/wiki/Romfs){ target="_blank" }
+
+
+
+
+## sevenzip
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        The 7-Zip file format is a compressed archive format with high compression ratios, supporting multiple algorithms, CRC checks, and multi-volume archives.
+
+        ---
+
+        - **Handler type:** Archive
+        
+
+    === "References"
+
+        - [7-Zip Technical Documentation](https://fastapi.metacpan.org/source/BJOERN/Compress-Deflate7-1.0/7zip/DOC/7zFormat.txt){ target="_blank" }
+
+
+
+
+## D-Link SHRS
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        SHRS is a D-Link firmware format with a custom header containing metadata, SHA-512 digests, and AES-CBC encryption parameters. The firmware data is encrypted using a fixed key and IV stored in the header.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** D-Link
+
+    === "References"
+
+        - [Breaking the D-Link DIR3060 Firmware Encryption - Recon - Part 1](https://0x00sec.org/t/breaking-the-d-link-dir3060-firmware-encryption-recon-part-1/21943){ target="_blank" }
+
+
+
+
+## Android Sparse Image
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Android sparse images are a file format used to efficiently store disk images by representing sequences of zero blocks compactly. The format includes a file header, followed by chunk headers and data, with support for raw, fill, and 'don't care' chunks.
+
+        ---
+
+        - **Handler type:** FileSystem
+        - **Vendor:** Google
+
+    === "References"
+
+        - [Android Sparse Image Format Documentation](https://formats.kaitai.io/android_sparse/){ target="_blank" }
+        - [simg2img Tool](https://github.com/anestisb/android-simg2img){ target="_blank" }
+
+
+
+
+## squashfs_v1
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        SquashFS version 1 is a compressed, read-only file system format designed for minimal storage usage. It is commonly used in embedded systems and early Linux distributions.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [SquashFS Documentation](https://dr-emann.github.io/squashfs/){ target="_blank" }
+        - [SquashFS Wikipedia](https://en.wikipedia.org/wiki/SquashFS){ target="_blank" }
+
+
+
+
+## squashfs_v2
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        SquashFS version 2 is a compressed, read-only file system format designed for minimal storage usage. It builds upon version 1 with additional features and improvements for embedded systems and Linux distributions.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [SquashFS Documentation](https://dr-emann.github.io/squashfs/){ target="_blank" }
+        - [SquashFS Wikipedia](https://en.wikipedia.org/wiki/SquashFS){ target="_blank" }
+
+
+
+
+## squashfs_v3
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        SquashFS version 3 is a compressed, read-only file system format designed for minimal storage usage. It is widely used in embedded systems and Linux distributions for efficient storage and fast access.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [SquashFS Documentation](https://dr-emann.github.io/squashfs/){ target="_blank" }
+        - [SquashFS Wikipedia](https://en.wikipedia.org/wiki/SquashFS){ target="_blank" }
+
+
+
+
+## squashfs_v3_broadcom
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        SquashFS version 3 Broadcom is a variant of the SquashFS v3 format used in Broadcom firmware. It features a unique magic number and may include specific optimizations for Broadcom devices.
+
+        ---
+
+        - **Handler type:** FileSystem
+        - **Vendor:** Broadcom
+
+    === "References"
+
+        - [SquashFS Documentation](https://dr-emann.github.io/squashfs/){ target="_blank" }
+        - [SquashFS Wikipedia](https://en.wikipedia.org/wiki/SquashFS){ target="_blank" }
+
+
+
+
+## squashfs_v3_ddwrt
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        SquashFS version 3 DD-WRT is a variant of the SquashFS v3 format used in DD-WRT firmware. It features a unique magic number and may include specific optimizations for embedded systems.
+
+        ---
+
+        - **Handler type:** FileSystem
+        - **Vendor:** DDWRT
+
+    === "References"
+
+        - [SquashFS Documentation](https://dr-emann.github.io/squashfs/){ target="_blank" }
+        - [SquashFS Wikipedia](https://en.wikipedia.org/wiki/SquashFS){ target="_blank" }
+
+
+
+
+## squashfs_v3_nonstandard
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        SquashFS version 3 is a compressed, read-only file system format designed for minimal storage usage. It is widely used in embedded systems and Linux distributions for efficient storage and fast access.
+
+        ---
+
+        - **Handler type:** FileSystem
+        - **Vendor:** unknown
+
+    === "References"
+
+        - [SquashFS Documentation](https://dr-emann.github.io/squashfs/){ target="_blank" }
+        - [SquashFS Wikipedia](https://en.wikipedia.org/wiki/SquashFS){ target="_blank" }
+
+
+
+
+## squashfs_v4_be
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        SquashFS version 4 is a compressed, read-only file system format designed for minimal storage usage and fast access. It supports both big-endian and little-endian formats and is widely used in embedded systems and Linux distributions.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [SquashFS Documentation](https://dr-emann.github.io/squashfs/){ target="_blank" }
+        - [SquashFS Wikipedia](https://en.wikipedia.org/wiki/SquashFS){ target="_blank" }
+
+
+
+
+## squashfs_v4_le
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        SquashFS version 4 is a compressed, read-only file system format designed for minimal storage usage and fast access. It is widely used in embedded systems and Linux distributions for efficient storage management.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [SquashFS Documentation](https://dr-emann.github.io/squashfs/){ target="_blank" }
+        - [SquashFS Wikipedia](https://en.wikipedia.org/wiki/SquashFS){ target="_blank" }
+
+
+
+
+## stuffit
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        StuffIt SIT archives is a legacy compressed archive format commonly used on macOS and earlier Apple systems.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** StuffIt Technologies
+
+    === "References"
+
+        - [StuffIt SIT File Format Documentation](https://en.wikipedia.org/wiki/StuffIt){ target="_blank" }
+
+
+
+
+## stuffit5
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        StuffIt SIT archives is a legacy compressed archive format commonly used on macOS and earlier Apple systems.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** StuffIt Technologies
+
+    === "References"
+
+        - [StuffIt SIT File Format Documentation](https://en.wikipedia.org/wiki/StuffIt){ target="_blank" }
+
+
+
+
+## tar_ustar
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        USTAR (Uniform Standard Tape Archive) tar files is an extension of the original tar format with additional metadata fields.
+
+        ---
+
+        - **Handler type:** Archive
+        
+
+    === "References"
+
+        - [USTAR Format Documentation](https://en.wikipedia.org/wiki/Tar_(computing)#USTAR_format){ target="_blank" }
+        - [POSIX Tar Format Specification](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html){ target="_blank" }
+
+
+
+
+## tar_unix
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Unix tar files are a widely used archive format for storing files and directories with metadata.
+
+        ---
+
+        - **Handler type:** Archive
+        
+
+    === "References"
+
+        - [Unix Tar Format Documentation](https://en.wikipedia.org/wiki/Tar_(computing)){ target="_blank" }
+        - [GNU Tar Manual](https://www.gnu.org/software/tar/manual/){ target="_blank" }
+
+
+
+
+## Netgear TRX v1
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Netgear TRX v1 firmware format includes a custom header with partition offsets and a CRC32 checksum for integrity verification. It supports up to three partitions defined in the header.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Netgear
+
+    === "References"
+
+
+
+
+
+
+## Netgear TRX v2
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Netgear TRX v2 firmware format includes a custom header with partition offsets and a CRC32 checksum for integrity verification. It supports up to four partitions defined in the header.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Netgear
+
+    === "References"
+
+
+
+
+
+
+## ubi
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        UBI (Unsorted Block Image) is a volume management system for raw flash devices, providing wear leveling and bad block management. It operates as a layer between the MTD subsystem and higher-level filesystems like UBIFS.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [UBI Documentation](https://www.kernel.org/doc/html/latest/driver-api/ubi.html){ target="_blank" }
+        - [UBI Wikipedia](https://en.wikipedia.org/wiki/UBIFS#UBI){ target="_blank" }
+
+
+
+
+## ubifs
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        UBIFS (Unsorted Block Image File System) is a flash file system designed for raw flash memory, providing wear leveling, error correction, and power failure resilience. It operates on top of UBI volumes, which manage flash blocks on raw NAND or NOR flash devices.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [UBIFS Documentation](https://www.kernel.org/doc/html/latest/filesystems/ubifs.html){ target="_blank" }
+        - [UBIFS Wikipedia](https://en.wikipedia.org/wiki/UBIFS){ target="_blank" }
+
+
+
+
+## uzip
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        FreeBSD UZIP is a block-based compressed disk image format. It uses a table of contents (TOC) to index compressed blocks, supporting ZLIB, LZMA, and ZSTD compression algorithms.
+
+        ---
+
+        - **Handler type:** Compression
+        - **Vendor:** FreeBSD
+
+    === "References"
+
+        - [FreeBSD UZIP Documentation](https://github.com/freebsd/freebsd-src/tree/master/sys/geom/uzip){ target="_blank" }
+
+
+
+
+## xz
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        XZ is a compressed file format that uses the LZMA2 algorithm for high compression efficiency. It is designed for general-purpose data compression with support for integrity checks and padding for alignment.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [XZ File Format Specification](https://tukaani.org/xz/xz-file-format-1.0.4.txt){ target="_blank" }
+        - [XZ Wikipedia](https://en.wikipedia.org/wiki/XZ_Utils){ target="_blank" }
+
+
+
+
+## yaffs
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        YAFFS (Yet Another Flash File System) is a log-structured file system designed for NAND flash memory, storing data in fixed-size chunks with associated metadata. It supports features like wear leveling, error correction, and efficient handling of power loss scenarios.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [YAFFS Documentation](https://yaffs.net/){ target="_blank" }
+        - [YAFFS Wikipedia](https://en.wikipedia.org/wiki/YAFFS){ target="_blank" }
+
+
+
+
+## zip
+
+!!! warning "Partially supported"
+
+    === "Description"
+
+        ZIP is a widely used archive file format that supports multiple compression methods, file spanning, and optional encryption. It includes metadata such as file names, sizes, and timestamps, and supports both standard and ZIP64 extensions for large files.
+
+        ---
+
+        - **Handler type:** Archive
+        
+
+    === "References"
+
+        - [ZIP File Format Specification](https://pkware.com/documents/casestudies/APPNOTE.TXT){ target="_blank" }
+        - [ZIP64 Format Specification](https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE-6.3.1.TXT){ target="_blank" }
+
+    === "Limitations"
+
+        - Does not support encrypted ZIP files.
+
+
+## zlib
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        The zlib format is a compressed data format based on the DEFLATE algorithm, often used for data compression in various applications. It includes a lightweight header and checksum for data integrity.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [zlib File Format Specification](https://www.zlib.net/manual.html){ target="_blank" }
+        - [zlib Wikipedia](https://en.wikipedia.org/wiki/Zlib){ target="_blank" }
+
+
+
+
+## zstd
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Zstandard (ZSTD) is a fast lossless compression algorithm with high compression ratios, designed for modern data storage and transfer. Its file format includes a frame structure with optional dictionary support and checksums for data integrity.
+
+        ---
+
+        - **Handler type:** Compression
+        
+
+    === "References"
+
+        - [Zstandard File Format Specification](https://facebook.github.io/zstd/zstd_manual.html){ target="_blank" }
+        - [Zstandard Wikipedia](https://en.wikipedia.org/wiki/Zstandard){ target="_blank" }

--- a/flake.nix
+++ b/flake.nix
@@ -118,12 +118,25 @@
               nodejs # for pyright
             ] ++ unblob.runtimeDeps;
 
+            uvExtraArgs = [
+              "--group"
+              "docs"
+            ];
+
             venvPatches = [
               (
                 # https://github.com/NixOS/nixpkgs/blob/70f6d2ad78eee1617f0871878e509b6d78a8b13b/pkgs/development/python-modules/python-magic/default.nix#L25-L27
                 replaceVars "${path}/pkgs/development/python-modules/python-magic/libmagic-path.patch" {
                   libmagic = "${file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}";
                 }
+              )
+              (
+                (replaceVars "${path}/pkgs/development/python-modules/cairocffi/dlopen-paths.patch" {
+                  ext = stdenv.hostPlatform.extensions.sharedLibrary;
+                  cairo = cairo.out;
+                  glib = glib.out;
+                  gdk_pixbuf = gdk-pixbuf.out;
+                })
               )
             ];
           };

--- a/justfile
+++ b/justfile
@@ -1,0 +1,1 @@
+mod doc ".just/doc.just"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,12 +24,19 @@ markdown_extensions:
       permalink: true
   - pymdownx.magiclink
   - def_list
+  - attr_list
   - admonition
+  - pymdownx.details
+  - pymdownx.superfences
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 theme:
   name: material

--- a/python/unblob/doc.py
+++ b/python/unblob/doc.py
@@ -1,0 +1,92 @@
+from typing import Union
+
+from .models import HandlerDoc, Reference
+
+_HANDLER_DOC_MARKDOWN_TEMPLATE = """## {name}
+
+!!! {support_info}
+
+    === "Description"
+
+{description}
+
+        ---
+
+        - **Handler type:** {type}
+        {vendor}
+
+    === "References"
+
+{references}
+
+{limitations}
+
+"""
+
+
+def _make_paragraph(lines: Union[str, None, list[str]]):  # noqa: C901
+    if not lines:
+        return ""
+
+    if not isinstance(lines, list):
+        lines = lines.splitlines()
+
+    def _starting_enumeration_needs_newline():
+        # Enumerations blocks needs an empty line before and after the blocks
+        if not line.startswith("-"):
+            return False
+        if not formatted_lines:
+            return False
+        previous_line = formatted_lines[-1].strip()
+        return previous_line != "" and not previous_line.startswith("-")
+
+    formatted_lines = []
+    for line in [line.strip() for line in lines]:
+        if line:
+            if _starting_enumeration_needs_newline():
+                formatted_lines.append("")
+            leading_space_count = 4 if line.startswith("===") else 8
+            formatted_lines.append(" " * leading_space_count + line)
+        else:
+            formatted_lines.append(line)
+    return "\n".join(formatted_lines)
+
+
+def _make_url(*, text: str, link: str) -> str:
+    return f'[{text}]({link}){{ target="_blank" }}'
+
+
+def make_references(references: list[Reference]):
+    if not references:
+        return ""
+
+    return _make_paragraph(
+        [
+            *[f"- {_make_url(text=ref.title, link=ref.url)}" for ref in references],
+        ]
+    )
+
+
+def make_limitations(limitations: list[str]) -> str:
+    if not limitations:
+        return ""
+
+    return '    === "Limitations"\n\n' + _make_paragraph(
+        [
+            *[f"- {limitation}" for limitation in limitations],
+        ]
+    )
+
+
+def generate_markdown(doc: HandlerDoc) -> str:
+    return _HANDLER_DOC_MARKDOWN_TEMPLATE.format(
+        name=doc.name,
+        type=doc.handler_type.value,
+        vendor=f"- **Vendor:** {doc.vendor}" if doc.vendor is not None else "",
+        description=_make_paragraph(doc.description),
+        references=make_references(doc.references),
+        support_info='success "Fully supported"'
+        if doc.fully_supported
+        else 'warning "Partially supported"',
+        limitations=make_limitations(doc.limitations),
+    )

--- a/python/unblob/handlers/archive/ar.py
+++ b/python/unblob/handlers/archive/ar.py
@@ -6,7 +6,17 @@ import arpy
 from structlog import get_logger
 
 from ...file_utils import FileSystem, OffsetFile, iterate_file
-from ...models import Extractor, ExtractResult, File, Handler, HexString, ValidChunk
+from ...models import (
+    Extractor,
+    ExtractResult,
+    File,
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    ValidChunk,
+)
 from ...report import ExtractionProblem
 
 logger = get_logger()
@@ -58,11 +68,25 @@ class ARHandler(Handler):
             """
             // "!<arch>\\n", 58 chars of whatever, then the ARFMAG
             21 3C 61 72 63 68 3E 0A [58] 60 0A
-    """
+            """
         )
     ]
 
     EXTRACTOR = ArExtractor()
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="Handles Unix AR (archive) files, which are used to store multiple files in a single archive with a simple header format.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="Unix AR File Format Documentation",
+                url="https://en.wikipedia.org/wiki/Ar_(Unix)",
+            )
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         offset_file = OffsetFile(file, start_offset)

--- a/python/unblob/handlers/archive/arc.py
+++ b/python/unblob/handlers/archive/arc.py
@@ -4,7 +4,15 @@ from structlog import get_logger
 
 from unblob.extractors.command import Command
 
-from ...models import File, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -19,7 +27,7 @@ class ARCHandler(StructHandler):
             """
             // Each entry in an archive begins with a one byte archive marker set to 0x1A.
             // The marker is followed by a one byte header type code, from 0x0 to 0x7.
-            // Then a null-byte or unitialized-byte terminated filename string of 13 bytes, the
+            // Then a null-byte or uninitialized-byte terminated filename string of 13 bytes, the
             // uninitialized byte is always set between 0xf0 and 0xff.
             1A (01 | 02 | 03 | 04 | 05 | 06 | 07) [12] (00 | F0 | F1 | F2 | F3 | F4 | F5 | F6 | F7 | F8 | F9 | FA | FB | FC | FD | FE | FF)
             """
@@ -41,6 +49,20 @@ class ARCHandler(StructHandler):
 
     HEADER_STRUCT = "arc_head_t"
     EXTRACTOR = Command("unar", "-no-directory", "-o", "{outdir}", "{inpath}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="Handles ARC archive files, which are legacy archive formats used to store multiple files with metadata such as file size, creation date, and CRC.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="ARC File Format Documentation",
+                url="https://en.wikipedia.org/wiki/ARC_(file_format)",
+            )
+        ],
+        limitations=[],
+    )
 
     def valid_name(self, name: bytes) -> bool:
         try:

--- a/python/unblob/handlers/archive/arj.py
+++ b/python/unblob/handlers/archive/arj.py
@@ -6,7 +6,15 @@ from structlog import get_logger
 
 from ...extractors import Command
 from ...file_utils import Endian, convert_int32
-from ...models import File, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -100,6 +108,24 @@ class ARJHandler(StructHandler):
     HEADER_STRUCT = "arj_header_t"
 
     EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-o{outdir}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="Handles ARJ archive files, which are legacy compressed archive formats used to store multiple files with metadata such as file size, creation date, and CRC.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="ARJ File Format Documentation",
+                url="https://docs.fileformat.com/compression/arj/",
+            ),
+            Reference(
+                title="ARJ Technical Information",
+                url="https://github.com/tripsin/unarj/blob/master/UNARJ.H#L203",
+            ),
+        ],
+        limitations=[],
+    )
 
     def _read_arj_main_header(self, file: File, start_offset: int) -> int:
         file.seek(start_offset)

--- a/python/unblob/handlers/archive/autel/ecc.py
+++ b/python/unblob/handlers/archive/autel/ecc.py
@@ -7,7 +7,10 @@ from unblob.file_utils import File, InvalidInputFormat, iterate_file
 from unblob.models import (
     Endian,
     Extractor,
+    HandlerDoc,
+    HandlerType,
     HexString,
+    Reference,
     StructHandler,
     StructParser,
     ValidChunk,
@@ -318,6 +321,20 @@ class AutelECCHandler(StructHandler):
     C_DEFINITIONS = C_DEFINITIONS
     HEADER_STRUCT = "autel_header_t"
     EXTRACTOR = ECCExtractor()
+
+    DOC = HandlerDoc(
+        name="Autel ECC",
+        description="Autel ECC files consist of a custom header followed by encrypted data blocks. The header includes metadata such as magic bytes, file size, and copyright information.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Autel",
+        references=[
+            Reference(
+                title="Autel ECC Decryption Script (Sector7)",
+                url="https://gist.github.com/sector7-nl/3fc815cd2497817ad461bfbd393294cb",  # Replace with actual reference if available
+            )
+        ],
+        limitations=[],
+    )
 
     def is_valid_header(self, header) -> bool:
         return header.header_size == 0x20

--- a/python/unblob/handlers/archive/cab.py
+++ b/python/unblob/handlers/archive/cab.py
@@ -3,7 +3,15 @@ from typing import Optional
 from structlog import get_logger
 
 from ...extractors import Command
-from ...models import File, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -41,6 +49,24 @@ class CABHandler(StructHandler):
     HEADER_STRUCT = "cab_header_t"
 
     EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-o{outdir}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="Handles Microsoft Cabinet (CAB) archive files, which are used for compressed file storage and software installation.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Microsoft",
+        references=[
+            Reference(
+                title="Microsoft Cabinet File Format Documentation",
+                url="https://en.wikipedia.org/wiki/Cabinet_(file_format)",
+            ),
+            Reference(
+                title="Ubuntu Manual - cabextract",
+                url="https://manpages.ubuntu.com/manpages/focal/man1/cabextract.1.html",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         header = self.parse_header(file)

--- a/python/unblob/handlers/archive/cpio.py
+++ b/python/unblob/handlers/archive/cpio.py
@@ -22,7 +22,10 @@ from ...models import (
     ExtractResult,
     File,
     Handler,
+    HandlerDoc,
+    HandlerType,
     HexString,
+    Reference,
     ValidChunk,
 )
 
@@ -427,6 +430,20 @@ class BinaryHandler(_CPIOHandlerBase):
 
     EXTRACTOR = BinaryCPIOExtractor()
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="CPIO (Copy In, Copy Out) is an archive file format used for bundling files and directories along with their metadata. It is commonly used in Unix-like systems for creating backups or transferring files, and supports various encoding formats including binary and ASCII.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="GNU CPIO Manual",
+                url="https://www.gnu.org/software/cpio/manual/cpio.html",
+            ),
+        ],
+        limitations=[],
+    )
+
 
 class PortableOldASCIIHandler(_CPIOHandlerBase):
     NAME = "cpio_portable_old_ascii"
@@ -435,6 +452,20 @@ class PortableOldASCIIHandler(_CPIOHandlerBase):
 
     EXTRACTOR = PortableOldASCIIExtractor()
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="CPIO (Copy In, Copy Out) is an archive file format used for bundling files and directories along with their metadata. It is commonly used in Unix-like systems for creating backups or transferring files, and supports various encoding formats including binary and ASCII.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="GNU CPIO Manual",
+                url="https://www.gnu.org/software/cpio/manual/cpio.html",
+            ),
+        ],
+        limitations=[],
+    )
+
 
 class PortableASCIIHandler(_CPIOHandlerBase):
     NAME = "cpio_portable_ascii"
@@ -442,9 +473,37 @@ class PortableASCIIHandler(_CPIOHandlerBase):
 
     EXTRACTOR = PortableASCIIExtractor()
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="CPIO (Copy In, Copy Out) is an archive file format used for bundling files and directories along with their metadata. It is commonly used in Unix-like systems for creating backups or transferring files, and supports various encoding formats including binary and ASCII.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="GNU CPIO Manual",
+                url="https://www.gnu.org/software/cpio/manual/cpio.html",
+            ),
+        ],
+        limitations=[],
+    )
+
 
 class PortableASCIIWithCRCHandler(_CPIOHandlerBase):
     NAME = "cpio_portable_ascii_crc"
     PATTERNS = [HexString("30 37 30 37 30 32 // 07 07 02")]
 
     EXTRACTOR = PortableASCIIWithCRCExtractor()
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="CPIO (Copy In, Copy Out) is an archive file format used for bundling files and directories along with their metadata. It is commonly used in Unix-like systems for creating backups or transferring files, and supports various encoding formats including binary and ASCII.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="GNU CPIO Manual",
+                url="https://www.gnu.org/software/cpio/manual/cpio.html",
+            ),
+        ],
+        limitations=[],
+    )

--- a/python/unblob/handlers/archive/dlink/encrpted_img.py
+++ b/python/unblob/handlers/archive/dlink/encrpted_img.py
@@ -6,7 +6,16 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from structlog import get_logger
 
 from unblob.file_utils import File, InvalidInputFormat
-from unblob.models import Endian, Extractor, Regex, StructHandler, ValidChunk
+from unblob.models import (
+    Endian,
+    Extractor,
+    HandlerDoc,
+    HandlerType,
+    Reference,
+    Regex,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -51,6 +60,20 @@ class EncrptedHandler(StructHandler):
     C_DEFINITIONS = C_DEFINITIONS
     HEADER_STRUCT = "dlink_header_t"
     EXTRACTOR = EncrptedExtractor()
+
+    DOC = HandlerDoc(
+        name="D-Link encrpted_img",
+        description="A binary format used by D-Link to store encrypted firmware or data. It consists of a custom 12-byte magic header followed by the encrypted payload.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="D-Link",
+        references=[
+            Reference(
+                title="How-To: Extracting Decryption Keys for D-Link",
+                url="https://www.onekey.com/resource/extracting-decryption-keys-dlink",  # Replace with actual reference if available
+            )
+        ],
+        limitations=[],
+    )
 
     def is_valid_header(self, header) -> bool:
         return header.size >= len(header)

--- a/python/unblob/handlers/archive/dlink/shrs.py
+++ b/python/unblob/handlers/archive/dlink/shrs.py
@@ -10,7 +10,10 @@ from unblob.file_utils import File, InvalidInputFormat
 from unblob.models import (
     Endian,
     Extractor,
+    HandlerDoc,
+    HandlerType,
     HexString,
+    Reference,
     StructHandler,
     StructParser,
     ValidChunk,
@@ -68,6 +71,20 @@ class SHRSHandler(StructHandler):
     C_DEFINITIONS = C_DEFINITIONS
     HEADER_STRUCT = "dlink_header_t"
     EXTRACTOR = SHRSExtractor()
+
+    DOC = HandlerDoc(
+        name="D-Link SHRS",
+        description="SHRS is a D-Link firmware format with a custom header containing metadata, SHA-512 digests, and AES-CBC encryption parameters. The firmware data is encrypted using a fixed key and IV stored in the header.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="D-Link",
+        references=[
+            Reference(
+                title="Breaking the D-Link DIR3060 Firmware Encryption - Recon - Part 1",
+                url="https://0x00sec.org/t/breaking-the-d-link-dir3060-firmware-encryption-recon-part-1/21943",  # Replace with actual reference if available
+            )
+        ],
+        limitations=[],
+    )
 
     def is_valid_header(self, header, file: File) -> bool:
         if header.file_size < len(header):

--- a/python/unblob/handlers/archive/dmg.py
+++ b/python/unblob/handlers/archive/dmg.py
@@ -5,7 +5,15 @@ from structlog import get_logger
 from unblob.extractors.command import Command
 
 from ...file_utils import Endian
-from ...models import File, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -66,6 +74,20 @@ class DMGHandler(StructHandler):
     # See more about this problem: https://newbedev.com/hfs-private-directory-data
     EXTRACTOR = Command(
         "7z", "x", "-xr!*HFS+ Private Data*", "-y", "{inpath}", "-o{outdir}"
+    )
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="Apple Disk Image (DMG) files are commonly used on macOS for software distribution and disk image storage.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Apple",
+        references=[
+            Reference(
+                title="Apple Disk Image Format Documentation",
+                url="http://newosxbook.com/DMG.html",
+            ),
+        ],
+        limitations=[],
     )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:

--- a/python/unblob/handlers/archive/engeniustech/engenius.py
+++ b/python/unblob/handlers/archive/engeniustech/engenius.py
@@ -4,7 +4,15 @@ from typing import Optional
 from structlog import get_logger
 
 from unblob.file_utils import Endian, File, InvalidInputFormat, StructParser
-from unblob.models import Extractor, HexString, StructHandler, ValidChunk
+from unblob.models import (
+    Extractor,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -79,6 +87,20 @@ class EngeniusHandler(StructHandler):
     HEADER_STRUCT = "engenius_header_t"
     EXTRACTOR = EngeniusExtractor()
     PATTERN_MATCH_OFFSET = -0x5C
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="Engenius firmware files contain a custom header with metadata, followed by encrypted data using an XOR cipher. The header includes fields like version, model, and length, which are essential for decryption and extraction.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Engenius",
+        references=[
+            Reference(
+                title="enfringement - Tools for working with EnGenius WiFi hardware.",
+                url="https://github.com/ryancdotorg/enfringement",  # Replace with actual reference if available
+            )
+        ],
+        limitations=["Does not support all firmware versions."],
+    )
 
     def is_valid_header(self, header) -> bool:
         if header.length <= len(header):

--- a/python/unblob/handlers/archive/hp/bdl.py
+++ b/python/unblob/handlers/archive/hp/bdl.py
@@ -6,7 +6,16 @@ from structlog import get_logger
 
 from unblob.extractor import carve_chunk_to_file
 from unblob.file_utils import Endian, File, InvalidInputFormat, StructParser, snull
-from unblob.models import Chunk, Extractor, HexString, StructHandler, ValidChunk
+from unblob.models import (
+    Chunk,
+    Extractor,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -87,6 +96,20 @@ class HPBDLHandler(StructHandler):
     C_DEFINITIONS = C_DEFINITIONS
     HEADER_STRUCT = "bdl_header_t"
     EXTRACTOR = HPBDLExtractor()
+
+    DOC = HandlerDoc(
+        name="HP BDL",
+        description="The HP BDL format is a firmware archive containing a custom header and a table of contents that specifies offsets and sizes of embedded firmware components. It includes metadata such as release, brand, device ID, version, and revision.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="HP",
+        references=[
+            Reference(
+                title="hpbdl",
+                url="https://github.com/tylerwhall/hpbdl",
+            )
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         header = self.parse_header(file, endian=Endian.LITTLE)

--- a/python/unblob/handlers/archive/hp/ipkg.py
+++ b/python/unblob/handlers/archive/hp/ipkg.py
@@ -15,7 +15,10 @@ from unblob.file_utils import (
 from unblob.models import (
     Extractor,
     ExtractResult,
+    HandlerDoc,
+    HandlerType,
     HexString,
+    Reference,
     StructHandler,
     ValidChunk,
 )
@@ -98,6 +101,20 @@ class HPIPKGHandler(StructHandler):
     C_DEFINITIONS = C_DEFINITIONS
     HEADER_STRUCT = "ipkg_header_t"
     EXTRACTOR = HPIPKGExtractor()
+
+    DOC = HandlerDoc(
+        name="HP IPKG",
+        description="HP IPKG firmware archives consist of a custom header, followed by a table of contents and file entries. Each entry specifies metadata such as file name, offset, size, and CRC32 checksum.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="HP",
+        references=[
+            Reference(
+                title="hpbdl",
+                url="https://github.com/tylerwhall/hpbdl",
+            )
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         header = self.parse_header(file, endian=Endian.LITTLE)

--- a/python/unblob/handlers/archive/instar/bneg.py
+++ b/python/unblob/handlers/archive/instar/bneg.py
@@ -5,7 +5,15 @@ from structlog import get_logger
 
 from unblob.extractor import carve_chunk_to_file
 from unblob.file_utils import Endian, File, InvalidInputFormat, StructParser
-from unblob.models import Chunk, Extractor, HexString, StructHandler, ValidChunk
+from unblob.models import (
+    Chunk,
+    Extractor,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -68,6 +76,15 @@ class BNEGHandler(StructHandler):
     C_DEFINITIONS = C_DEFINITIONS
     HEADER_STRUCT = "bneg_header_t"
     EXTRACTOR = BNEGExtractor()
+
+    DOC = HandlerDoc(
+        name="Instar BNEG",
+        description="BNEG firmware files consist of a custom header followed by two partitions containing firmware components. The header specifies metadata such as magic value, version, and partition sizes.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Instar",
+        references=[],
+        limitations=[],
+    )
 
     def is_valid_header(self, header) -> bool:
         if header.partition_1_size == 0:

--- a/python/unblob/handlers/archive/instar/instar_hd.py
+++ b/python/unblob/handlers/archive/instar/instar_hd.py
@@ -6,7 +6,7 @@ from structlog import get_logger
 
 from unblob.file_utils import File
 from unblob.handlers.archive.zip import ZIPHandler
-from unblob.models import Extractor, HexString
+from unblob.models import Extractor, HandlerDoc, HandlerType, HexString
 
 logger = get_logger()
 
@@ -45,3 +45,12 @@ class InstarHDHandler(ZIPHandler):
     EXTRACTOR = InstarHDExtractor()
 
     EOCD_RECORD_HEADER = 0x9054B50
+
+    DOC = HandlerDoc(
+        name="Instar HD",
+        description="Instar HD firmware files are modified ZIP archives with non-standard local file headers, central directory headers, and end-of-central-directory records. These modifications include custom magic bytes to differentiate them from standard ZIP files.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Instar",
+        references=[],
+        limitations=[],
+    )

--- a/python/unblob/handlers/archive/netgear/chk.py
+++ b/python/unblob/handlers/archive/netgear/chk.py
@@ -6,7 +6,16 @@ from structlog import get_logger
 
 from unblob.extractor import carve_chunk_to_file
 from unblob.file_utils import Endian, File, InvalidInputFormat, StructParser
-from unblob.models import Chunk, Extractor, HexString, StructHandler, ValidChunk
+from unblob.models import (
+    Chunk,
+    Extractor,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -57,6 +66,20 @@ class NetgearCHKHandler(StructHandler):
     C_DEFINITIONS = C_DEFINITIONS
     HEADER_STRUCT = "chk_header_t"
     EXTRACTOR = CHKExtractor()
+
+    DOC = HandlerDoc(
+        name="Netgear CHK",
+        description="Netgear CHK firmware files consist of a custom header containing metadata and checksums, followed by kernel and root filesystem partitions. The header includes fields for partition sizes, checksums, and a board identifier.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Netgear",
+        references=[
+            Reference(
+                title="CHK Image Format Image Builder Tool for the R7800 Series",
+                url="https://github.com/Getnear/R7800/blob/master/tools/firmware-utils/src/mkchkimg.c",
+            )
+        ],
+        limitations=[],
+    )
 
     def is_valid_header(self, header) -> bool:
         if header.header_len != len(header):

--- a/python/unblob/handlers/archive/netgear/trx.py
+++ b/python/unblob/handlers/archive/netgear/trx.py
@@ -7,7 +7,15 @@ from structlog import get_logger
 
 from unblob.extractor import carve_chunk_to_file
 from unblob.file_utils import Endian, File, InvalidInputFormat, StructParser
-from unblob.models import Chunk, Extractor, HexString, StructHandler, ValidChunk
+from unblob.models import (
+    Chunk,
+    Extractor,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    StructHandler,
+    ValidChunk,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -99,6 +107,15 @@ class NetgearTRXv1Handler(NetgearTRXBase):
     C_DEFINITIONS = TRX_V1_C_DEFINITION
     EXTRACTOR = TRXExtractor(TRX_V1_C_DEFINITION)
 
+    DOC = HandlerDoc(
+        name="Netgear TRX v1",
+        description="Netgear TRX v1 firmware format includes a custom header with partition offsets and a CRC32 checksum for integrity verification. It supports up to three partitions defined in the header.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Netgear",
+        references=[],
+        limitations=[],
+    )
+
 
 class NetgearTRXv2Handler(NetgearTRXBase):
     NAME = "trx_v2"
@@ -113,3 +130,12 @@ class NetgearTRXv2Handler(NetgearTRXBase):
     ]
     C_DEFINITIONS = TRX_V2_C_DEFINITION
     EXTRACTOR = TRXExtractor(TRX_V2_C_DEFINITION)
+
+    DOC = HandlerDoc(
+        name="Netgear TRX v2",
+        description="Netgear TRX v2 firmware format includes a custom header with partition offsets and a CRC32 checksum for integrity verification. It supports up to four partitions defined in the header.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Netgear",
+        references=[],
+        limitations=[],
+    )

--- a/python/unblob/handlers/archive/qnap/qnap_nas.py
+++ b/python/unblob/handlers/archive/qnap/qnap_nas.py
@@ -11,6 +11,8 @@ from unblob.models import (
     Endian,
     Extractor,
     Handler,
+    HandlerDoc,
+    HandlerType,
     HexString,
     StructParser,
     ValidChunk,
@@ -110,6 +112,15 @@ class QnapHandler(Handler):
         HexString("F5 7B 47 03"),
     ]
     EXTRACTOR = QnapExtractor()
+
+    DOC = HandlerDoc(
+        name="QNAP NAS",
+        description="QNAP NAS firmware files consist of a custom header, encrypted data sections, and a footer marking the end of the encrypted stream. The header contains metadata such as device ID, firmware version, and encryption details.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="QNAP",
+        references=[],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         context = QTSSearchContext(start_offset=start_offset, file=file, end_offset=-1)

--- a/python/unblob/handlers/archive/rar.py
+++ b/python/unblob/handlers/archive/rar.py
@@ -14,7 +14,15 @@ from structlog import get_logger
 
 from unblob.extractors import Command
 
-from ...models import File, Handler, HexString, ValidChunk
+from ...models import (
+    File,
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -32,13 +40,31 @@ class RarHandler(Handler):
     ]
     EXTRACTOR = Command("unar", "-no-directory", "-p", "", "{inpath}", "-o", "{outdir}")
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="RAR archive files are commonly used for compressed data storage. They can contain multiple files and directories, and support various compression methods.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="RAR 4.x File Format Documentation",
+                url="https://codedread.github.io/bitjs/docs/unrar.html",
+            ),
+            Reference(
+                title="RAR 5.x File Format Documentation",
+                url="https://www.rarlab.com/technote.htm#rarsign",
+            ),
+        ],
+        limitations=["Does not support encrypted RAR files."],
+    )
+
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         try:
             rar_file = rarfile.RarFile(file)
         except (rarfile.Error, ValueError):
             return None
 
-        # RarFile have the side effect of moving the file pointer
+        # RarFile has the side effect of moving the file pointer
         rar_end_offset = file.tell()
 
         return ValidChunk(

--- a/python/unblob/handlers/archive/sevenzip.py
+++ b/python/unblob/handlers/archive/sevenzip.py
@@ -32,8 +32,11 @@ from ...models import (
     DirectoryHandler,
     File,
     Glob,
+    HandlerDoc,
+    HandlerType,
     HexString,
     MultiFile,
+    Reference,
     StructHandler,
     ValidChunk,
 )
@@ -90,6 +93,20 @@ class SevenZipHandler(StructHandler):
     HEADER_STRUCT = HEADER_STRUCT
     EXTRACTOR = Command("7z", "x", "-p", "-y", "{inpath}", "-o{outdir}")
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="The 7-Zip file format is a compressed archive format with high compression ratios, supporting multiple algorithms, CRC checks, and multi-volume archives.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="7-Zip Technical Documentation",
+                url="https://fastapi.metacpan.org/source/BJOERN/Compress-Deflate7-1.0/7zip/DOC/7zFormat.txt",
+            ),
+        ],
+        limitations=[],
+    )
+
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         header = self.parse_header(file)
 
@@ -105,6 +122,20 @@ class MultiVolumeSevenZipHandler(DirectoryHandler):
     EXTRACTOR = MultiFileCommand("7z", "x", "-p", "-y", "{inpath}", "-o{outdir}")
 
     PATTERN = Glob("*.7z.001")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="The 7-Zip file format is a compressed archive format with high compression ratios, supporting multiple algorithms, CRC checks, and multi-volume archives.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="7-Zip Technical Documentation",
+                url="https://fastapi.metacpan.org/source/BJOERN/Compress-Deflate7-1.0/7zip/DOC/7zFormat.txt",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_multifile(self, file: Path) -> Optional[MultiFile]:
         paths = sorted(

--- a/python/unblob/handlers/archive/stuffit.py
+++ b/python/unblob/handlers/archive/stuffit.py
@@ -24,7 +24,15 @@ from structlog import get_logger
 
 from ...extractors import Command
 from ...file_utils import Endian
-from ...models import File, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -66,6 +74,22 @@ class StuffItSITHandler(_StuffItHandlerBase):
     """
     HEADER_STRUCT = "sit_header_t"
 
+    EXTRACTOR = Command("unar", "-no-directory", "-o", "{outdir}", "{inpath}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="StuffIt SIT archives is a legacy compressed archive format commonly used on macOS and earlier Apple systems.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="StuffIt Technologies",
+        references=[
+            Reference(
+                title="StuffIt SIT File Format Documentation",
+                url="https://en.wikipedia.org/wiki/StuffIt",
+            )
+        ],
+        limitations=[],
+    )
+
 
 class StuffIt5Handler(_StuffItHandlerBase):
     NAME = "stuffit5"
@@ -75,7 +99,7 @@ class StuffIt5Handler(_StuffItHandlerBase):
             """
             // "StuffIt (c)1997-"
             53 74 75 66 66 49 74 20 28 63 29 31 39 39 37 2D
-    """
+        """
         )
     ]
 
@@ -91,3 +115,19 @@ class StuffIt5Handler(_StuffItHandlerBase):
         } stuffit5_header_t;
     """
     HEADER_STRUCT = "stuffit5_header_t"
+
+    EXTRACTOR = Command("unar", "-no-directory", "-o", "{outdir}", "{inpath}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="StuffIt SIT archives is a legacy compressed archive format commonly used on macOS and earlier Apple systems.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="StuffIt Technologies",
+        references=[
+            Reference(
+                title="StuffIt SIT File Format Documentation",
+                url="https://en.wikipedia.org/wiki/StuffIt",
+            )
+        ],
+        limitations=[],
+    )

--- a/python/unblob/handlers/archive/tar.py
+++ b/python/unblob/handlers/archive/tar.py
@@ -11,7 +11,10 @@ from ...models import (
     Extractor,
     ExtractResult,
     File,
+    HandlerDoc,
+    HandlerType,
     HexString,
+    Reference,
     Regex,
     StructHandler,
     ValidChunk,
@@ -183,6 +186,24 @@ class TarUstarHandler(_TarHandler):
     # to get to the start of the file.
     PATTERN_MATCH_OFFSET = -MAGIC_OFFSET
 
+    DOC = HandlerDoc(
+        name="tar_ustar",
+        description="USTAR (Uniform Standard Tape Archive) tar files is an extension of the original tar format with additional metadata fields.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="USTAR Format Documentation",
+                url="https://en.wikipedia.org/wiki/Tar_(computing)#USTAR_format",
+            ),
+            Reference(
+                title="POSIX Tar Format Specification",
+                url="https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html",
+            ),
+        ],
+        limitations=[],
+    )
+
 
 def _re_frame(regexp: str):
     """Wrap regexp to ensure its integrity from concatenation.
@@ -231,20 +252,24 @@ class TarUnixHandler(_TarHandler):
             + _padded_field(r"[0-7]", 12)  # char mtime[12]
             + _padded_field(r"[0-7]", 8)  # char chksum[8]
             + r"[0-7\x00]"  # char typeflag[1] - no extensions
-            # Extending/dropping typeflag pattern would cover all tar formats,
-            # r"[0-7xgA-Z\x00]" would probably match all current major implementations.
-            # Info on the values for typeflag:
-            #  - https://en.wikipedia.org/wiki/Tar_(computing)
-            #  - https://www.gnu.org/software/tar/manual/html_node/Standard.html
-            #  - https://github.com/openbsd/src/blob/master/bin/pax/tar.h
-            #  - https://codebrowser.dev/glibc/glibc/posix/tar.h.html
-            #  - https://www.ibm.com/docs/el/aix/7.2?topic=files-tarh-file
-            # Values 'A'-'Z' are reserved for custom implementations.
-            # All other values are reserved for future POSIX.1 revisions.
-            # Several places mention custom extensions and how they extract it,
-            # e.g. the IBM link above is quite explicit.
-            # Since its possible values are somewhat vague,
-            # it might be better still to not include this field in the pattern at all.
         ),
     ]
     PATTERN_MATCH_OFFSET = -100  # go back to beginning of skipped name
+
+    DOC = HandlerDoc(
+        name="tar_unix",
+        description="Unix tar files are a widely used archive format for storing files and directories with metadata.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="Unix Tar Format Documentation",
+                url="https://en.wikipedia.org/wiki/Tar_(computing)",
+            ),
+            Reference(
+                title="GNU Tar Manual",
+                url="https://www.gnu.org/software/tar/manual/",
+            ),
+        ],
+        limitations=[],
+    )

--- a/python/unblob/handlers/archive/xiaomi/hdr.py
+++ b/python/unblob/handlers/archive/xiaomi/hdr.py
@@ -17,6 +17,8 @@ from unblob.models import (
     Endian,
     Extractor,
     ExtractResult,
+    HandlerDoc,
+    HandlerType,
     HexString,
     StructHandler,
     StructParser,
@@ -170,8 +172,16 @@ class HDR1Handler(HDRHandlerBase):
     ]
     C_DEFINITIONS = C_DEFINITIONS
     HEADER_STRUCT = "hdr1_header_t"
-
     EXTRACTOR = HDRExtractor("hdr1_header_t")
+
+    DOC = HandlerDoc(
+        name="Xiaomi HDR1",
+        description="Xiaomi HDR1 firmware files feature a custom header containing metadata, CRC32 checksum, and blob offsets for embedded data. These files are used in Xiaomi devices for firmware updates.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Xiaomi",
+        references=[],
+        limitations=[],
+    )
 
 
 class HDR2Handler(HDRHandlerBase):
@@ -188,3 +198,12 @@ class HDR2Handler(HDRHandlerBase):
     C_DEFINITIONS = C_DEFINITIONS
     HEADER_STRUCT = "hdr2_header_t"
     EXTRACTOR = HDRExtractor("hdr2_header_t")
+
+    DOC = HandlerDoc(
+        name="Xiaomi HDR2",
+        description="Xiaomi HDR2 firmware files feature a custom header with metadata, CRC32 checksum, and blob offsets for embedded data. These files also include additional fields for device ID and region information.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Xiaomi",
+        references=[],
+        limitations=[],
+    )

--- a/python/unblob/handlers/archive/zip.py
+++ b/python/unblob/handlers/archive/zip.py
@@ -6,7 +6,15 @@ from structlog import get_logger
 
 from ...extractors import Command
 from ...file_utils import InvalidInputFormat, iterate_patterns
-from ...models import File, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -79,6 +87,24 @@ class ZIPHandler(StructHandler):
 
     # empty password with -p will make sure the command will not hang
     EXTRACTOR = Command("7z", "x", "-p", "-y", "{inpath}", "-o{outdir}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="ZIP is a widely used archive file format that supports multiple compression methods, file spanning, and optional encryption. It includes metadata such as file names, sizes, and timestamps, and supports both standard and ZIP64 extensions for large files.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor=None,
+        references=[
+            Reference(
+                title="ZIP File Format Specification",
+                url="https://pkware.com/documents/casestudies/APPNOTE.TXT",
+            ),
+            Reference(
+                title="ZIP64 Format Specification",
+                url="https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE-6.3.1.TXT",
+            ),
+        ],
+        limitations=["Does not support encrypted ZIP files."],
+    )
 
     ENCRYPTED_FLAG = 0b0001
     EOCD_RECORD_HEADER = 0x6054B50

--- a/python/unblob/handlers/compression/bzip2.py
+++ b/python/unblob/handlers/compression/bzip2.py
@@ -7,7 +7,16 @@ from structlog import get_logger
 from unblob.extractors import Command
 
 from ...file_utils import InvalidInputFormat, SeekError, StructParser, stream_scan
-from ...models import File, Handler, HexString, Regex, ValidChunk
+from ...models import (
+    File,
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    Regex,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -127,6 +136,24 @@ class BZip2Handler(Handler):
     PATTERNS = [Regex(r"\x42\x5a\x68[\x31-\x39]\x31\x41\x59\x26\x53\x59")]
 
     EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-so", stdout="bzip2.uncompressed")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="The bzip2 format is a block-based compression format that uses the Burrows-Wheeler transform and Huffman coding for high compression efficiency. Each stream starts with a header and consists of one or more compressed blocks, ending with a footer containing a checksum.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="bzip2 File Format Documentation",
+                url="https://sourceware.org/bzip2/manual/manual.html",
+            ),
+            Reference(
+                title="bzip2 Technical Specification",
+                url="https://en.wikipedia.org/wiki/Bzip2",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         if not _validate_stream_header(file):

--- a/python/unblob/handlers/compression/compress.py
+++ b/python/unblob/handlers/compression/compress.py
@@ -40,7 +40,15 @@ from structlog import get_logger
 from unblob.extractors import Command
 
 from ...file_utils import Endian, InvalidInputFormat, convert_int8, convert_int16
-from ...models import File, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -63,6 +71,24 @@ class UnixCompressHandler(StructHandler):
 
     EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-so", stdout="lzw.uncompressed")
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="Unix compress files use the Lempel-Ziv-Welch (LZW) algorithm for data compression and are identified by a 2-byte magic number (0x1F 0x9D). This format supports optional block compression and variable bit lengths ranging from 9 to 16 bits.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="Unix Compress File Format Documentation",
+                url="https://fuchsia.googlesource.com/third_party/wuffs/+/HEAD/std/lzw/README.md",
+            ),
+            Reference(
+                title="LZW Compression Algorithm",
+                url="https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Welch",
+            ),
+        ],
+        limitations=[],
+    )
+
     def unlzw(self, file: File, start_offset: int, max_len: int) -> int:  # noqa: C901
         """Calculate the end of a unix compress stream.
 
@@ -78,7 +104,7 @@ class UnixCompressHandler(StructHandler):
         Copyright (C) 2014, 2015 Mark Adler This software is provided
         'as-is', without any express or implied warranty.  In no event
         will the authors be held liable for any damages arising from
-        the use of this software.  Permission is granted to anyone to
+        the use of this software. Permission is granted to anyone to
         use this software for any purpose, including commercial
         applications, and to alter it and redistribute it freely,
         subject to the following restrictions:

--- a/python/unblob/handlers/compression/gzip.py
+++ b/python/unblob/handlers/compression/gzip.py
@@ -36,8 +36,11 @@ from ...models import (
     File,
     Glob,
     Handler,
+    HandlerDoc,
+    HandlerType,
     HexString,
     MultiFile,
+    Reference,
     ValidChunk,
 )
 from ._gzip_reader import SingleMemberGzipReader
@@ -131,6 +134,24 @@ class GZIPHandler(Handler):
         """
         )
     ]
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="GZIP is a compressed file format that uses the DEFLATE algorithm and includes metadata such as original file name and modification time. It is commonly used for efficient file storage and transfer.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="GZIP File Format Specification",
+                url="https://datatracker.ietf.org/doc/html/rfc1952",
+            ),
+            Reference(
+                title="GZIP Wikipedia",
+                url="https://en.wikipedia.org/wiki/Gzip",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         fp = SingleMemberGzipReader(file)

--- a/python/unblob/handlers/compression/lz4.py
+++ b/python/unblob/handlers/compression/lz4.py
@@ -12,7 +12,15 @@ from structlog import get_logger
 from unblob.extractors import Command
 
 from ...file_utils import Endian, InvalidInputFormat, convert_int8, convert_int32
-from ...models import File, Handler, HexString, ValidChunk
+from ...models import (
+    File,
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -76,6 +84,24 @@ class LegacyFrameHandler(_LZ4HandlerBase):
     NAME = "lz4_legacy"
     PATTERNS = [HexString("02 21 4C 18")]
 
+    DOC = HandlerDoc(
+        name="LZ4 Legacy",
+        description="LZ4 legacy format is an older framing format used prior to the LZ4 Frame specification, featuring a simpler structure and no support for skippable frames or extensive metadata. Unlike the default LZ4 Frame format, it lacks built-in checksums, versioning, or block independence flags, making it less robust and primarily used for backward compatibility.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="LZ4 Frame Format Documentation",
+                url="https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md",
+            ),
+            Reference(
+                title="LZ4 Wikipedia",
+                url="https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)",
+            ),
+        ],
+        limitations=[],
+    )
+
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         self._skip_magic_bytes(file)
 
@@ -112,6 +138,24 @@ class SkippableFrameHandler(_LZ4HandlerBase):
     NAME = "lz4_skippable"
     PATTERNS = [HexString("5? 2A 4D 18")]
 
+    DOC = HandlerDoc(
+        name="LZ4 Skippable",
+        description="LZ4 skippable format is designed to encapsulate arbitrary data within an LZ4 stream allowing compliant parsers to skip over it safely. This format does not contain compressed data itself but is often used for embedding metadata or non-LZ4 content alongside standard frames.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="LZ4 Frame Format Documentation",
+                url="https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md",
+            ),
+            Reference(
+                title="LZ4 Wikipedia",
+                url="https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)",
+            ),
+        ],
+        limitations=[],
+    )
+
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         self._skip_magic_bytes(file)
         frame_size = convert_int32(file.read(FRAME_SIZE_LEN), Endian.LITTLE)
@@ -126,6 +170,24 @@ class DefaultFrameHandler(_LZ4HandlerBase):
     NAME = "lz4_default"
 
     PATTERNS = [HexString("04 22 4D 18")]
+
+    DOC = HandlerDoc(
+        name="LZ4",
+        description="LZ4 is a high-speed lossless compression algorithm designed for real-time data compression with minimal memory usage.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="LZ4 Frame Format Documentation",
+                url="https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md",
+            ),
+            Reference(
+                title="LZ4 Wikipedia",
+                url="https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         self._skip_magic_bytes(file)

--- a/python/unblob/handlers/compression/lzh.py
+++ b/python/unblob/handlers/compression/lzh.py
@@ -3,7 +3,15 @@ from typing import Optional
 
 from ...extractors import Command
 from ...file_utils import Endian
-from ...models import File, Regex, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    Reference,
+    Regex,
+    StructHandler,
+    ValidChunk,
+)
 
 PADDING_LEN = 2
 # CPP/7zip/Archive/LzhHandler.cpp
@@ -55,6 +63,20 @@ class LZHHandler(StructHandler):
     HEADER_STRUCT = "lzh_default_header_t"
 
     EXTRACTOR = Command("7z", "x", "-p", "-y", "{inpath}", "-o{outdir}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="LZH is a legacy archive format that uses various compression methods such as '-lh0-' and '-lh5-'. It was widely used in Japan and on older systems for compressing and archiving files.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="LZH Compression Format",
+                url="https://en.wikipedia.org/wiki/LHA_(file_format)",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         header = self.parse_header(file, Endian.LITTLE)

--- a/python/unblob/handlers/compression/lzip.py
+++ b/python/unblob/handlers/compression/lzip.py
@@ -6,7 +6,15 @@ from structlog import get_logger
 from unblob.extractors import Command
 
 from ...file_utils import Endian, convert_int64
-from ...models import File, Handler, HexString, ValidChunk
+from ...models import (
+    File,
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -20,6 +28,28 @@ class LZipHandler(Handler):
     NAME = "lzip"
 
     PATTERNS = [HexString("4C 5A 49 50 01")]
+
+    EXTRACTOR = Command(
+        "lziprecover", "-k", "-D0", "-i", "{inpath}", "-o", "{outdir}/lz.uncompressed"
+    )
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="Lzip is a lossless compressed file format based on the LZMA algorithm. It features a simple header, CRC-checked integrity, and efficient compression for large files.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="Lzip File Format Documentation",
+                url="https://www.nongnu.org/lzip/manual/lzip_manual.html",
+            ),
+            Reference(
+                title="Lzip Wikipedia",
+                url="https://en.wikipedia.org/wiki/Lzip",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         file.seek(HEADER_LEN, io.SEEK_CUR)
@@ -38,7 +68,3 @@ class LZipHandler(Handler):
             file.seek(-8, io.SEEK_CUR)
 
         return ValidChunk(start_offset=start_offset, end_offset=end_offset)
-
-    EXTRACTOR = Command(
-        "lziprecover", "-k", "-D0", "-i", "{inpath}", "-o", "{outdir}/lz.uncompressed"
-    )

--- a/python/unblob/handlers/compression/lzma.py
+++ b/python/unblob/handlers/compression/lzma.py
@@ -13,7 +13,15 @@ from ...file_utils import (
     convert_int32,
     convert_int64,
 )
-from ...models import File, Handler, HexString, ValidChunk
+from ...models import (
+    File,
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -45,6 +53,24 @@ class LZMAHandler(Handler):
     ]
 
     EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-so", stdout="lzma.uncompressed")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="LZMA is a compression format based on the Lempel-Ziv-Markov chain algorithm, offering high compression ratios and efficient decompression. It is commonly used in standalone .lzma files and embedded in other formats like 7z.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="LZMA File Format Documentation",
+                url="https://tukaani.org/xz/lzma.txt",
+            ),
+            Reference(
+                title="LZMA Wikipedia",
+                url="https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm",
+            ),
+        ],
+        limitations=[],
+    )
 
     def is_valid_stream(self, dictionary_size: int, uncompressed_size: int) -> bool:
         # dictionary size is non-zero (section 1.1.2 of format definition)

--- a/python/unblob/handlers/compression/lzo.py
+++ b/python/unblob/handlers/compression/lzo.py
@@ -8,7 +8,15 @@ from structlog import get_logger
 from unblob.extractors import Command
 
 from ...file_utils import Endian, convert_int32
-from ...models import File, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -79,6 +87,24 @@ class LZOHandler(StructHandler):
     HEADER_STRUCT = "lzo_header"
 
     EXTRACTOR = Command("lzop", "-d", "-f", "-f", "-N", "-p{outdir}", "{inpath}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="LZO is a data compression format featuring a simple header structure and optional checksum verification. It is optimized for fast decompression and supports various compression levels and flags for additional metadata.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="LZO File Format Documentation",
+                url="http://www.lzop.org/",
+            ),
+            Reference(
+                title="LZO Wikipedia",
+                url="https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Oberhumer",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         header = self.cparser_be.lzo_header_no_filter_t(file)

--- a/python/unblob/handlers/compression/uzip.py
+++ b/python/unblob/handlers/compression/uzip.py
@@ -17,6 +17,9 @@ from unblob.models import (
     Extractor,
     ExtractResult,
     File,
+    HandlerDoc,
+    HandlerType,
+    Reference,
     Regex,
     StructHandler,
     ValidChunk,
@@ -110,6 +113,20 @@ class UZIPHandler(StructHandler):
     HEADER_STRUCT = HEADER_STRUCT
     C_DEFINITIONS = C_DEFINITIONS
     EXTRACTOR = UZIPExtractor()
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="FreeBSD UZIP is a block-based compressed disk image format. It uses a table of contents (TOC) to index compressed blocks, supporting ZLIB, LZMA, and ZSTD compression algorithms.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor="FreeBSD",
+        references=[
+            Reference(
+                title="FreeBSD UZIP Documentation",
+                url="https://github.com/freebsd/freebsd-src/tree/master/sys/geom/uzip",
+            ),
+        ],
+        limitations=[],
+    )
 
     def is_valid_header(self, header) -> bool:
         return (

--- a/python/unblob/handlers/compression/xz.py
+++ b/python/unblob/handlers/compression/xz.py
@@ -17,7 +17,16 @@ from ...file_utils import (
     round_up,
     stream_scan,
 )
-from ...models import File, Handler, HexString, InvalidInputFormat, ValidChunk
+from ...models import (
+    File,
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    InvalidInputFormat,
+    Reference,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -167,6 +176,24 @@ class XZHandler(Handler):
     PATTERNS = [HexString("FD 37 7A 58 5A 00")]
 
     EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-so", stdout="xz.uncompressed")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="XZ is a compressed file format that uses the LZMA2 algorithm for high compression efficiency. It is designed for general-purpose data compression with support for integrity checks and padding for alignment.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="XZ File Format Specification",
+                url="https://tukaani.org/xz/xz-file-format-1.0.4.txt",
+            ),
+            Reference(
+                title="XZ Wikipedia",
+                url="https://en.wikipedia.org/wiki/XZ_Utils",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         file.seek(start_offset + len(STREAM_START_MAGIC), io.SEEK_SET)

--- a/python/unblob/handlers/compression/zlib.py
+++ b/python/unblob/handlers/compression/zlib.py
@@ -8,7 +8,16 @@ from structlog import get_logger
 from unblob.handlers.archive.dmg import DMGHandler
 
 from ...file_utils import DEFAULT_BUFSIZE, InvalidInputFormat
-from ...models import Extractor, File, Handler, Regex, ValidChunk
+from ...models import (
+    Extractor,
+    File,
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    Reference,
+    Regex,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -35,6 +44,24 @@ class ZlibHandler(Handler):
     ]
 
     EXTRACTOR = ZlibExtractor()
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="The zlib format is a compressed data format based on the DEFLATE algorithm, often used for data compression in various applications. It includes a lightweight header and checksum for data integrity.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="zlib File Format Specification",
+                url="https://www.zlib.net/manual.html",
+            ),
+            Reference(
+                title="zlib Wikipedia",
+                url="https://en.wikipedia.org/wiki/Zlib",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         for pattern in DMGHandler.PATTERNS:

--- a/python/unblob/handlers/compression/zstd.py
+++ b/python/unblob/handlers/compression/zstd.py
@@ -6,7 +6,15 @@ from structlog import get_logger
 from unblob.extractors import Command
 
 from ...file_utils import Endian, InvalidInputFormat, convert_int8
-from ...models import File, Handler, HexString, ValidChunk
+from ...models import (
+    File,
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -25,6 +33,24 @@ class ZSTDHandler(Handler):
     PATTERNS = [HexString("28 B5 2F FD")]
 
     EXTRACTOR = Command("zstd", "-d", "{inpath}", "-o", "{outdir}/zstd.uncompressed")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="Zstandard (ZSTD) is a fast lossless compression algorithm with high compression ratios, designed for modern data storage and transfer. Its file format includes a frame structure with optional dictionary support and checksums for data integrity.",
+        handler_type=HandlerType.COMPRESSION,
+        vendor=None,
+        references=[
+            Reference(
+                title="Zstandard File Format Specification",
+                url="https://facebook.github.io/zstd/zstd_manual.html",
+            ),
+            Reference(
+                title="Zstandard Wikipedia",
+                url="https://en.wikipedia.org/wiki/Zstandard",
+            ),
+        ],
+        limitations=[],
+    )
 
     def get_frame_header_size(self, frame_header_descriptor: int) -> int:
         single_segment = (frame_header_descriptor >> 5 & 1) & 0b1

--- a/python/unblob/handlers/executable/elf.py
+++ b/python/unblob/handlers/executable/elf.py
@@ -17,7 +17,14 @@ from unblob.file_utils import (
     iterate_patterns,
     round_up,
 )
-from unblob.models import HexString, StructHandler, ValidChunk
+from unblob.models import (
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 lief.logging.disable()
 
@@ -347,6 +354,24 @@ class ELF32Handler(_ELFBase):
     """
     HEADER_STRUCT = "elf_header_32_t"
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="The 32-bit ELF (Executable and Linkable Format) is a binary file format used for executables, object code, shared libraries, and core dumps. It supports 32-bit addressing and includes headers for program and section information.",
+        handler_type=HandlerType.EXECUTABLE,
+        vendor=None,
+        references=[
+            Reference(
+                title="ELF File Format Specification",
+                url="https://refspecs.linuxfoundation.org/elf/elf.pdf",
+            ),
+            Reference(
+                title="ELF Wikipedia",
+                url="https://en.wikipedia.org/wiki/Executable_and_Linkable_Format",
+            ),
+        ],
+        limitations=[],
+    )
+
 
 class ELF64Handler(_ELFBase):
     NAME = "elf64"
@@ -425,3 +450,21 @@ class ELF64Handler(_ELFBase):
         } module_signature_t;
     """
     HEADER_STRUCT = "elf_header_64_t"
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="The 64-bit ELF (Executable and Linkable Format) is a binary file format used for executables, shared libraries, and core dumps. It supports 64-bit addressing and includes headers for program and section information.",
+        handler_type=HandlerType.EXECUTABLE,
+        vendor=None,
+        references=[
+            Reference(
+                title="ELF File Format Specification",
+                url="https://refspecs.linuxfoundation.org/elf/elf.pdf",
+            ),
+            Reference(
+                title="ELF Wikipedia",
+                url="https://en.wikipedia.org/wiki/Executable_and_Linkable_Format",
+            ),
+        ],
+        limitations=[],
+    )

--- a/python/unblob/handlers/filesystem/android/erofs.py
+++ b/python/unblob/handlers/filesystem/android/erofs.py
@@ -9,7 +9,10 @@ from unblob.file_utils import (
 )
 from unblob.models import (
     File,
+    HandlerDoc,
+    HandlerType,
     HexString,
+    Reference,
     StructHandler,
     ValidChunk,
 )
@@ -50,6 +53,24 @@ class EROFSHandler(StructHandler):
         "{inpath}",
     )
     PATTERN_MATCH_OFFSET = -SUPERBLOCK_OFFSET
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="EROFS (Enhanced Read-Only File System) is a lightweight, high-performance file system designed for read-only use cases, commonly used in Android and Linux. It features compression support, metadata efficiency, and a fixed superblock structure starting at offset 0x400.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor="Google",
+        references=[
+            Reference(
+                title="EROFS Documentation",
+                url="https://www.kernel.org/doc/html/latest/filesystems/erofs.html",
+            ),
+            Reference(
+                title="EROFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/Enhanced_Read-Only_File_System",
+            ),
+        ],
+        limitations=[],
+    )
 
     def is_valid_header(self, header) -> bool:
         try:

--- a/python/unblob/handlers/filesystem/android/sparse.py
+++ b/python/unblob/handlers/filesystem/android/sparse.py
@@ -6,7 +6,15 @@ from structlog import get_logger
 from unblob.extractors.command import Command
 
 from ....file_utils import Endian
-from ....models import File, Regex, StructHandler, ValidChunk
+from ....models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    Reference,
+    Regex,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -58,6 +66,24 @@ class SparseHandler(StructHandler):
     HEADER_STRUCT = "sparse_header_t"
 
     EXTRACTOR = Command("simg2img", "{inpath}", "{outdir}/raw.image")
+
+    DOC = HandlerDoc(
+        name="Android Sparse Image",
+        description="Android sparse images are a file format used to efficiently store disk images by representing sequences of zero blocks compactly. The format includes a file header, followed by chunk headers and data, with support for raw, fill, and 'don't care' chunks.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor="Google",
+        references=[
+            Reference(
+                title="Android Sparse Image Format Documentation",
+                url="https://formats.kaitai.io/android_sparse/",
+            ),
+            Reference(
+                title="simg2img Tool",
+                url="https://github.com/anestisb/android-simg2img",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         header = self.parse_header(file, Endian.LITTLE)

--- a/python/unblob/handlers/filesystem/cramfs.py
+++ b/python/unblob/handlers/filesystem/cramfs.py
@@ -5,7 +5,15 @@ from typing import Optional
 from unblob.extractors import Command
 
 from ...file_utils import Endian, convert_int32, get_endian
-from ...models import File, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 CRAMFS_FLAG_FSID_VERSION_2 = 0x00000001
 BIG_ENDIAN_MAGIC = 0x28_CD_3D_45
@@ -40,6 +48,24 @@ class CramFSHandler(StructHandler):
     HEADER_STRUCT = "cramfs_header_t"
 
     EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-o{outdir}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="CramFS is a lightweight, read-only file system format designed for simplicity and efficiency in embedded systems. It uses zlib compression for file data and stores metadata in a compact, contiguous structure.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="CramFS Documentation",
+                url="https://web.archive.org/web/20160304053532/http://sourceforge.net/projects/cramfs/",
+            ),
+            Reference(
+                title="CramFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/Cramfs",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         endian = get_endian(file, BIG_ENDIAN_MAGIC)

--- a/python/unblob/handlers/filesystem/extfs.py
+++ b/python/unblob/handlers/filesystem/extfs.py
@@ -5,7 +5,15 @@ from structlog import get_logger
 from unblob.file_utils import InvalidInputFormat
 
 from ...extractors import Command
-from ...models import File, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -65,6 +73,24 @@ class EXTHandler(StructHandler):
     PATTERN_MATCH_OFFSET = -MAGIC_OFFSET
 
     EXTRACTOR = Command("debugfs", "-R", 'rdump / "{outdir}"', "{inpath}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="ExtFS (Ext2/Ext3/Ext4) is a family of journaling file systems commonly used in Linux-based operating systems. It supports features like large file sizes, extended attributes, and journaling for improved reliability.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="Ext4 Documentation",
+                url="https://www.kernel.org/doc/html/latest/filesystems/ext4/index.html",
+            ),
+            Reference(
+                title="ExtFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/Ext4",
+            ),
+        ],
+        limitations=[],
+    )
 
     def valid_header(self, header) -> bool:
         if header.s_state not in [0x0, 0x1, 0x2]:

--- a/python/unblob/handlers/filesystem/fat.py
+++ b/python/unblob/handlers/filesystem/fat.py
@@ -7,7 +7,15 @@ from structlog import get_logger
 from unblob.extractors.command import Command
 from unblob.file_utils import InvalidInputFormat
 
-from ...models import File, Handler, HexString, ValidChunk
+from ...models import (
+    File,
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -45,6 +53,20 @@ class FATHandler(Handler):
     ]
 
     EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-o{outdir}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="FAT (File Allocation Table) is a file system format used for organizing and managing files on storage devices, supporting FAT12, FAT16, and FAT32 variants. It uses a table to map file clusters, enabling efficient file storage and retrieval.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="FAT Wikipedia",
+                url="https://en.wikipedia.org/wiki/File_Allocation_Table",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         pyfat_fs = PyFatNoClose(offset=start_offset)

--- a/python/unblob/handlers/filesystem/iso9660.py
+++ b/python/unblob/handlers/filesystem/iso9660.py
@@ -5,7 +5,15 @@ from structlog import get_logger
 from unblob.extractors import Command
 from unblob.file_utils import Endian
 
-from ...models import File, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -111,11 +119,29 @@ class ISO9660FSHandler(StructHandler):
 
     EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-o{outdir}")
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="ISO 9660 is a file system standard for optical disc media, defining a volume descriptor structure and directory hierarchy. It is widely used for CD-ROMs and supports cross-platform compatibility.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="ISO 9660 Specification",
+                url="https://wiki.osdev.org/ISO_9660",
+            ),
+            Reference(
+                title="ISO 9660 Wikipedia",
+                url="https://en.wikipedia.org/wiki/ISO_9660",
+            ),
+        ],
+        limitations=[],
+    )
+
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         header = self.parse_header(file, Endian.LITTLE)
         size = from_733(header.volume_space_size) * from_723(header.logical_block_size)
 
-        # We need to substract the system area given that we matched on volume descriptor,
+        # We need to subtract the system area given that we matched on volume descriptor,
         # which is the first struct afterward.
         real_start_offset = start_offset - SYSTEM_AREA_SIZE
         if real_start_offset < 0:

--- a/python/unblob/handlers/filesystem/jffs2.py
+++ b/python/unblob/handlers/filesystem/jffs2.py
@@ -13,7 +13,15 @@ from unblob.file_utils import (
 )
 
 from ...extractors import Command
-from ...models import File, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -155,6 +163,24 @@ class JFFS2OldHandler(_JFFS2Base):
 
     BIG_ENDIAN_MAGIC = 0x19_84
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="JFFS2 (Journaling Flash File System version 2) is a log-structured file system for flash memory devices, using an older magic number to identify its nodes. It organizes data into nodes with headers containing metadata and CRC checks for integrity.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="JFFS2 Documentation",
+                url="https://sourceware.org/jffs2/",
+            ),
+            Reference(
+                title="JFFS2 Wikipedia",
+                url="https://en.wikipedia.org/wiki/JFFS2",
+            ),
+        ],
+        limitations=[],
+    )
+
 
 class JFFS2NewHandler(_JFFS2Base):
     NAME = "jffs2_new"
@@ -165,3 +191,21 @@ class JFFS2NewHandler(_JFFS2Base):
     ]
 
     BIG_ENDIAN_MAGIC = 0x19_85
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="JFFS2 (Journaling Flash File System version 2) is a log-structured file system for flash memory devices, using an older magic number to identify its nodes. It organizes data into nodes with headers containing metadata and CRC checks for integrity.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="JFFS2 Documentation",
+                url="https://sourceware.org/jffs2/",
+            ),
+            Reference(
+                title="JFFS2 Wikipedia",
+                url="https://en.wikipedia.org/wiki/JFFS2",
+            ),
+        ],
+        limitations=[],
+    )

--- a/python/unblob/handlers/filesystem/ntfs.py
+++ b/python/unblob/handlers/filesystem/ntfs.py
@@ -5,7 +5,15 @@ from structlog import get_logger
 from unblob.file_utils import InvalidInputFormat
 
 from ...extractors import Command
-from ...models import File, Regex, StructHandler, ValidChunk
+from ...models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    Reference,
+    Regex,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -60,6 +68,20 @@ class NTFSHandler(StructHandler):
     HEADER_STRUCT = "ntfs_boot_t"
 
     EXTRACTOR = Command("7z", "x", "-x![SYSTEM]", "-y", "{inpath}", "-o{outdir}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="NTFS (New Technology File System) is a proprietary file system developed by Microsoft, featuring metadata support, advanced data structures, and journaling for reliability. It is commonly used in Windows operating systems for efficient storage and retrieval of files.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor="Microsoft",
+        references=[
+            Reference(
+                title="NTFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/NTFS",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         header = self.parse_header(file)

--- a/python/unblob/handlers/filesystem/romfs.py
+++ b/python/unblob/handlers/filesystem/romfs.py
@@ -19,7 +19,10 @@ from ...models import (
     Extractor,
     ExtractResult,
     File,
+    HandlerDoc,
+    HandlerType,
     HexString,
+    Reference,
     StructHandler,
     ValidChunk,
 )
@@ -328,6 +331,24 @@ class RomFSFSHandler(StructHandler):
     """
     HEADER_STRUCT = "romfs_header"
     EXTRACTOR = RomfsExtractor()
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="RomFS is a simple, space-efficient, read-only file system format designed for embedded systems. It features 16-byte alignment, minimal metadata overhead, and supports basic file types like directories, files, symlinks, and devices.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="RomFS Documentation",
+                url="https://www.kernel.org/doc/html/latest/filesystems/romfs.html",
+            ),
+            Reference(
+                title="RomFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/Romfs",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         if not valid_checksum(file.read(512)):

--- a/python/unblob/handlers/filesystem/squashfs.py
+++ b/python/unblob/handlers/filesystem/squashfs.py
@@ -6,7 +6,16 @@ from structlog import get_logger
 from unblob.extractors import Command
 
 from ...file_utils import Endian, StructParser, get_endian, round_up
-from ...models import Extractor, File, HexString, StructHandler, ValidChunk
+from ...models import (
+    Extractor,
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -113,6 +122,24 @@ class SquashFSv1Handler(_SquashFSBase):
     """
     HEADER_STRUCT = "squashfs_super_block_t"
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="SquashFS version 1 is a compressed, read-only file system format designed for minimal storage usage. It is commonly used in embedded systems and early Linux distributions.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="SquashFS Documentation",
+                url="https://dr-emann.github.io/squashfs/",
+            ),
+            Reference(
+                title="SquashFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/SquashFS",
+            ),
+        ],
+        limitations=[],
+    )
+
 
 class SquashFSv2Handler(SquashFSv1Handler):
     NAME = "squashfs_v2"
@@ -136,6 +163,24 @@ class SquashFSv2Handler(SquashFSv1Handler):
         ),
     ]
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="SquashFS version 2 is a compressed, read-only file system format designed for minimal storage usage. It builds upon version 1 with additional features and improvements for embedded systems and Linux distributions.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="SquashFS Documentation",
+                url="https://dr-emann.github.io/squashfs/",
+            ),
+            Reference(
+                title="SquashFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/SquashFS",
+            ),
+        ],
+        limitations=[],
+    )
+
 
 class SquashFSv3Handler(_SquashFSBase):
     NAME = "squashfs_v3"
@@ -158,6 +203,24 @@ class SquashFSv3Handler(_SquashFSBase):
         """
         ),
     ]
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="SquashFS version 3 is a compressed, read-only file system format designed for minimal storage usage. It is widely used in embedded systems and Linux distributions for efficient storage and fast access.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="SquashFS Documentation",
+                url="https://dr-emann.github.io/squashfs/",
+            ),
+            Reference(
+                title="SquashFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/SquashFS",
+            ),
+        ],
+        limitations=[],
+    )
 
     C_DEFINITIONS = r"""
         typedef struct squashfs3_super_block
@@ -219,6 +282,24 @@ class SquashFSv3DDWRTHandler(SquashFSv3Handler):
         ),
     ]
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="SquashFS version 3 DD-WRT is a variant of the SquashFS v3 format used in DD-WRT firmware. It features a unique magic number and may include specific optimizations for embedded systems.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor="DDWRT",
+        references=[
+            Reference(
+                title="SquashFS Documentation",
+                url="https://dr-emann.github.io/squashfs/",
+            ),
+            Reference(
+                title="SquashFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/SquashFS",
+            ),
+        ],
+        limitations=[],
+    )
+
 
 class SquashFSv3BroadcomHandler(SquashFSv3Handler):
     NAME = "squashfs_v3_broadcom"
@@ -247,6 +328,24 @@ class SquashFSv3BroadcomHandler(SquashFSv3Handler):
         ),
     ]
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="SquashFS version 3 Broadcom is a variant of the SquashFS v3 format used in Broadcom firmware. It features a unique magic number and may include specific optimizations for Broadcom devices.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor="Broadcom",
+        references=[
+            Reference(
+                title="SquashFS Documentation",
+                url="https://dr-emann.github.io/squashfs/",
+            ),
+            Reference(
+                title="SquashFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/SquashFS",
+            ),
+        ],
+        limitations=[],
+    )
+
 
 class SquashFSv3NSHandler(SquashFSv3Handler):
     NAME = "squashfs_v3_nonstandard"
@@ -273,6 +372,24 @@ class SquashFSv3NSHandler(SquashFSv3Handler):
         """
         ),
     ]
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="SquashFS version 3 is a compressed, read-only file system format designed for minimal storage usage. It is widely used in embedded systems and Linux distributions for efficient storage and fast access.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor="unknown",
+        references=[
+            Reference(
+                title="SquashFS Documentation",
+                url="https://dr-emann.github.io/squashfs/",
+            ),
+            Reference(
+                title="SquashFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/SquashFS",
+            ),
+        ],
+        limitations=[],
+    )
 
 
 class SquashFSv4LEHandler(_SquashFSBase):
@@ -314,6 +431,24 @@ class SquashFSv4LEHandler(_SquashFSBase):
         } squashfs4_super_block_t;
     """
     HEADER_STRUCT = "squashfs4_super_block_t"
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="SquashFS version 4 is a compressed, read-only file system format designed for minimal storage usage and fast access. It is widely used in embedded systems and Linux distributions for efficient storage management.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="SquashFS Documentation",
+                url="https://dr-emann.github.io/squashfs/",
+            ),
+            Reference(
+                title="SquashFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/SquashFS",
+            ),
+        ],
+        limitations=[],
+    )
 
 
 class SquashFSv4BEExtractor(Extractor):
@@ -367,3 +502,21 @@ class SquashFSv4BEHandler(SquashFSv4LEHandler):
     ]
 
     EXTRACTOR = SquashFSv4BEExtractor()
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="SquashFS version 4 is a compressed, read-only file system format designed for minimal storage usage and fast access. It supports both big-endian and little-endian formats and is widely used in embedded systems and Linux distributions.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="SquashFS Documentation",
+                url="https://dr-emann.github.io/squashfs/",
+            ),
+            Reference(
+                title="SquashFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/SquashFS",
+            ),
+        ],
+        limitations=[],
+    )

--- a/python/unblob/handlers/filesystem/ubi.py
+++ b/python/unblob/handlers/filesystem/ubi.py
@@ -9,7 +9,16 @@ from unblob.extractors import Command
 
 from ...file_utils import InvalidInputFormat, SeekError, get_endian, iterate_patterns
 from ...iter_utils import get_intervals
-from ...models import File, Handler, HexString, StructHandler, ValidChunk
+from ...models import (
+    File,
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -83,6 +92,24 @@ class UBIFSHandler(StructHandler):
 
     EXTRACTOR = Command("ubireader_extract_files", "{inpath}", "-w", "-o", "{outdir}")
 
+    DOC = HandlerDoc(
+        name=NAME,
+        description="UBIFS (Unsorted Block Image File System) is a flash file system designed for raw flash memory, providing wear leveling, error correction, and power failure resilience. It operates on top of UBI volumes, which manage flash blocks on raw NAND or NOR flash devices.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="UBIFS Documentation",
+                url="https://www.kernel.org/doc/html/latest/filesystems/ubifs.html",
+            ),
+            Reference(
+                title="UBIFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/UBIFS",
+            ),
+        ],
+        limitations=[],
+    )
+
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         endian = get_endian(file, self._BIG_ENDIAN_MAGIC)
         sb_header = self.parse_header(file, endian)
@@ -117,6 +144,24 @@ class UBIHandler(Handler):
     PATTERNS = [HexString("55 42 49 23 01  // UBI# and version 1")]
 
     EXTRACTOR = UBIExtractor("ubireader_extract_images", "{inpath}", "-o", "{outdir}")
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="UBI (Unsorted Block Image) is a volume management system for raw flash devices, providing wear leveling and bad block management. It operates as a layer between the MTD subsystem and higher-level filesystems like UBIFS.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="UBI Documentation",
+                url="https://www.kernel.org/doc/html/latest/driver-api/ubi.html",
+            ),
+            Reference(
+                title="UBI Wikipedia",
+                url="https://en.wikipedia.org/wiki/UBIFS#UBI",
+            ),
+        ],
+        limitations=[],
+    )
 
     def _guess_peb_size(self, file: File) -> int:
         # Since we don't know the PEB size, we need to guess it. At the moment we just find the

--- a/python/unblob/handlers/filesystem/yaffs.py
+++ b/python/unblob/handlers/filesystem/yaffs.py
@@ -21,7 +21,16 @@ from unblob.file_utils import (
     read_until_past,
     snull,
 )
-from unblob.models import Extractor, ExtractResult, Handler, HexString, ValidChunk
+from unblob.models import (
+    Extractor,
+    ExtractResult,
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    ValidChunk,
+)
 
 logger = get_logger()
 
@@ -744,6 +753,24 @@ class YAFFSHandler(Handler):
     ]
 
     EXTRACTOR = YAFFSExtractor()
+
+    DOC = HandlerDoc(
+        name=NAME,
+        description="YAFFS (Yet Another Flash File System) is a log-structured file system designed for NAND flash memory, storing data in fixed-size chunks with associated metadata. It supports features like wear leveling, error correction, and efficient handling of power loss scenarios.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="YAFFS Documentation",
+                url="https://yaffs.net/",
+            ),
+            Reference(
+                title="YAFFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/YAFFS",
+            ),
+        ],
+        limitations=[],
+    )
 
     def calculate_chunk(self, file: File, start_offset: int) -> Optional[ValidChunk]:
         parser = instantiate_parser(file, start_offset)

--- a/python/unblob/models.py
+++ b/python/unblob/models.py
@@ -1,4 +1,5 @@
 import abc
+import dataclasses
 import itertools
 import json
 from collections.abc import Iterable
@@ -28,6 +29,33 @@ logger = get_logger()
 #
 # file ──► pattern match ──► ValidChunk
 #
+
+
+class HandlerType(Enum):
+    ARCHIVE = "Archive"
+    COMPRESSION = "Compression"
+    FILESYSTEM = "FileSystem"
+    EXECUTABLE = "Executable"
+
+
+@dataclasses.dataclass(frozen=True)
+class Reference:
+    title: str
+    url: str
+
+
+@dataclasses.dataclass
+class HandlerDoc:
+    name: str
+    description: Union[str, None]
+    vendor: Union[str, None]
+    references: list[Reference]
+    limitations: list[str]
+    handler_type: HandlerType
+    fully_supported: bool = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        self.fully_supported = len(self.limitations) == 0
 
 
 @attrs.define(frozen=True)
@@ -417,6 +445,8 @@ class DirectoryHandler(abc.ABC):
 
     PATTERN: DirectoryPattern
 
+    DOC: HandlerDoc
+
     @classmethod
     def get_dependencies(cls):
         """Return external command dependencies needed for this handler to work."""
@@ -452,6 +482,8 @@ class Handler(abc.ABC, Generic[TExtractor]):
     PATTERN_MATCH_OFFSET: int = 0
 
     EXTRACTOR: TExtractor
+
+    DOC: HandlerDoc
 
     @classmethod
     def get_dependencies(cls):

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -5,9 +5,17 @@ import sys
 
 import unblob.plugins
 from unblob import cli
+from unblob.doc import generate_markdown
 from unblob.file_utils import File, FileSystem, iterbits, round_down
 from unblob.handlers.compression.lzo import HeaderFlags as LZOHeaderFlags
-from unblob.models import SingleFile, TaskResult, _JSONEncoder
+from unblob.models import (
+    Handler,
+    HandlerDoc,
+    HandlerType,
+    SingleFile,
+    TaskResult,
+    _JSONEncoder,
+)
 from unblob.parser import _HexStringToRegex
 from unblob.report import ChunkReport, FileMagicReport, StatReport
 
@@ -48,3 +56,13 @@ LZOHeaderFlags.MULTIPART
 LZOHeaderFlags.NAME_DEFAULT
 LZOHeaderFlags.STDIN
 LZOHeaderFlags.STDOUT
+
+HandlerType.ARCHIVE
+HandlerType.EXECUTABLE
+HandlerType.COMPRESSION
+HandlerType.FILESYSTEM
+
+HandlerDoc
+generate_markdown
+
+Handler.DOC


### PR DESCRIPTION
Early draft for handler documentation.

It introduces a `HandlerDoc` class that both `Handler` and `DirectoryHandler` requires under the `DOC` field. This class takes a name, a handler type, a description, and a list of references.

This is both useful for maintainers since the handlers will contain detailed information and references within the code (kinda like module info in Metasploit), and users as this is ultimately used to dynamically generate the documentation available on unblob.org

This is a very early draft. All the DOC fields were generated by copilot and must be reviewed. The markdown structure and what we do with the DOC content is still open to discussion.