### PR TITLE
fix: correct broken references

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -127,7 +127,7 @@ run all tests, with `python -m pytest tests/` in the activated virtualenv.
 ## Writing handlers
 
 Every handler inherits from the abstract class `Handler` located in
-[unblob/models.py](https://github.com/onekey-sec/unblob/blob/main/unblob/models.py):
+[unblob/models.py](https://github.com/onekey-sec/unblob/blob/main/python/unblob/models.py):
 
 ```python
 class Handler(abc.ABC):
@@ -218,7 +218,7 @@ If you need to parse structure using different endianness, the class exposes two
 
 `DirectoryHandler` is a specialized handler responsible for identifying multi-file formats
 located in a directory or in a subtree. The abstract class is located in
-[unblob/models.py](https://github.com/onekey-sec/unblob/blob/main/unblob/models.py):
+[unblob/models.py](https://github.com/onekey-sec/unblob/blob/main/python/unblob/models.py):
 
 ```python
 class DirectoryHandler(abc.ABC):
@@ -444,7 +444,7 @@ unblob -P ./myplugins/ ...
 
 We developed a bunch of utility functions which helped us during the development of
 existing unblob handlers. Do not hesitate to take a look at them in
-[unblob/file_utils.py](https://github.com/onekey-sec/unblob/blob/main/unblob/file_utils.py)
+[unblob/file_utils.py](https://github.com/onekey-sec/unblob/blob/main/python/unblob/file_utils.py)
 to see if any of those functions could help you during your own handler
 development.
 
@@ -545,7 +545,7 @@ the `Extractor` Python class.
 ### Extractor class
 
 The `Extractor` interface is defined in
-[unblob/models.py](https://github.com/onekey-sec/unblob/blob/main/unblob/models.py):
+[unblob/models.py](https://github.com/onekey-sec/unblob/blob/main/python/unblob/models.py):
 
 ```python
 class Extractor(abc.ABC):
@@ -571,13 +571,13 @@ Two methods are exposed by this class:
     checks for path traversals, and performing io by using Python libraries
     (`os`, `pathlib.Path`), but it turns out somewhat tedious.
     Instead we recommend to remove boilerplate and use a helper class `FileSystem` from
-    [unblob/file_utils.py](https://github.com/onekey-sec/unblob/blob/main/unblob/file_utils.py)
+    [unblob/file_utils.py](https://github.com/onekey-sec/unblob/blob/main/python/unblob/file_utils.py)
     which ensures that all file objects are created under its root.
 
 ### DirectoryExtractor class
 
 The `DirectoryExtractor` interface is defined in
-[unblob/models.py](https://github.com/onekey-sec/unblob/blob/main/unblob/models.py):
+[unblob/models.py](https://github.com/onekey-sec/unblob/blob/main/python/unblob/models.py):
 
 ```python
 class DirectoryExtractor(abc.ABC):

--- a/docs/extractors.md
+++ b/docs/extractors.md
@@ -7,7 +7,7 @@ hide:
 
 unblob relies on various tools for extracting the contents of a blob. These
 extractors are either **third party tools (e.g. 7z)**, or part of unblob (available
-in [`unblob/extractors`](https://github.com/onekey-sec/unblob/tree/main/unblob/extractors)
+in [`unblob/extractors`](https://github.com/onekey-sec/unblob/tree/main/python/unblob/extractors)
 directory or specific ones next to the handler, e.g.:
 [`unblob/handlers/filesystem/romfs.py`](https://github.com/onekey-sec/unblob/blob/3008039881a0434deb75962e7999b7e35aca8271/unblob/handlers/filesystem/romfs.py#L334)).
 


### PR DESCRIPTION
## PR Summary
Commit 530eacf091d6e57984d28714e6bbcadbab265de2 moved `unblob` source files to `python`. This PR adjusts sources to changes.