### PR TITLE
bug: Unable to define custom report types

### DIFF
--- a/python/unblob/report.py
+++ b/python/unblob/report.py
@@ -30,14 +30,14 @@ class ReportBase(BaseModel):
         return self.__class__.__name__
 
 
-class CustomReport(ReportBase):
-    """A report that is meant to be extended by users that extend unblob with custom report models."""
+class CustomReportBase(ReportBase):
+    """A base class for custom report types defined by users."""
     model_config = ConfigDict(extra="allow")
 
     @computed_field
     @property
     def __typename__(self) -> str:
-        """All user-defined reports will bare the same typename for usage in tagged unions."""
+        """All custom reports will have the same typename for usage in tagged unions."""
         return "CustomReport"
 
 


### PR DESCRIPTION
Users are no longer able to use custom handlers that return `ExtractResult` with custom extraction report models.

Elaborated in #1328. 

---

I didn't see contribution guidelines - so I'm not trying to merge this. Just sharing an example.