### PR TITLE
chore(nix): add debug info output for p7zip

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -29,6 +29,8 @@ final: prev:
     '';
     # orig had `src` attribute, but we are using `srcs`. This trips a warning.
     __intentionallyOverridingVersion = true;
+
+    separateDebugInfo = true;
   });
 
   unblob = final.callPackage ./package.nix { };


### PR DESCRIPTION
Its builder strips the output by default. `separateDebugInfo` adds a `p7zip.debug` output containing only the debug symbols.

The only other custom package of ours, `e2fsprogs-nofortify` is not stripped.