### PR TITLE
fix(ci): migrate docker-run-action to fork

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Check wheel (x86-musllinux)
         if: matrix.platform.target == 'x86_64' && startsWith(matrix.platform.manylinux, 'musllinux')
-        uses: addnab/docker-run-action@v3
+        uses: maus007/docker-run-action-fork@v1
         with:
           image: alpine:latest
           options: -v ${{ github.workspace }}:/io -w /io
@@ -215,7 +215,7 @@ jobs:
 
       - name: Check wheel (cross-musllinux)
         if: matrix.platform.target != 'x86_64' && startsWith(matrix.platform.manylinux, 'musllinux')
-        uses: addnab/docker-run-action@v3
+        uses: maus007/docker-run-action-fork@v1
         with:
           image: alpine:latest
           options: -v ${{ github.workspace }}:/io -w /io


### PR DESCRIPTION
Github is doing something infrastructure side and we're only seeing it now, but the Dockerfile image used by `addnab/docker-run-action` is too old¹.

The project is unmaintained and recommendation is to switch to the fork from `maus007`, which adds two commits² on top to fix the issue.

[1] https://github.com/addnab/docker-run-action/issues/62
[2] https://github.com/addnab/docker-run-action/compare/main...maus007:docker-run-action-fork:main