### PR TITLE
chore(deps): add clippy to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,7 @@
               statix
               libz
               cargo
+              clippy
               rustc
               just
 


### PR DESCRIPTION
Without that, clippy-driver comes from system-wide rustup instead of the devshell environment. This leads to conflicts in versions, leading to cargo clippy failing during pre-commit.