### PR TITLE
add usedforsecurity=False to md5/sha1 for FIPS compliance

### DIFF
--- a/python/unblob/handlers/archive/par2.py
+++ b/python/unblob/handlers/archive/par2.py
@@ -60,7 +60,9 @@ class MultiVolumePAR2Handler(DirectoryHandler):
                 packet_content = f.read(
                     header.packet_length - len(header) + offset_to_recovery_id
                 )
-                packet_checksum = hashlib.md5(packet_content).digest()  # noqa: S324
+                packet_checksum = hashlib.md5(
+                    packet_content, usedforsecurity=False
+                ).digest()
 
                 if packet_checksum != header.md5_hash:
                     return False

--- a/python/unblob/report.py
+++ b/python/unblob/report.py
@@ -171,8 +171,8 @@ class HashReport(ReportBase):
     @classmethod
     def from_path(cls, path: Path):
         chunk_size = 1024 * 64
-        md5 = hashlib.md5()  # noqa: S324
-        sha1 = hashlib.sha1()  # noqa: S324
+        md5 = hashlib.md5(usedforsecurity=False)
+        sha1 = hashlib.sha1(usedforsecurity=False)
         sha256 = hashlib.sha256()
 
         with path.open("rb") as f:


### PR DESCRIPTION
Small changes to comply with the FIPS standard: updates calls to `hashlib` constructors to include `usedforsecurity=False`, explicitly marking MD5/SHA1 usage as non-cryptographic. This enables unblob to run on FIPS-restricted systems.
- MD5 updated to comply with FIPS 140-2
- SHA1 updated to comply with FIPS 140-3

These changes do not have a functional impact on the hash output or behavior. 