### PR TITLE
Upgrade macos runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -234,7 +234,7 @@ jobs:
         platform:
           - runner: macos-15-intel
             target: x86_64
-          - runner: macos-14
+          - runner: macos-15
             target: aarch64
     steps:
       - name: Checkout source code


### PR DESCRIPTION
macos-13 runners have been officially deprecated by Github, see https://github.com/actions/runner-images/issues/13046
