### PR TITLE
chore(deps): migrate from p7zip to 7zip

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -9,13 +9,27 @@ apt-get install --no-install-recommends -y \
     lz4 \
     lziprecover \
     lzop \
-    p7zip-full \
     partclone \
     unar \
     upx \
     xz-utils \
     libmagic1 \
     zstd
+
+case "$(dpkg --print-architecture)" in
+    amd64) sevenzip_arch="x64" ;;
+    arm64) sevenzip_arch="arm64" ;;
+    *)
+        echo "Unsupported architecture for 7-Zip: $(dpkg --print-architecture)" >&2
+        exit 1
+        ;;
+esac
+
+curl -L -o 7zip.tar.xz "https://www.7-zip.org/a/7z2600-linux-${sevenzip_arch}.tar.xz"
+install -d /usr/local/bin
+tar -xf 7zip.tar.xz -C /usr/local/bin 7zz 7zzs
+ln -sf /usr/local/bin/7zz /usr/local/bin/7z
+rm -f 7zip.tar.xz
 
 curl -L -o sasquatch_1.0.deb "https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v4.5.1-6/sasquatch_1.0_$(dpkg --print-architecture).deb"
 dpkg -i sasquatch_1.0.deb

--- a/overlay.nix
+++ b/overlay.nix
@@ -8,30 +8,21 @@ final: prev:
     nativeCheckInputs = (super.nativeCheckInputs or [ ]) ++ [ final.which ];
   });
 
-  p7zip16 = prev.p7zip.overrideAttrs (super: rec {
-    pname = "p7zip16";
-    version = "16.02";
-    srcs = [
-      (final.fetchurl {
-        url = "mirror://sourceforge/p7zip/p7zip_${version}_src_all.tar.bz2";
-        sha256 = "5eb20ac0e2944f6cb9c2d51dd6c4518941c185347d4089ea89087ffdd6e2341f";
-      })
-      (final.fetchurl {
-        url = "http://deb.debian.org/debian/pool/main/p/p7zip/p7zip_${version}+dfsg-8.debian.tar.xz";
-        sha256 = "sha256-ASF9yhZnrw3kiTWlHcRqrUQubryseZ1xQQG37fllHrU=";
-      })
-    ];
-    sourceRoot = "p7zip_${version}";
-    nativeBuildInputs = (super.nativeBuildInputs or [ ]) ++ [ final.quilt ];
-    prePatch = ''
-      export QUILT_PATCHES=../debian/patches
-      quilt push -a
-    '';
-    # orig had `src` attribute, but we are using `srcs`. This trips a warning.
-    __intentionallyOverridingVersion = true;
-
-    separateDebugInfo = true;
-  });
+  sevenzip =
+    let
+      inherit (final) _7zz;
+      _7z-link = final.runCommand "_7z-link" { } ''
+        mkdir -p $out/bin
+        ln -sfn ${_7zz}/bin/7zz "$out/bin/7z"
+      '';
+    in
+    final.symlinkJoin {
+      name = "sevenzip";
+      paths = [
+        _7zz
+        _7z-link
+      ];
+    };
 
   erofs-utils = prev.erofs-utils.overrideAttrs (_: rec {
     version = "1.8.10";

--- a/package.nix
+++ b/package.nix
@@ -12,7 +12,7 @@
   lz4,
   lziprecover,
   lzop,
-  p7zip16,
+  sevenzip,
   partclone,
   sasquatch,
   sasquatch-v4be,
@@ -32,7 +32,7 @@ let
     jefferson
     lziprecover
     lzop
-    p7zip16
+    sevenzip
     sasquatch
     sasquatch-v4be
     ubi_reader


### PR DESCRIPTION
Up until now we've been using p7zip with backported patches from Debian but we don't think it provides sufficient security guarantees anymore.

Through Nix derivation we were pulling version 16.02 with backport patches from Debian. In our Dockerfile we were pulling the bookworm version, which is 22.01. This is also problematic since we're not relying on the same version depending on environment.

Given recent vulnerabilities affecting 7zip (CVE-2025-11002 (path traversal), CVE-2023-52168 (heap overflow), CVE-2023-52169 (oob read)), we consider it safer to simply pull from the latest version provided by official maintainers of 7zip.

This partly goes against the rationale of
7adce8e35eea4dbaf2601cc06bc627bcf7a448de, which is related to MBR extraction. This will be handled by having our own internal MBR extractor instead of relying on 7zip, given its behavior.