### PR TITLE
chore(deps): split dev dependencies in sub-groups

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: "Wether to install 3rd Party dependencies (for tests)"
     required: false
     default: "true" # unfortunately boolean variables are not supported
+  uv-groups:
+    description: "Space-separated uv dependency groups to install"
+    required: false
+    default: ""
 
 name: "Setup dependencies"
 description: "Install all required dependencies for worflows to run."
@@ -38,7 +42,15 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Install the project
-      run: uv sync
+      run: |
+        set -e
+        group_args=""
+        if [ -n "${{ inputs.uv-groups }}" ]; then
+          for group in ${{ inputs.uv-groups }}; do
+            group_args="$group_args --group ${group}"
+          done
+        fi
+        uv sync --no-dev ${group_args}
       shell: bash
 
     - name: Setup pip # some tools need it, and uv virtualenvs doesn't contain it

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,7 @@ jobs:
         uses: ./.github/actions/setup-dependencies
         with:
           install-test-deps: "false"
+          uv-groups: "check"
 
       - name: Setup Nix
         uses: cachix/install-nix-action@v31
@@ -56,6 +57,8 @@ jobs:
 
       - name: Setup 3rd party dependencies
         uses: ./.github/actions/setup-dependencies
+        with:
+          uv-groups: "type"
 
       - name: Check - pyright
         run: uv run pyright .
@@ -90,6 +93,7 @@ jobs:
         uses: ./.github/actions/setup-dependencies
         with:
           python-version: ${{ matrix.python-version }}
+          uv-groups: "test"
 
       - name: Setup git lfs
         uses: ./.github/actions/setup-git-lfs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,15 +39,18 @@ version = "25.11.25"
 unblob = "unblob.cli:main"
 
 [dependency-groups]
-dev = [
-  "atheris>=2.3,<3.0; sys_platform == 'linux' and python_version < '3.12'",
+check = [
   "pre-commit>=3.5,<5.0",
-  "pyright>=1.1.349",
-  "pytest-cov>=7,<8",
-  "pytest>=8.0.0",
   "pyyaml>=6.0.1",
   "ruff==0.14.14",
   "taplo>=0.9.3",
+  "vulture>=2.13",
+]
+dev = [
+  { include-group = "check" },
+  { include-group = "fuzz" },
+  { include-group = "test" },
+  { include-group = "type" },
 ]
 docs = [
   "cairosvg>=2.7.1",
@@ -56,6 +59,16 @@ docs = [
   "mkdocstrings>=0.30,<0.31",
   "pillow>=10.2.0,<12.0",
   "pymdown-extensions>=10.15",
+]
+fuzz = [
+  "atheris>=2.3,<3.0; sys_platform == 'linux' and python_version < '3.12'",
+]
+test = [
+  "pytest-cov>=7,<8",
+  "pytest>=8.0.0",
+]
+type = [
+  "pyright>=1.1.349",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -1881,6 +1881,13 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+check = [
+    { name = "pre-commit" },
+    { name = "pyyaml" },
+    { name = "ruff" },
+    { name = "taplo" },
+    { name = "vulture" },
+]
 dev = [
     { name = "atheris", marker = "python_full_version < '3.12' and sys_platform == 'linux'" },
     { name = "pre-commit" },
@@ -1890,6 +1897,7 @@ dev = [
     { name = "pyyaml" },
     { name = "ruff" },
     { name = "taplo" },
+    { name = "vulture" },
 ]
 docs = [
     { name = "cairosvg" },
@@ -1898,6 +1906,16 @@ docs = [
     { name = "mkdocstrings-python" },
     { name = "pillow" },
     { name = "pymdown-extensions" },
+]
+fuzz = [
+    { name = "atheris", marker = "python_full_version < '3.12' and sys_platform == 'linux'" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+type = [
+    { name = "pyright" },
 ]
 
 [package.metadata]
@@ -1927,6 +1945,13 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+check = [
+    { name = "pre-commit", specifier = ">=3.5,<5.0" },
+    { name = "pyyaml", specifier = ">=6.0.1" },
+    { name = "ruff", specifier = "==0.14.14" },
+    { name = "taplo", git = "https://github.com/tamasfe/taplo?tag=0.10.0" },
+    { name = "vulture", specifier = ">=2.13" },
+]
 dev = [
     { name = "atheris", marker = "python_full_version < '3.12' and sys_platform == 'linux'", specifier = ">=2.3,<3.0" },
     { name = "pre-commit", specifier = ">=3.5,<5.0" },
@@ -1936,6 +1961,7 @@ dev = [
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "ruff", specifier = "==0.14.14" },
     { name = "taplo", git = "https://github.com/tamasfe/taplo?tag=0.10.0" },
+    { name = "vulture", specifier = ">=2.13" },
 ]
 docs = [
     { name = "cairosvg", specifier = ">=2.7.1" },
@@ -1945,6 +1971,12 @@ docs = [
     { name = "pillow", specifier = ">=10.2.0,<12.0" },
     { name = "pymdown-extensions", specifier = ">=10.15" },
 ]
+fuzz = [{ name = "atheris", marker = "python_full_version < '3.12' and sys_platform == 'linux'", specifier = ">=2.3,<3.0" }]
+test = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-cov", specifier = ">=7,<8" },
+]
+type = [{ name = "pyright", specifier = ">=1.1.349" }]
 
 [[package]]
 name = "urllib3"
@@ -1968,6 +2000,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/25/925f35db758a0f9199113aaf61d703de891676b082bd7cf73ea01d6000f7/vulture-2.14.tar.gz", hash = "sha256:cb8277902a1138deeab796ec5bef7076a6e0248ca3607a3f3dee0b6d9e9b8415", size = 58823, upload-time = "2024-12-08T17:39:43.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/56/0cc15b8ff2613c1d5c3dc1f3f576ede1c43868c1bc2e5ccaa2d4bcd7974d/vulture-2.14-py2.py3-none-any.whl", hash = "sha256:d9a90dba89607489548a49d557f8bac8112bd25d3cbc8aeef23e860811bd5ed9", size = 28915, upload-time = "2024-12-08T17:39:40.573Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We have multiple dev dependencies serving different purposes (testing, type checking, code formatting, file linting, fuzzing). All of these dependencies are built or installed in multiple CI steps that only requires a subset of them.

Introduced the 'uv-groups' argument to the setup-dependencies action. The action now always execute uv with `--no-dev`, and we can provide an explicit dev subgroup so it's installed.

The dev group stays the same.