### PR TITLE
fix: ensure extracted directories stay writable

### DIFF
--- a/python/unblob/file_utils.py
+++ b/python/unblob/file_utils.py
@@ -546,7 +546,10 @@ class FileSystem:
         logger.debug("creating directory", dir_path=path, _verbosity=3)
         safe_path = self._get_extraction_path(path, "mkdir")
 
-        safe_path.mkdir(mode=mode, parents=parents, exist_ok=exist_ok)
+        # Directories with restrictive permission bits (e.g. 0o000) immediately
+        # block creation of nested entries, so force owner rwx during extraction.
+        safe_mode = mode | 0o700
+        safe_path.mkdir(mode=safe_mode, parents=parents, exist_ok=exist_ok)
 
     def mkfifo(self, path: Path, mode=0o666):
         logger.debug("creating fifo", path=path, _verbosity=3)


### PR DESCRIPTION
A fix was required due to `PermissionError` being raised on a CPIO archive:

```
2025-12-09 14:18.12 [error    ] Unknown error happened while extracting chunk pid=254493
Traceback (most recent call last):
  File "/usr/lib/python3.10/pathlib.py", line 1175, in mkdir
    self._accessor.mkdir(self, mode)
PermissionError: [Errno 13] Permission denied: '/tmp/out/bad_cpio.bin_extract/opt/redacted'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/quentin/.local/lib/python3.10/site-packages/unblob/processing.py", line 630, in _extract_chunk
    if result := chunk.extract(carved_path, extract_dir):
  File "/home/quentin/.local/lib/python3.10/site-packages/unblob/models.py", line 120, in extract
    return self.handler.extract(inpath, outdir)
  File "/home/quentin/.local/lib/python3.10/site-packages/unblob/models.py", line 472, in extract
    return self.EXTRACTOR.extract(inpath, outdir)
  File "/home/quentin/.local/lib/python3.10/site-packages/unblob/handlers/archive/cpio.py", line 387, in extract
    parser.dump_entries(fs)
  File "/home/quentin/.local/lib/python3.10/site-packages/unblob/handlers/archive/cpio.py", line 220, in dump_entries
    fs.mkdir(
  File "/home/quentin/.local/lib/python3.10/site-packages/unblob/file_utils.py", line 522, in mkdir
    safe_path.mkdir(mode=mode, parents=parents, exist_ok=exist_ok)
  File "/usr/lib/python3.10/pathlib.py", line 1184, in mkdir
    if not exist_ok or not self.is_dir():
  File "/usr/lib/python3.10/pathlib.py", line 1305, in is_dir
    return S_ISDIR(self.stat().st_mode)
  File "/usr/lib/python3.10/pathlib.py", line 1097, in stat
    return self._accessor.stat(self, follow_symlinks=follow_symlinks)
PermissionError: [Errno 13] Permission denied: '/tmp/out/bad_cpio.bin_extract/opt/redacted'
```