### PR TITLE
fix(extractor): fix report typing issue with ExtractCommandFailedReport

### DIFF
--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -5,12 +5,14 @@ from unittest.mock import ANY
 from zipfile import ZipFile, ZipInfo
 
 import pytest
+from pydantic_core._pydantic_core import ValidationError
 
 from unblob.models import ProcessResult, Task, TaskResult
 from unblob.processing import ExtractionConfig, process_file
 from unblob.report import (
     CarveDirectoryReport,
     ChunkReport,
+    ExtractCommandFailedReport,
     FileMagicReport,
     HashReport,
     StatReport,
@@ -449,3 +451,21 @@ def get_normalized_task_results(process_result: ProcessResult) -> list[TaskResul
 
 def get_chunk_ids(task_result) -> list[str]:
     return [chunk_report.id for chunk_report in task_result.filter_reports(ChunkReport)]
+
+
+def test_extract_command_failed_invalid():
+    with pytest.raises(ValidationError):
+        ExtractCommandFailedReport(
+            command="test",
+            stdout=1,  # pyright: ignore[reportArgumentType]
+            stderr="",  # pyright: ignore[reportArgumentType]
+            exit_code=1,
+        )
+
+    with pytest.raises(ValidationError):
+        ExtractCommandFailedReport(
+            command="test",
+            stdout="",  # pyright: ignore[reportArgumentType]
+            stderr=1,  # pyright: ignore[reportArgumentType]
+            exit_code=1,
+        )


### PR DESCRIPTION
The `ExtractCommandFailedReport` class only accepts bytes for its stdout and stderr fields.

The `subprocess.run` call that executes the extraction command returns a `subprocess.CompletedProcess` object, where its stdout and stderr can be either `bytes`, `str`, or `None` depending on how it was called:
> stderr
Captured stderr from the child process. A bytes sequence, or a string if [run()](https://docs.python.org/3/library/subprocess.html#subprocess.run) was called with an encoding, errors, or text=True. None if stderr was not captured.
> stdout
Captured stdout from the child process. A bytes sequence, or a string if [run()](https://docs.python.org/3/library/subprocess.html#subprocess.run) was called with an encoding, errors, or text=True. None if stdout was not captured.

 Source: https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess

This discrepancy triggered pydantic validation error, especially in the gzip handler:

```
File
"/nix/store/zgivnxh4vs6cwappddrmqfmbxx8f3l7m-inspector-env/lib/python3.13/site-packages/unblob/handlers/compression/gzip.py", line 92, in extract
    return extractor.extract(inpath, outdir)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File
"/nix/store/zgivnxh4vs6cwappddrmqfmbxx8f3l7m-inspector-env/lib/python3.13/site-packages/unblob/extractors/command.py", line 60, in extract
    error_report = ExtractCommandFailedReport(
        command=command,
    ...&lt;2 lines&gt;...
        exit_code=res.returncode,
    )
  File
"/nix/store/zgivnxh4vs6cwappddrmqfmbxx8f3l7m-inspector-env/lib/python3.13/site-packages/pydantic/main.py", line 250, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data,
self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for ExtractCommandFailedReport
stdout
  Input should be a valid bytes [type=bytes_type, input_value=None,
input_type=NoneType]
    For further information visit
https://errors.pydantic.dev/2.12/v/bytes_type
```

That's because this handler, and a few others such as compress, lzma, bzip2, and xz redirects stdout to an output file:

```
grep stdout= python/unblob/handlers/ -r                
python/unblob/handlers/compression/gzip.py:        extractor = Command("7z", "x", "-y", "{inpath}", "-so", stdout=name)
python/unblob/handlers/compression/gzip.py:            "7z", "x", "-p", "-y", "{inpath}", "-so", stdout=name
python/unblob/handlers/compression/compress.py:    EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-so", stdout="lzw.uncompressed")
python/unblob/handlers/compression/lzma.py:    EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-so", stdout="lzma.uncompressed")
python/unblob/handlers/compression/bzip2.py:    EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-so", stdout="bzip2.uncompressed")
python/unblob/handlers/compression/xz.py:    EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-so", stdout="xz.uncompressed")
```

This leads to `res.stdout` being None since "None if stdout was not captured.".

Some notes:
- We now normalize these fields to bytes to make sure the model is strictly followed.
- This is unrelated to 3513bcc since pydantic models of unblob reports were already validated prior.
- It is still unclear why this was not picked up by our type checker. Ideally this type checking miss should be fixed too. I tried a bunch of things to hint pyright to no avail.

The blast radius of this bug is limited to gzip, compress, lzma, bzip2 and xz handler when the decompression command fails. Still, I'd like to push for a timely review here.