### PR TITLE
fix(logging): preserve dumpstruct ansi output

### DIFF
--- a/python/unblob/logging.py
+++ b/python/unblob/logging.py
@@ -14,6 +14,19 @@ def format_hex(value: int):
     return f"0x{value:x}"
 
 
+class RawString:
+    """Wrap a string so ConsoleRenderer prints it without repr()-escaping."""
+
+    def __init__(self, value: str | None):
+        self._value = value or ""
+
+    def __repr__(self) -> str:
+        return self._value
+
+    def __str__(self) -> str:
+        return self._value
+
+
 class noformat:  # noqa: N801
     """Keep the value from formatting.
 
@@ -43,7 +56,7 @@ def _format_message(value: Any, extract_root: Path) -> Any:
         return new_value.as_posix().encode("utf-8", errors="surrogateescape")
 
     if isinstance(value, Structure):
-        return dumpstruct(value, output="string")
+        return RawString(dumpstruct(value, output="string"))
 
     if isinstance(value, int):
         return format_hex(value)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -4,7 +4,7 @@ from typing import Any
 import pytest
 import structlog
 
-from unblob.logging import _format_message, noformat
+from unblob.logging import RawString, _format_message, noformat
 from unblob.report import UnknownError
 
 
@@ -45,3 +45,10 @@ def test_UnknownError_can_be_logged():  # noqa: N802
     logger.error(
         "unknown", **UnknownError(exception=Exception("whatever")).model_dump()
     )
+
+
+def test_raw_str_repr_keeps_value():
+    value = "abc\n\x1b[31mred\x1b[0m"
+    wrapped = RawString(value)
+    assert repr(wrapped) == value
+    assert str(wrapped) == value


### PR DESCRIPTION
With structlog 25.5.0 the renderer’s `_repr` in structlog/dev.py now applies `repr()` to any string containing whitespace/newlines, so the ANSI bytes gets escaped and the dump is quoted instead of being emitted raw.

It's been annoying me since it changed. Now is the time to fix it.

Before:

<img width="1711" height="402" alt="image" src="https://github.com/user-attachments/assets/983a0aea-4416-47ec-aa2d-587066146aa8" />

After:

<img width="1711" height="402" alt="image" src="https://github.com/user-attachments/assets/5bf51d49-cfb2-4f51-858e-6b3018fc960b" />

It's _way_ easier to debug new handler this way, that's why we used it in the first place.
