### PR TITLE
fix(docs): fix typo in installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -232,7 +232,7 @@ There is a handy `install-deps.sh` script included in the repository and PyPI pa
         curl -L -o libss2_1.47.0-3.ok2.deb "https://github.com/onekey-sec/e2fsprogs/releases/download/v1.47.0-3.ok2/libss2_1.47.0-3.ok2_$(dpkg --print-architecture).deb"
         sudo dpkg -i libext2fs2_1.47.0-3.ok2.deb libss2_1.47.0-3.ok2.deb
         sudo dpkg -i e2fsprogs_1.47.0-3.ok2.deb
-        rm -f libext2fs2_1.47.0-3.ok2.deb libss2_1.47.0-3.ok2.deb e2fsprogs_1.47.0-3.ok2.de
+        rm -f libext2fs2_1.47.0-3.ok2.deb libss2_1.47.0-3.ok2.deb e2fsprogs_1.47.0-3.ok2.deb
 
    In case you already had e2fsprogs installed, you might need to upgrade some more packages from e2fsprogs.
    You can get the names of the installed e2fsprogs binary packages this way:


### PR DESCRIPTION
Just a little typo fix in `docs/installation.md` to avoid broken commands when copy-pastes