### PR TITLE
Fix renovate integaration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "pymdown-extensions>=10.15",
   "pyperscan>=0.3.0",
   "python-magic>=0.4.27",
-  "pyzstd",
+  "pyzstd>0.16.2",
   "rarfile>=4.1",
   "rich>=13.3.5",
   "structlog>=24.1.0",

--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,9 @@
     "enabled": true,
     "description": "opt-in support for nix https://docs.renovatebot.com/modules/manager/nix/#enabling"
   },
+  "pep621": {
+    "rangeStrategy": "update-lockfile"
+  },
   "pre-commit": {
     "enabled": true,
     "description": "opt-in support for pre-commit  https://docs.renovatebot.com/modules/manager/nix/#enabling"

--- a/uv.lock
+++ b/uv.lock
@@ -1874,7 +1874,7 @@ requires-dist = [
     { name = "pymdown-extensions", specifier = ">=10.15" },
     { name = "pyperscan", specifier = ">=0.3.0" },
     { name = "python-magic", specifier = ">=0.4.27" },
-    { name = "pyzstd" },
+    { name = "pyzstd", specifier = ">0.16.2" },
     { name = "rarfile", specifier = ">=4.1" },
     { name = "rich", specifier = ">=13.3.5" },
     { name = "structlog", specifier = ">=24.1.0" },


### PR DESCRIPTION
Since some time around April, renovate started to update only
packages, where `pyproject.toml` update was needed (constraints
update).

I have not found documentation about this change, only a github discussion[^1].

Meaning of rangeStrategy=update-lockfile[^2] option:

> Update the lock file when in-range updates are available, otherwise
> replace for updates out of range.

And replace:

> Replace the range with a newer one if the new version falls outside
> it, and update nothing otherwise

[^1]: https://github.com/renovatebot/renovate/discussions/36286
[^2]: https://docs.renovatebot.com/configuration-options/#rangestrategy

At least when using the PEP621 backend (uv), renovate only cares about
dependencies which have at least one constraint, otherwise it bypasses
them.

This can see from the logs[^3]:

          {
            "datasource": "pypi",
            "depName": "pyzstd",
            "depType": "project.dependencies",
            "lockedVersion": "0.17.0",
            "packageName": "pyzstd",
            "skipReason": "unspecified-version",
            "updates": []
          },

[^3]: https://developer.mend.io/github/onekey-sec/unblob
