### PR TITLE
fix(doc): collapse repeated separators in fragment identifiers

### DIFF
--- a/python/unblob/cli.py
+++ b/python/unblob/cli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import atexit
+import re
 import sys
 from collections.abc import Iterable
 from importlib.metadata import version
@@ -162,7 +163,7 @@ def build_handlers_doc(
                 else "octicons-alert-fill-12"
             )
             f.write(
-                f"""    | [`{handler_class.DOC.name.upper()}`](#{slugifier(handler_class.DOC.name, sep="-")}) | {handler_class.DOC.handler_type.name} | :{support_icon}: |\n"""
+                f"""    | [`{handler_class.DOC.name.upper()}`](#{re.sub(r"-{2,}", "-", slugifier(handler_class.DOC.name, sep="-"))}) | {handler_class.DOC.handler_type.name} | :{support_icon}: |\n"""
             )
 
         for handler_class in sorted_handlers:


### PR DESCRIPTION
Some `HandlerDoc` name may be set to things like `Format A | Format B` or `Format A / Format A variant`, which leads to fragment identifier set to `#format-a--format-a-variant` while it should be set to `#format-a-format-a-variant`.

Fixed by collapsing repeating `-` character using regular expression matching.