### PR TITLE
feat(reporting): support plugin-registered report types

### DIFF
--- a/python/unblob/cli.py
+++ b/python/unblob/cli.py
@@ -22,6 +22,7 @@ from unblob.report import (
     Severity,
     StatReport,
     UnknownChunkReport,
+    register_report_types,
 )
 
 from .cli_options import verbosity_option
@@ -366,6 +367,9 @@ def cli(
 
     extra_dir_handlers = plugin_manager.load_dir_handlers_from_plugins()
     dir_handlers += tuple(extra_dir_handlers)
+
+    extra_report_types = plugin_manager.load_report_types_from_plugins()
+    register_report_types(extra_report_types)
 
     extra_magics_to_skip = () if clear_skip_magics else DEFAULT_SKIP_MAGIC
     skip_magic = tuple(sorted(set(skip_magic).union(extra_magics_to_skip)))

--- a/python/unblob/hookspecs.py
+++ b/python/unblob/hookspecs.py
@@ -1,6 +1,7 @@
 import pluggy
 
 from unblob.models import DirectoryHandler, Handler
+from unblob.report import Report
 
 hookspec = pluggy.HookspecMarker("unblob")
 
@@ -19,5 +20,14 @@ def unblob_register_dir_handlers() -> list[type[DirectoryHandler]]:
     """Register directory handler types to known handlers.
 
     :returns: The list of directory handlers to be registered
+    """
+    return []
+
+
+@hookspec
+def unblob_register_reports() -> list[type[Report]]:
+    """Register report types to known reports.
+
+    :returns: The list of report types to be registered
     """
     return []

--- a/python/unblob/plugins.py
+++ b/python/unblob/plugins.py
@@ -10,6 +10,7 @@ from structlog import get_logger
 
 from unblob import hookspecs
 from unblob.models import DirectoryHandler, Handler
+from unblob.report import Report
 
 # The entrypoints are defined by the to-be-loaded plugins. The version
 # should be incremented whenever a backward-incompatible change is
@@ -118,3 +119,11 @@ class UnblobPluginManager(pluggy.PluginManager):
             )
 
         return extra_handlers
+
+    def load_report_types_from_plugins(self) -> list[type[Report]]:
+        extra_report_types = list(itertools.chain(*self.hook.unblob_register_reports()))
+        if extra_report_types:
+            logger.debug(
+                "Loaded report types from plugins", report_types=extra_report_types
+            )
+        return extra_report_types

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -21,7 +21,10 @@ from unblob.report import (
     ChunkReport,
     ExtractCommandFailedReport,
     FileMagicReport,
+    MultiFileReport,
+    Report,
     StatReport,
+    UnknownChunkReport,
     UnknownError,
 )
 
@@ -32,9 +35,12 @@ _HexStringToRegex.range_jump
 _HexStringToRegex.alternative
 
 TaskResult.filter_reports
+TaskResult.validate_reports
 ChunkReport.handler_name
+ChunkReport.validate_extraction_reports
 FileMagicReport.magic
 FileMagicReport.mime_type
+MultiFileReport.validate_extraction_reports
 StatReport.is_link
 
 SingleFile
@@ -75,6 +81,9 @@ generate_markdown
 Handler.DOC
 
 ReportModelAdapter
+Report.__typename__
+
+UnknownChunkReport.validate_randomness
 
 UnknownError.model_config
 UnknownError.model_post_init


### PR DESCRIPTION
Implemented a report registry and plugin hook so external packages can register Report subclasses, with runtime validation of those reports.

This allows advanced users of unblob have their own handlers and extractors yield custom reports without raising pydantic validation exceptions (which was happening before) while keeping strong validation of these custom reports through pydantic.

Documentation has been edited to cover how users can define and register custom reports, mirroring our handler/extractor documentation.

Related to https://github.com/onekey-sec/unblob/issues/1328