### PR TITLE
feat(handler): add support for DEAFBEAD files

### DIFF
--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -16,6 +16,7 @@
     | [`CPIO (PORTABLE ASCII)`](#cpio-portable-ascii) | ARCHIVE | :octicons-check-16: |
     | [`CPIO (PORTABLE OLD ASCII)`](#cpio-portable-old-ascii) | ARCHIVE | :octicons-check-16: |
     | [`CRAMFS`](#cramfs) | FILESYSTEM | :octicons-check-16: |
+    | [`D-LINK DEAFBEAD`](#d-link-deafbead) | ARCHIVE | :octicons-check-16: |
     | [`D-LINK ENCRPTED_IMG`](#d-link-encrpted_img) | ARCHIVE | :octicons-check-16: |
     | [`D-LINK SHRS`](#d-link-shrs) | ARCHIVE | :octicons-check-16: |
     | [`DMG`](#dmg) | ARCHIVE | :octicons-check-16: |
@@ -321,6 +322,20 @@
 
         - [CramFS Documentation](https://web.archive.org/web/20160304053532/http://sourceforge.net/projects/cramfs/){ target="_blank" }
         - [CramFS Wikipedia](https://en.wikipedia.org/wiki/Cramfs){ target="_blank" }
+## D-Link DEAFBEAD
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Archive files as found in D-Link DSL-500G and DSL-504G firmware images.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** D-Link
+
+    === "References"
 ## D-Link encrpted_img
 
 !!! success "Fully supported"

--- a/python/unblob/handlers/__init__.py
+++ b/python/unblob/handlers/__init__.py
@@ -18,7 +18,7 @@ from .archive import (
     zip as ziparchive,
 )
 from .archive.autel import ecc
-from .archive.dlink import encrpted_img, shrs
+from .archive.dlink import deafbead, encrpted_img, shrs
 from .archive.engeniustech import engenius
 from .archive.hp import bdl, ipkg
 from .archive.instar import bneg, instar_hd
@@ -56,6 +56,7 @@ from .filesystem.android import erofs, sparse
 
 BUILTIN_HANDLERS: Handlers = (
     cramfs.CramFSHandler,
+    deafbead.DeafBeadHandler,
     extfs.EXTHandler,
     fat.FATHandler,
     jffs2.JFFS2NewHandler,

--- a/python/unblob/handlers/archive/dlink/deafbead.py
+++ b/python/unblob/handlers/archive/dlink/deafbead.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import gzip
+import io
+from pathlib import Path, PureWindowsPath
+
+from unblob.file_utils import Endian, File, FileSystem, InvalidInputFormat, StructParser
+from unblob.models import (
+    Extractor,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    StructHandler,
+    ValidChunk,
+)
+
+C_DEFINITIONS = r"""
+    typedef struct deafbead_header {
+        uint32 magic;           /* "DE AF BE AD" */
+    } deafbead_header_t;
+
+    typedef struct deafbead_dir {
+        uint8  magic;           /* "86" */
+        uint16 name_len;
+        char   name[name_len];
+    } deafbead_dir_t;
+
+    typedef struct deafbead_file {
+        uint8  magic;           /* "87" */
+        uint16 name_len;
+        char   name[name_len];
+        uint32 file_size;
+        char   file_contents[file_size];
+    } deafbead_file_t;
+"""
+DIR_MAGIC = b"\x86"
+FILE_MAGIC = b"\x87"
+VALID_MAGICS = {DIR_MAGIC, FILE_MAGIC}
+HEADER_LEN = 4
+
+
+class DeafBeadExtractor(Extractor):
+    def __init__(self):
+        self._struct_parser = StructParser(C_DEFINITIONS)
+
+    def extract(self, inpath: Path, outdir: Path):
+        fs = FileSystem(outdir)
+        with File.from_path(inpath) as file:
+            file.seek(HEADER_LEN)
+            while (magic := file.read(1)) in VALID_MAGICS:
+                file.seek(-1, io.SEEK_CUR)  # go back to read the full struct
+                if magic == DIR_MAGIC:
+                    self._handle_dir(file, fs)
+                elif magic == FILE_MAGIC:
+                    self._handle_file(file, fs)
+
+    def _handle_dir(self, file: File, fs: FileSystem):
+        dir_header = self._struct_parser.parse("deafbead_dir_t", file, Endian.LITTLE)
+        fs.mkdir(self._convert_path(dir_header.name))
+
+    def _handle_file(self, file: File, fs: FileSystem):
+        file_header = self._struct_parser.parse("deafbead_file_t", file, Endian.LITTLE)
+        try:
+            decompressed = gzip.decompress(file_header.file_contents)
+            fs.write_bytes(self._convert_path(file_header.name), decompressed)
+        except gzip.BadGzipFile as error:
+            raise InvalidInputFormat("Invalid GZIP file") from error
+
+    @staticmethod
+    def _convert_path(path_entry: bytes) -> Path:
+        decoded_path = path_entry.decode("utf-8", errors="replace")
+        if "\\" in decoded_path:  # windows path => convert slashes
+            return Path(PureWindowsPath(decoded_path).as_posix())
+        return Path(decoded_path)
+
+
+class DeafBeadHandler(StructHandler):
+    NAME = "deafbead"
+    PATTERNS = [HexString("DE AF BE AD (86 | 87)")]
+
+    DOC = HandlerDoc(
+        name="D-Link DEAFBEAD",
+        description="Archive files as found in D-Link DSL-500G and DSL-504G firmware images.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="D-Link",
+        references=[],
+        limitations=[],
+    )
+
+    C_DEFINITIONS = C_DEFINITIONS
+    HEADER_STRUCT = "deafbead_header_t"
+    EXTRACTOR = DeafBeadExtractor()
+
+    def calculate_chunk(self, file: File, start_offset: int) -> ValidChunk | None:
+        file.seek(start_offset + HEADER_LEN)
+        while (magic := file.read(1)) in VALID_MAGICS:
+            file.seek(-1, io.SEEK_CUR)
+            if magic == DIR_MAGIC:
+                header = self.cparser_le.deafbead_dir_t(file)
+                if header.name_len == 0:
+                    raise InvalidInputFormat("Invalid directory header.")
+            else:
+                header = self.cparser_le.deafbead_file_t(file)
+                if header.name_len == 0 or header.file_size == 0:
+                    raise InvalidInputFormat("Invalid file header.")
+
+        end_offset = file.tell()
+        if magic:  # if EOF wasn't reached (i.e. magic is not empty), we need to undo the last read
+            end_offset -= 1
+        return ValidChunk(start_offset=start_offset, end_offset=end_offset)

--- a/tests/handlers/archive/test_deafbead.py
+++ b/tests/handlers/archive/test_deafbead.py
@@ -1,0 +1,60 @@
+import pytest
+
+from unblob.file_utils import File, InvalidInputFormat
+from unblob.handlers.archive.dlink.deafbead import DeafBeadHandler
+from unblob.testing import unhex
+
+DB_FILE_CONTENTS = unhex(
+    """\
+00000000: deaf bead 8608 0074 6573 745f 6469 7287  .......test_dir.
+00000010: 1300 7465 7374 5f64 6972 5c66 6f6f 6261  ..test_dir\\fooba
+00000020: 722e 7478 741b 0000 001f 8b08 0064 d968  r.txt........d.h
+00000030: 6902 ff4b cbcf 4f4a 2ce2 0200 4797 2cb2  i..K..OJ,...G.,.
+00000040: 0700 0000 8708 0074 6573 742e 7478 741d  .......test.txt.
+00000050: 0000 001f 8b08 0064 d968 6902 ff2b 492d  .......d.hi..+I-
+00000060: 2e31 3432 36e1 0200 f54d cf25 0900 0000  .1426....M.%....
+00000070: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+"""
+)
+
+INVALID = unhex(
+    """\
+00000000: deaf bead 86ff ffff ffff ffff ffff ffff  ................
+00000010: ffff ffff ffff ffff ffff ffff ffff ffff  ................
+"""
+)
+
+
+@pytest.mark.parametrize(
+    "end_index",
+    [
+        0x70,  # file ends at end of deafbead file
+        0x80,  # some padding after deafbead file
+    ],
+)
+def test_chunk_calculation(end_index):
+    file = File.from_bytes(DB_FILE_CONTENTS[:end_index])
+    handler = DeafBeadHandler()
+    chunk = handler.calculate_chunk(file, 0)
+
+    assert chunk is not None
+    assert chunk.start_offset == 0
+    assert chunk.end_offset == 0x70
+
+
+@pytest.mark.parametrize(
+    "contents, error",
+    [
+        (INVALID, EOFError),
+        (bytes.fromhex("deafbead 86 00"), EOFError),
+        (bytes.fromhex("deafbead 86 0000"), InvalidInputFormat),
+        (bytes.fromhex("deafbead 87 00"), EOFError),
+        (bytes.fromhex("deafbead 87 0100 00 00000000"), InvalidInputFormat),
+        (bytes.fromhex("deafbead 87 0100 00 01000000"), EOFError),
+    ],
+)
+def test_invalid_chunk(contents, error):
+    file = File.from_bytes(contents)
+    handler = DeafBeadHandler()
+    with pytest.raises(error):
+        handler.calculate_chunk(file, 0)

--- a/tests/integration/archive/dlink/deafbead/__input__/fruit.deafbead
+++ b/tests/integration/archive/dlink/deafbead/__input__/fruit.deafbead
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82814da691e8b583e1711fe1b7251b938a3de3645441c55b15abb9259328063a
+size 167

--- a/tests/integration/archive/dlink/deafbead/__output__/fruit.deafbead_extract/apple.txt
+++ b/tests/integration/archive/dlink/deafbead/__output__/fruit.deafbead_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/archive/dlink/deafbead/__output__/fruit.deafbead_extract/more_fruit/banana.txt
+++ b/tests/integration/archive/dlink/deafbead/__output__/fruit.deafbead_extract/more_fruit/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/archive/dlink/deafbead/__output__/fruit.deafbead_extract/more_fruit/cherry.txt
+++ b/tests/integration/archive/dlink/deafbead/__output__/fruit.deafbead_extract/more_fruit/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7


### PR DESCRIPTION
Adds support for DEAFBEAD archive files as found e.g. in D-Link DSL-500G and DSL-504G firmware images.
Unblob already unpacks the contents from those archives, because the files are compressed with gzip, but the folder structure and file names get lost in the process.
