### PR TITLE
feat(handler): add upx decompression to elf executable

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -17,6 +17,7 @@
   simg2img,
   ubi_reader,
   unar,
+  upx,
   zstd,
   versionCheckHook,
   rustPlatform,
@@ -36,6 +37,7 @@ let
     ubi_reader
     simg2img
     unar
+    upx
     zstd
     lz4
   ];

--- a/tests/integration/executable/elf/elf64/__input__/hello.upx
+++ b/tests/integration/executable/elf/elf64/__input__/hello.upx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1961a6f9723ea06f99ebd59b2ce6337622fa561eb8b14bf17f0f10c8dd02d92
+size 5820

--- a/tests/integration/executable/elf/elf64/__input__/hello_notes.upx
+++ b/tests/integration/executable/elf/elf64/__input__/hello_notes.upx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff88b41ffd02dc9863bd4a360c4f4cc510589067034ff6c804f96ee81dac5df0
+size 6340

--- a/tests/integration/executable/elf/elf64/__output__/hello.upx_extract/hello.elf
+++ b/tests/integration/executable/elf/elf64/__output__/hello.upx_extract/hello.elf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6421be7ba2f344caca2a6d1ae72a91782f976d6006f248459770865550440538
+size 15960

--- a/tests/integration/executable/elf/elf64/__output__/hello_notes.upx_extract/hello_notes.elf
+++ b/tests/integration/executable/elf/elf64/__output__/hello_notes.upx_extract/hello_notes.elf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6421be7ba2f344caca2a6d1ae72a91782f976d6006f248459770865550440538
+size 15960


### PR DESCRIPTION
UPX is a free, secure, portable, extendable, high-performance
executable packer for several executable formats. 

The UPX header is written after the elf header. The offset depends on how big the ELF is. Luckily UPX writes in the last 4 bytes of the compressed file the offet to the header. 

Create UPX file :
> `upx --best foo.elf -ofoo.upx`

Decompress UPX file: 
> `upx -d foo.upx -ofoo.decompressed`

Key notes:
- UPX uses a lot of alignments, which is why computing the UPX header after the ELF header can cause discrepancies
- The UPX header is called loader and is 12 bytes long, with `UPX!` as magic
- File format is little endian
- Supports 32 bit & 64 bit platforms
- UPX uses `stat` to get information about the compressed file, which is why the total compressed file size is no where to be found
- Checksum is calculated over the stubloader and uses adler32
- Loader size is **not** the actual size, since it is aligned. The alignment must be subtracted. It will be used to determine the data length used in the checksum function

Header format :
> 4 bytes : Checksum
> 4 bytes : Magic
> 2 bytes : Loader size
> 1 byte : Version
> 1 byte : Format

Using python's `lief` library,  it possible to get the offset of the last segment. Subtracting the loader size of it, returns the stub loader offset **after** alignment. Subtracting the alignment return the **correct** loader offset used for the checksum. Following the official UPX github repository, in `src/p_lx_elf.cpp` line `385` to `447` is where the alignment is done. Before calculating the total alignment, `xct_off` checks for shared android library in the section names of the elf header. If there is one present, this will change the total alignment afterwards.  To summarize, UPX aligns the loader size to be a multiple of 4, with additional steps in between. The alignment is the difference between the loader size in the header and the value after the alignment calculation. The checksum size the loader size minus the alignment.

[Sources]
https://bbs.kanxue.com/thread-248779.htm
https://github.com/upx/upx/blob/devel/src/stub/src/include/linux.h
https://github.com/upx/upx/blob/devel/src/p_lx_elf.cpp
https://www.programmersought.com/article/58884806733/