### PR TITLE
Revert "chore(ci): pin sccache to version 0.12.0"

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -26,7 +26,6 @@ runs:
       uses: mozilla-actions/sccache-action@v0.0.9
       with:
         disable_annotations: true # it is very spammy, but useful for diagnostics
-        version: "v0.12.0"
 
     - name: Enable sccache
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -116,8 +116,6 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-        with:
-          version: "v0.12.0"
 
       - name: Run cargo test
         env:


### PR DESCRIPTION
This reverts commit 80638313f0a6b2b6683bf90a171f6c2a09be1059.

v0.14.0 has been [released](https://github.com/mozilla/sccache/releases/tag/v0.14.0) and contains releases for x86_64-apple-darwin.

We need this, because otherwise the `sccache stats` command fails due to a mismatch between the local version (pinned to `0.12.0`) and the one used by `PyO3/maturin-action@v1` (`0.14.0` as of today).

See https://github.com/onekey-sec/unblob/actions/runs/21916347148/job/63428969199 for example.

https://github.com/onekey-sec/unblob/pull/1383 and https://github.com/onekey-sec/unblob/pull/1382 failed because of that, I cleared our whole sccache cache and re-run the job but it failed again so to me this is the only logical reason. We'll see if it passes here.