### PR TITLE
Add upx to dependencies list

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -12,6 +12,7 @@ apt-get install --no-install-recommends -y \
     p7zip-full \
     partclone \
     unar \
+    upx \
     xz-utils \
     libmagic1 \
     zstd


### PR DESCRIPTION
`upx` dependency, which is used for processing [ELFs](https://github.com/onekey-sec/unblob/blob/15b9fc78a8339a7f6f36e65e3dc81cec6ef3ef2c/python/unblob/handlers/executable/elf.py#L152), is currently missing from the Docker container:
```
~ % docker run --rm -it --entrypoint bash ghcr.io/onekey-sec/unblob:latest
unblob@24788f601886:/data/output$ upx
bash: upx: command not found
```

Attempt to process [test file](https://github.com/onekey-sec/unblob/blob/main/tests/integration/executable/elf/elf64/__input__/hello.upx):
```
unblob % docker run \
  --rm \
  --pull always \
  -v $(pwd)/io:/data/output \
  -v $(pwd):/data/input \
ghcr.io/onekey-sec/unblob:latest /data/input/tests/integration/executable/elf/elf64/__input__/hello.upx
latest: Pulling from onekey-sec/unblob
Digest: sha256:2f9d2412f029f5bbf68e5940d3f31230bdf92b725db5b3c969dda9ddd83ced14
Status: Image is up to date for ghcr.io/onekey-sec/unblob:latest

╭────────────────────────────── unblob (25.5.26) ──────────────────────────────╮
│ Output path: None                                                            │
│ Extracted files: 1                                                           │
│ Extracted directories: 0                                                     │
│ Extracted links: 0                                                           │
│ Extraction directory size: 5.68 KB                                           │
╰────────────────────────────────── Summary ───────────────────────────────────╯
       Chunks distribution
┏━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓
┃ Chunk type ┃  Size   ┃  Ratio  ┃
┡━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━┩
│ ELF64      │ 5.68 KB │ 100.00% │
│ UNKNOWN    │ 0.00 B  │  0.00%  │
└────────────┴─────────┴─────────┘
Chunk identification ratio: 100.00%
                  Encountered errors
┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Severity       ┃ Name                              ┃
┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ Severity.ERROR │ ExtractorDependencyNotFoundReport │
└────────────────┴───────────────────────────────────┘
```

[CI tests](https://github.com/onekey-sec/unblob/blob/15b9fc78a8339a7f6f36e65e3dc81cec6ef3ef2c/.github/workflows/CI.yml#L98) are [passing successfully](https://github.com/onekey-sec/unblob/actions/runs/19435543605/job/55605828402#step:5:743) only because `upx` is [pre-installed](https://github.com/ivanovanton/test-upx/actions/runs/19543388926/job/55955678492#step:2:1) in the [ubuntu:latest](https://github.com/onekey-sec/unblob/blob/15b9fc78a8339a7f6f36e65e3dc81cec6ef3ef2c/.github/workflows/CI.yml#L81) image provided by GitHub.

