### PR TITLE
feat(models): allow multi-pattern globbing

### DIFF
--- a/python/unblob/models.py
+++ b/python/unblob/models.py
@@ -416,11 +416,14 @@ class DirectoryPattern:
 
 
 class Glob(DirectoryPattern):
-    def __init__(self, pattern):
-        self._pattern = pattern
+    def __init__(self, *patterns):
+        if not patterns:
+            raise ValueError("At least one pattern must be provided")
+        self._patterns = patterns
 
     def get_files(self, directory: Path) -> Iterable[Path]:
-        return directory.glob(self._pattern)
+        for pattern in self._patterns:
+            yield from directory.glob(pattern)
 
 
 class SingleFile(DirectoryPattern):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,6 +6,7 @@ import pytest
 from unblob.file_utils import InvalidInputFormat
 from unblob.models import (
     Chunk,
+    Glob,
     ProcessResult,
     ReportModelAdapter,
     Task,
@@ -364,3 +365,25 @@ def test_unknown_chunk_report_randomness_validation():
     )
 
     assert isinstance(report.randomness, RandomnessReport)
+
+
+class TestGlob:
+    def test_single_pattern(self, tmp_path: Path):
+        path_a = tmp_path / "a.txt"
+        path_a.touch()
+        path_b = tmp_path / "b.log"
+        path_b.touch()
+
+        glob = Glob("*.txt")
+        assert list(glob.get_files(tmp_path)) == [path_a]
+
+    def test_multiple_patterns(self, tmp_path: Path):
+        path_a = tmp_path / "a.txt"
+        path_a.touch()
+        path_b = tmp_path / "b.log"
+        path_b.touch()
+        path_c = tmp_path / "c.bin"
+        path_c.touch()
+
+        glob = Glob("*.txt", "*.log")
+        assert list(glob.get_files(tmp_path)) == [path_a, path_b]


### PR DESCRIPTION
Allow Glob to accept multiple filename patterns so directory handlers can match several globs since pathlib's glob lacks alternation support.

Designed this way so we don't introduce breaking API changes, especially in `DirectoryHandler` that already use `Glob`.

I'm working on an internal `DirectoryHandler` that requires this very feature.