### PR TITLE
fix(doc): only generate documentation for handler with a valid DOC attribute

### DIFF
--- a/python/unblob/cli.py
+++ b/python/unblob/cli.py
@@ -106,7 +106,10 @@ def build_handlers_doc(
     extra_dir_handlers = plugin_manager.load_dir_handlers_from_plugins()
     dir_handlers = ctx.params["dir_handlers"] + tuple(extra_dir_handlers)
 
-    all_handlers = handlers + dir_handlers
+    # we only want handler with a valid DOC entry
+    all_handlers = [
+        handler for handler in handlers + dir_handlers if handler.DOC is not None
+    ]
 
     slugifier = slugs.slugify(case="lower", percent_encode=True)
     format_table_headers = """    | Format        | Type                                 | Fully supported?    |\n    | :------------ | :----------------------------------- | :-----------------: |\n"""

--- a/python/unblob/models.py
+++ b/python/unblob/models.py
@@ -448,7 +448,7 @@ class DirectoryHandler(abc.ABC):
 
     PATTERN: DirectoryPattern
 
-    DOC: HandlerDoc
+    DOC: Union[HandlerDoc, None]
 
     @classmethod
     def get_dependencies(cls):
@@ -486,7 +486,7 @@ class Handler(abc.ABC, Generic[TExtractor]):
 
     EXTRACTOR: TExtractor
 
-    DOC: HandlerDoc
+    DOC: Union[HandlerDoc, None]
 
     @classmethod
     def get_dependencies(cls):


### PR DESCRIPTION
Some unblob developers may not want to expose some of their handlers through the auto-generated documentation. To do that, they simply do not set the DOC attribute.