### PR TITLE
chore: remove outdated justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,1 +1,0 @@
-mod doc ".just/doc.just"


### PR DESCRIPTION
This file is no longer needed since 72d775d795a0622915cc933ec1259ed30d91f705