### PR TITLE
fix(docker): pin down base image to debian bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 
 RUN mkdir -p /data/input /data/output
 RUN useradd -m unblob


### PR DESCRIPTION
They got updated to trixie, and we have dependency installation problems there

    44.62 dpkg: dependency problems prevent configuration of libext2fs2:amd64:
    44.62  libext2fs2t64:amd64 (1.47.2-3+b3) breaks libext2fs2 (<< 1.47.2-3) and is installed.
    44.62   Version of libext2fs2:amd64 to be configured is 1.47.0-3.ok2.
    44.62
    44.62 dpkg: error processing package libext2fs2:amd64 (--install):
    44.62  dependency problems - leaving unconfigured
    44.62 Setting up libss2:amd64 (1.47.0-3.ok2) ...
    44.67 Processing triggers for libc-bin (2.41-12) ...
    44.73 Errors were encountered while processing:
    44.73  libext2fs2:amd64

We need to fix it eventually though.