### PR TITLE
feat(handler): add support for squashfs v4 broadcom variants

### DIFF
--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -59,6 +59,7 @@
     | [`SQUASHFS (V3-DDWRT)`](#squashfs-v3-ddwrt) | FILESYSTEM | :octicons-check-16: |
     | [`SQUASHFS (V3-NON-STANDARD)`](#squashfs-v3-non-standard) | FILESYSTEM | :octicons-check-16: |
     | [`SQUASHFS (V4-BE)`](#squashfs-v4-be) | FILESYSTEM | :octicons-check-16: |
+    | [`SQUASHFS (V4-BROADCOM)`](#squashfs-v4-broadcom) | FILESYSTEM | :octicons-check-16: |
     | [`SQUASHFS (V4-LE)`](#squashfs-v4-le) | FILESYSTEM | :octicons-check-16: |
     | [`STUFFIT SIT`](#stuffit-sit) | ARCHIVE | :octicons-check-16: |
     | [`STUFFIT SIT (V5)`](#stuffit-sit-v5) | ARCHIVE | :octicons-check-16: |
@@ -1031,6 +1032,23 @@
 
         - **Handler type:** FileSystem
         
+
+    === "References"
+
+        - [SquashFS Documentation](https://dr-emann.github.io/squashfs/){ target="_blank" }
+        - [SquashFS Wikipedia](https://en.wikipedia.org/wiki/SquashFS){ target="_blank" }
+## SquashFS (v4-broadcom)
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        SquashFS version 4 is a compressed, read-only file system format designed for minimal storage usage. It is widely used in embedded systems and Linux distributions for efficient storage and fast access.
+
+        ---
+
+        - **Handler type:** FileSystem
+        - **Vendor:** Broadcom
 
     === "References"
 

--- a/python/unblob/handlers/__init__.py
+++ b/python/unblob/handlers/__init__.py
@@ -71,6 +71,7 @@ BUILTIN_HANDLERS: Handlers = (
     squashfs.SquashFSv3NSHandler,
     squashfs.SquashFSv4LEHandler,
     squashfs.SquashFSv4BEHandler,
+    squashfs.SquashFSv4BroadcomHandler,
     ubi.UBIHandler,
     ubi.UBIFSHandler,
     yaffs.YAFFSHandler,

--- a/python/unblob/handlers/filesystem/squashfs.py
+++ b/python/unblob/handlers/filesystem/squashfs.py
@@ -498,3 +498,48 @@ class SquashFSv4BEHandler(SquashFSv4LEHandler):
         ],
         limitations=[],
     )
+
+
+class SquashFSv4BroadcomHandler(SquashFSv4LEHandler):
+    NAME = "squashfs_v4_broadcom"
+
+    BIG_ENDIAN_MAGIC = 0x71_73_68_73
+
+    EXTRACTOR = SquashFSExtractor(4, 0x71_73_68_73)
+
+    PATTERNS = [
+        HexString(
+            """
+            // 00000000  71 73 68 73 00 00 00 05  62 1f 5e 09 00 02 00 00  |qshs....b.^.....|
+            // 00000010  00 00 00 01 00 01 00 11  00 c0 00 01 00 04 00 00  |................|
+            // squashfs_v4_magic_broadcom_be
+            71 73 68 73 [24] 00 04
+        """
+        ),
+        HexString(
+            """
+            // 00000000  73 68 73 71 03 00 00 00  00 c1 9c 61 00 00 02 00  |shsq.......a....|
+            // 00000010  01 00 00 00 01 00 11 00  c0 00 01 00 04 00 00 00  |................|
+            // squashfs_v4_magic_broadcom_le
+            73 68 73 71 [24] 04 00
+        """
+        ),
+    ]
+
+    DOC = HandlerDoc(
+        name="SquashFS (v4-broadcom)",
+        description="SquashFS version 4 is a compressed, read-only file system format designed for minimal storage usage. It is widely used in embedded systems and Linux distributions for efficient storage and fast access.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor="Broadcom",
+        references=[
+            Reference(
+                title="SquashFS Documentation",
+                url="https://dr-emann.github.io/squashfs/",
+            ),
+            Reference(
+                title="SquashFS Wikipedia",
+                url="https://en.wikipedia.org/wiki/SquashFS",
+            ),
+        ],
+        limitations=[],
+    )

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__input__/squashfs_v4_be.bin
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__input__/squashfs_v4_be.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:283f074b6415b4105d3ec76861b823106c82b96724df30da7f9620e56549c6e6
+size 4096

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__input__/squashfs_v4_be.nopad.bin
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__input__/squashfs_v4_be.nopad.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46f7c57770f62692fdc22ad8ed65739242f43aafa5e62a4be075ed899e21e75f
+size 307

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__input__/squashfs_v4_le.bin
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__input__/squashfs_v4_le.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7963fba31962c614e439f4f7a43a1eddec43afe1bdb1ffb059e72f8a15bd10b
+size 4096

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__input__/squashfs_v4_le.nopad.bin
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__input__/squashfs_v4_le.nopad.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ef3815d87a50c32ed5c540003ecaa4e383604708efc2916ad2ba8644b9e8487
+size 308

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.bin_extract/apple1.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.bin_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.bin_extract/apple2.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.bin_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.bin_extract/apple3.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.bin_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.bin_extract/apple4.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.bin_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.nopad.bin_extract/apple1.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.nopad.bin_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.nopad.bin_extract/apple2.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.nopad.bin_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.nopad.bin_extract/apple3.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.nopad.bin_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.nopad.bin_extract/apple4.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_be.nopad.bin_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_le.bin_extract/apple.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_le.bin_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_le.bin_extract/cherry.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_le.bin_extract/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_le.nopad.bin_extract/apple1.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_le.nopad.bin_extract/apple1.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6181259c6b2ca629a56920b422e9a8f212a4d0bcead923df92dbd66fbb7e1c30
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_le.nopad.bin_extract/apple2.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_le.nopad.bin_extract/apple2.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:919fc82d6f1031d305dbce2fc5a74a6df5ddf2da472ee4d137c681cef28d4aff
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_le.nopad.bin_extract/apple3.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_le.nopad.bin_extract/apple3.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d95014ed3f24e86ce5fc3a4529f057d7b2318d9b24b54f2e9476b154bd21ec6
+size 7

--- a/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_le.nopad.bin_extract/apple4.txt
+++ b/tests/integration/filesystem/squashfs/squashfs_v4_broadcom/__output__/squashfs_v4_le.nopad.bin_extract/apple4.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08d9b05b15b998f2dbc741399fef4350c7863cc85df2305d7da4e83e8c8a959d
+size 7


### PR DESCRIPTION
Adds support for unpacking broadcom variants of squashfs v4 images (e.g. found in D-Link DSL-2640B and Asus DSL-N12HP)

- [x] needs https://github.com/onekey-sec/sasquatch/pull/34 to work