### PR TITLE
feat: added d-link alpha encimg archive handler

### DIFF
--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -16,6 +16,8 @@
     | [`CPIO (PORTABLE ASCII)`](#cpio-portable-ascii) | ARCHIVE | :octicons-check-16: |
     | [`CPIO (PORTABLE OLD ASCII)`](#cpio-portable-old-ascii) | ARCHIVE | :octicons-check-16: |
     | [`CRAMFS`](#cramfs) | FILESYSTEM | :octicons-check-16: |
+    | [`D-LINK ALPHA ENCIMG V1 FIRMWARE`](#d-link-alpha-encimg-v1-firmware) | ARCHIVE | :octicons-check-16: |
+    | [`D-LINK ALPHA ENCIMG V2 FIRMWARE`](#d-link-alpha-encimg-v2-firmware) | ARCHIVE | :octicons-check-16: |
     | [`D-LINK DEAFBEAD`](#d-link-deafbead) | ARCHIVE | :octicons-check-16: |
     | [`D-LINK ENCRPTED_IMG`](#d-link-encrpted_img) | ARCHIVE | :octicons-check-16: |
     | [`D-LINK FPKG`](#d-link-fpkg) | ARCHIVE | :octicons-check-16: |
@@ -325,6 +327,40 @@
 
         - [CramFS Documentation](https://web.archive.org/web/20160304053532/http://sourceforge.net/projects/cramfs/){ target="_blank" }
         - [CramFS Wikipedia](https://en.wikipedia.org/wiki/Cramfs){ target="_blank" }
+## D-Link Alpha encimg V1 Firmware
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Encrypted firmware images found in D-Link DIR devices manufactured by Alpha Networks.Uses AES-256-CBC encryption with device-specific keys.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** D-Link
+
+    === "References"
+
+        - [OpenWRT forum](https://forum.openwrt.org/t/adding-openwrt-support-for-d-link-dir-x1860-mt7621-mt7915-ax1800/106500){ target="_blank" }
+        - [delink tool](https://github.com/devttys0/delink/blob/main/src/encimg.rs){ target="_blank" }
+## D-Link Alpha encimg v2 Firmware
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Encrypted firmware images found in D-Link DIR devices manufactured by Alpha Networks.Uses AES-256-CBC encryption with device-specific keys.Unlike the other variant, this one uses a prepended unencrypted WRGG03 header.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** D-Link
+
+    === "References"
+
+        - [OpenWRT Wiki](https://openwrt.org/toh/d-link/d-link_dap_series_of_business_access_points#old_generation_dap-2xxxdap-3xxx_built_by_alpha_networks){ target="_blank" }
+        - [delink tool](https://github.com/devttys0/delink/blob/main/src/encimg.rs){ target="_blank" }
 ## D-Link DEAFBEAD
 
 !!! success "Fully supported"

--- a/python/unblob/handlers/__init__.py
+++ b/python/unblob/handlers/__init__.py
@@ -18,7 +18,7 @@ from .archive import (
     zip as ziparchive,
 )
 from .archive.autel import ecc
-from .archive.dlink import deafbead, encrpted_img, fpkg, shrs
+from .archive.dlink import alpha_encimg, deafbead, encrpted_img, fpkg, shrs
 from .archive.engeniustech import engenius
 from .archive.hp import bdl, ipkg
 from .archive.instar import bneg, instar_hd
@@ -81,6 +81,8 @@ BUILTIN_HANDLERS: Handlers = (
     trx.NetgearTRXv2Handler,
     encrpted_img.EncrptedHandler,
     shrs.SHRSHandler,
+    alpha_encimg.AlphaEncimgHandler,
+    alpha_encimg.AlphaEncimgV2Handler,
     fpkg.FPKGHandler,
     hdr.HDR1Handler,
     hdr.HDR2Handler,

--- a/python/unblob/handlers/archive/dlink/alpha_encimg.py
+++ b/python/unblob/handlers/archive/dlink/alpha_encimg.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import io
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import (
+    Cipher,
+    algorithms,
+    modes,
+)
+
+from unblob._rust import math_tools
+from unblob.file_utils import Endian, File, FileSystem, InvalidInputFormat, StructParser
+from unblob.models import (
+    Extractor,
+    ExtractResult,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from cryptography.hazmat.primitives.ciphers import CipherContext
+
+C_DEFINITIONS = r"""
+    typedef struct dlink_alpha_header {
+        uint32 magic1;
+        uint32 signature_len;
+        uint32 padding;
+        char   signature[signature_len];    /* "signature=XXXXXX_dlink.YYYY_ZZZZZZ\0" */
+        // where XXXXXX seems to be the Alpha Networks model number, YYYY the year
+        // and ZZZZZZ the D-Link model number
+        uint32 magic2;
+        uint32 signature_len2;
+        uint32 fsize;                       /* size of the firmware image (without 128 Bytes header) */
+    } dlink_alpha_header_t;
+
+    // see https://github.com/openwrt/firmware-utils/blob/master/src/mkwrggimg.c
+    typedef struct wrgg03_header {
+        char        signature[32];    /* signature without "signature=" */
+        uint32      magic1;
+        uint32      magic2;
+        char        version[16];
+        char        model[16];
+        uint32      flag[2];
+        uint32  	reserve[2];
+        char        buildno[16];
+        uint32  	fsize;
+        uint32  	offset;
+        char		devname[32];
+        char		digest[16];
+    } wrgg03_header_t;
+"""
+XOR_RANGE = 0xFC
+UNENCRYPTED_ENTROPY_THRESHOLD = 3
+
+
+@dataclass
+class EncParams:
+    signature: bytes
+    key: bytes
+    iv: bytes
+
+    @property
+    def mangled_key(self):
+        return self._mangle(self.signature, self.key)
+
+    @property
+    def mangled_iv(self):
+        return self._mangle(self.signature, self.iv)
+
+    @staticmethod
+    def _mangle(image_sign: bytes, data: bytes) -> bytes:
+        sign_len = len(image_sign)
+        return bytes(
+            data_byte ^ ((i + 1) % XOR_RANGE) ^ image_sign[i % sign_len]
+            for i, data_byte in enumerate(data)
+        )
+
+
+@dataclass
+class EncParamsV2(EncParams):
+    key: bytes = b"oVhq0hvXHdfaGFLdubM4/QvuVHdKee7v"
+    iv: bytes = b"0BO5nlYankuVBe4s"
+
+
+ENC_START_TO_PARAMS = {
+    # DAP-1665 B
+    bytes.fromhex("35 66 6f 68"): EncParams(
+        signature=b"wapac25_dlink.2015_dap1665",
+        key=b"EfCHXytwsC6F0zsedwZc+9vDbCjE3ge4",
+        iv=b"ggPy917jwESpnfXm",
+    ),
+    # DAP-1720 A
+    bytes.fromhex("68 01 cc fb"): EncParams(
+        signature=b"wapac28_dlink.2015_dap1720",
+        key=b"qBiz6o/1RVQTtJBd3FS7FDbqogE8yoBm",
+        iv=b"EfDMqWWxHCOhEqgY",
+    ),
+    # DIR-822 C1
+    bytes.fromhex("df 8c 39 0d"): EncParams(
+        signature=b"wrgac43s_dlink.2015_dir822c1",
+        key=b"KNpsEntCcsep1jdFIs3wnXySKRGNCGmf",
+        iv=b"uph587JdKHrtAUlr",
+    ),
+    # DIR-842 C1 / C2
+    bytes.fromhex("f5 2a a0 b4"): EncParams(
+        signature=b"wrgac65_dlink.2015_dir842",
+        key=b"xQYoRZeD726UAbRb846kO7TeNw8eZa6u",
+        iv=b"zufEbNF3kUafxFiE",
+    ),
+    # DIR-842 C3 (same as C1 except for the "EU" at the end of the signature)
+    bytes.fromhex("21 dd da 00"): EncParams(
+        signature=b"wrgac65_dlink.2015_dir842EU",
+        key=b"xQYoRZeD726UAbRb846kO7TeNw8eZa6u",
+        iv=b"zufEbNF3kUafxFiE",
+    ),
+    # DIR-850L A1
+    bytes.fromhex("e3 13 00 5b"): EncParams(
+        signature=b"wrgac05_dlob.hans_dir850l",
+        key=b"BIuS1CVMEQG+0pUeE99jnR+vLlLd9unr",
+        iv=b"f3+odwHhmJL1ceW1",
+    ),
+    # DIR-850L B1
+    bytes.fromhex("0a 14 e4 24"): EncParams(
+        signature=b"wrgac25_dlink.2013gui_dir850l",
+        key=b"qQehHMEmEPQ5izL+cabn8bNHZXHjkp6W",
+        iv=b"Mmb+IKQgnO8OuF4b",
+    ),
+    # DIR-859 A
+    bytes.fromhex("4c 1b 95 af"): EncParams(
+        signature=b"wrgac37_dlink.2013gui_dir859",
+        key=b"KY0H9R2PDL3eu1J4uCVd1CK7BJ7vF1kc",
+        iv=b"qbStAzIRvWeQHz5U",
+    ),
+    # FixMe: add more entries when they are found
+}
+
+
+def decrypt_chunk(encrypted: bytes, enc_params: EncParams) -> bytes:
+    decryptor = _get_decryptor(enc_params)
+    return decryptor.update(encrypted) + decryptor.finalize()
+
+
+def decrypt_file(
+    file: File, enc_params: EncParams, chunk_size: int = 16
+) -> Iterable[bytes]:
+    decryptor = _get_decryptor(enc_params)
+    while chunk := file.read(chunk_size):
+        yield decryptor.update(chunk)
+    yield decryptor.finalize()
+
+
+def _get_decryptor(enc_params: EncParams) -> CipherContext:
+    cipher = Cipher(
+        algorithms.AES(enc_params.mangled_key),
+        modes.CBC(enc_params.mangled_iv),
+        backend=default_backend(),
+    )
+    return cipher.decryptor()
+
+
+class AlphaEncimgExtractorV1(Extractor):
+    def extract(self, inpath: Path, outdir: Path) -> ExtractResult | None:
+        fs = FileSystem(outdir)
+        with File.from_path(inpath) as file:
+            enc_magic = file.read(4)
+            enc_params = ENC_START_TO_PARAMS.get(enc_magic)
+            if not enc_params:
+                raise InvalidInputFormat("Device not supported")
+            file.seek(0, io.SEEK_SET)
+            out_path = Path(f"{enc_params.signature.decode()}.bin")
+            fs.write_chunks(out_path, decrypt_file(file, enc_params))
+        return ExtractResult(reports=fs.problems)
+
+
+class AlphaEncimgExtractorV2(Extractor):
+    def extract(self, inpath: Path, outdir: Path) -> ExtractResult | None:
+        struct_parser = StructParser(C_DEFINITIONS)
+        fs = FileSystem(outdir)
+        with File.from_path(inpath) as file:
+            header = struct_parser.parse("wrgg03_header_t", file, Endian.BIG)
+            enc_params = EncParamsV2(signature=header.signature.rstrip(b"\0"))
+            file.seek(AlphaEncimgV2Handler.HEADER_SIZE, io.SEEK_SET)
+            out_path = Path(f"{enc_params.signature.decode()}.bin")
+            fs.write_chunks(out_path, decrypt_file(file, enc_params))
+        return ExtractResult(reports=fs.problems)
+
+
+class AlphaEncimgHandler(StructHandler):
+    NAME = "alpha_encimg_v1"
+    PATTERNS = [
+        HexString("35 66 6f 68 ef 1a fe 1f 34 ef 4f 11 21 05 4e be"),  # DAP-1665 B
+        HexString("68 01 cc fb ad 6b a0 ba 33 04 b0 9c bb 48 b0 27"),  # DAP-1720 A
+        HexString("df 8c 39 0d 22 b4 dc 29 fb 4e bf db e8 e1 8b fb"),  # DIR-822 C1
+        HexString("f5 2a a0 b4 92 53 bf ef f8 21 a6 2e 28 a7 39 8b"),  # DIR-842 C1 / C2
+        HexString("21 dd da 00 99 d8 87 a9 d5 2d 7e ff 3b 58 70 a6"),  # DIR-842 C3
+        HexString("e3 13 00 5b 76 df 0b e8 83 24 5a 42 ff 91 2d 3d"),  # DIR-850L A1
+        HexString("0a 14 e4 24 ff 0f b4 d7 53 66 a0 b0 72 fe ab df"),  # DIR-850L B1
+        HexString("4c 1b 95 af 93 72 5f 81 03 03 96 4d dd 76 01 74"),  # DIR-859 A
+        HexString("98 9c 3c 2c 6b 19 1b 25 6e 03 ee 0f 72 5c 6c a0"),  # DIR-865L A
+        HexString("3d e6 02 63 3f c1 85 e7 d2 bf 64 af 29 57 3a bd"),  # DIR-868L A
+        HexString("8e 69 57 e7 76 09 d7 94 47 75 78 a2 4a 1f c9 b2"),  # DIR-880L A
+        HexString("92 61 58 58 14 db bb 3b e5 a5 f3 e7 10 9c a2 0b"),  # DIR-885L A
+        HexString("cb c3 a7 4c 50 0f 42 43 a5 d9 7c a5 25 6b cd ba"),  # DIR-890L A
+        HexString("91 5a c9 a2 11 ff aa 6d b0 12 e8 8d 2c 3c 23 cb"),  # DIR-895L A
+    ]
+    EXTRACTOR = AlphaEncimgExtractorV1()
+    C_DEFINITIONS = C_DEFINITIONS
+    DOC = HandlerDoc(
+        name="D-Link Alpha encimg V1 Firmware",
+        description=(
+            "Encrypted firmware images found in D-Link DIR devices manufactured by Alpha Networks."
+            "Uses AES-256-CBC encryption with device-specific keys."
+        ),
+        handler_type=HandlerType.ARCHIVE,
+        vendor="D-Link",
+        references=[
+            Reference(
+                title="OpenWRT forum",
+                url="https://forum.openwrt.org/t/adding-openwrt-support-for-d-link-dir-x1860-mt7621-mt7915-ax1800/106500",
+            ),
+            Reference(
+                title="delink tool",
+                url="https://github.com/devttys0/delink/blob/main/src/encimg.rs",
+            ),
+        ],
+        limitations=[],
+    )
+    HEADER_STRUCT = "dlink_alpha_header_t"
+    HEADER_SIZE = 0x80
+    _SIGNATURE_PREFIX = b"signature="
+    MAGIC = {0x5EA3A417}
+
+    def _get_header(self, file: File):
+        encrypted_header = file.read(self.HEADER_SIZE)
+        enc_params = ENC_START_TO_PARAMS.get(encrypted_header[:4])
+        if not enc_params:
+            raise InvalidInputFormat("Device not supported")
+
+        decrypted_header = decrypt_chunk(encrypted_header, enc_params)
+        header = self._struct_parser.parse(
+            self.HEADER_STRUCT, decrypted_header, Endian.BIG
+        )
+        self._validate(enc_params, file, header)
+        return header
+
+    def calculate_chunk(self, file: File, start_offset: int) -> ValidChunk | None:
+        header = self._get_header(file)
+        end_offset = start_offset + self.HEADER_SIZE + header.fsize
+        return ValidChunk(start_offset=start_offset, end_offset=end_offset)
+
+    def _validate(self, enc_params: EncParams, file: File, header):
+        if header.magic1 not in self.MAGIC:
+            raise InvalidInputFormat(f"Invalid magic: {header.magic1}")
+
+        expected_signature = self._SIGNATURE_PREFIX + enc_params.signature
+        if header.signature.rstrip(b"\0") != expected_signature:
+            raise InvalidInputFormat(f"Invalid signature {header.signature}")
+
+        remaining = file.size() - file.tell()
+        if header.fsize > remaining:
+            raise InvalidInputFormat("Invalid file size")
+
+        if header.fsize % 16:
+            raise InvalidInputFormat(
+                f"Firmware size not aligned to 16 bytes: {header.fsize}"
+            )
+
+
+class AlphaEncimgV2Handler(AlphaEncimgHandler):
+    NAME = "alpha_encimg_v2"
+    PATTERNS = [
+        HexString("77 61 70 [29] 21 03 08 20 21 03 08 20"),  # Alpha Networks DAP-2xxx
+    ]
+    EXTRACTOR = AlphaEncimgExtractorV2()
+    DOC = HandlerDoc(
+        name="D-Link Alpha encimg v2 Firmware",
+        description=(
+            "Encrypted firmware images found in D-Link DIR devices manufactured by Alpha Networks."
+            "Uses AES-256-CBC encryption with device-specific keys."
+            "Unlike the other variant, this one uses a prepended unencrypted WRGG03 header."
+        ),
+        handler_type=HandlerType.ARCHIVE,
+        vendor="D-Link",
+        references=[
+            Reference(
+                title="OpenWRT Wiki",
+                url="https://openwrt.org/toh/d-link/d-link_dap_series_of_business_access_points#old_generation_dap-2xxxdap-3xxx_built_by_alpha_networks",
+            ),
+            Reference(
+                title="delink tool",
+                url="https://github.com/devttys0/delink/blob/main/src/encimg.rs",
+            ),
+        ],
+        limitations=[],
+    )
+    HEADER_SIZE = 0xA0
+    HEADER_STRUCT = "wrgg03_header_t"
+    _SIGNATURE_PREFIX = b""
+    MAGIC = {0x20080321, 0x21030820}
+    KNOWN_UNENCRYPTED = (
+        bytes.fromhex("5d 00 00 80"),
+        bytes.fromhex("d0 0d fe ed"),
+        bytes.fromhex("10 ec 7a 0d"),  # DAP X2810/X2850
+    )
+
+    def _validate(self, enc_params: EncParams, file: File, header):
+        first_block = file.read(16)
+        file.seek(-16, os.SEEK_CUR)
+        if self._is_not_encrypted(first_block):
+            raise InvalidInputFormat("Firmware payload does not seem to be encrypted")
+        super()._validate(enc_params, file, header)
+
+    def _is_not_encrypted(self, first_block: bytes) -> bool:
+        return (
+            any(first_block.startswith(m) for m in self.KNOWN_UNENCRYPTED)
+            or math_tools.shannon_entropy(first_block) < UNENCRYPTED_ENTROPY_THRESHOLD
+        )
+
+    def _get_header(self, file: File):
+        current_offset = file.tell()
+        header_le = self.parse_header(file, Endian.LITTLE)
+        file.seek(current_offset, io.SEEK_SET)
+        header_be = self.parse_header(file, Endian.BIG)
+        # there are little and big endian devices that use this format, but there seems to be
+        # only one mandatory integer header field: size (sadly we cannot write signatures for that)
+        # since the size is an uint32 and the FW image should be smaller than 64 MB, it is safe to assume
+        # that the correct endianness is the one with the smaller size field
+        header = header_le if header_le.fsize < header_be.fsize else header_be
+
+        device = header.signature.rstrip(b"\0")
+        enc_params = EncParamsV2(signature=device)
+        self._validate(enc_params, file, header)
+        return header

--- a/tests/handlers/archive/test_alpha_encimg.py
+++ b/tests/handlers/archive/test_alpha_encimg.py
@@ -1,0 +1,113 @@
+import pytest
+
+from unblob.file_utils import File, InvalidInputFormat
+from unblob.handlers.archive.dlink.alpha_encimg import (
+    AlphaEncimgHandler,
+    AlphaEncimgV2Handler,
+)
+from unblob.testing import unhex
+
+FILE_CONTENTS_V1 = unhex(
+    """\
+00000000: f52a a0b4 9253 bfef f821 a62e 28a7 398b  .*...S...!..(.9.
+00000010: c353 6d97 101a 76ff 489d ea94 21e4 7ee5  .Sm...v.H...!.~.
+00000020: db0c eb46 05e4 e3fd d3ce 38d2 8987 a932  ...F......8....2
+00000030: f53e 809b f0d2 8d2d c9a2 76af 1997 6f12  .>.....-..v...o.
+00000040: 0d52 ccbb a0d2 3555 c83e eb1e 8334 11ba  .R....5U.>...4..
+00000050: 5bdd 56bc 04ef 2469 4db1 022f 6df2 b877  [.V...$iM../m..w
+00000060: 9d28 af55 2a60 bb35 f8e6 87a5 cbf0 b198  .(.U*`.5........
+00000070: 2fde 451f cb18 b70c 6ec0 85fc 526b 4805  /.E.....n...RkH.
+00000080: 2b13 1235 fc27 199e dc6a 0d4a 2366 668e  +..5.'...j.J#ff.
+00000090: cc35 56b5 e915 c4e0 7f86 a120 bfe3 0972  .5V........ ...r
+000000a0: 61ec d2cc 53fb 099d 10d7 8f8c 531a 5780  a...S.......S.W.
+000000b0: 017b 7dbc 3430 baa0 7550 fb14 00ea 33a9  .{}.40..uP....3.
+000000c0: 5436 0ec5 a253 19e6 43a2 2ac6 2000 808e  T6...S..C.*. ...
+"""
+)
+V2_SIZE_OFFSET = 0x68
+FILE_CONTENTS_V2_LE = unhex(
+    """\
+00000000: 7761 7061 6333 305f 646b 6273 5f64 6170  wapac30_dkbs_dap
+00000010: 3236 3130 0000 0000 0000 0000 0000 0000  2610............
+00000020: 2103 0820 2103 0820 7632 2e30 3672 3038  !.. !.. v2.06r08
+00000030: 3973 3839 3830 3800 6461 7032 3631 3000  9s89808.dap2610.
+00000040: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00000050: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00000060: 0000 0000 0000 0000 1000 0000 0000 0000  ................
+00000070: 2f64 6576 2f75 7261 6e64 6f6d 0000 0000  /dev/urandom....
+00000080: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00000090: 8ea3 0e0a 7ac2 40b3 bc33 9e3c 1343 0802  ....z.@..3.<.C..
+000000a0: d6bd 2993 c5da 1c58 f8b0 0f0b 776f e3f2  ..)....X....wo..
+"""
+)
+FILE_CONTENTS_V2_BE = (
+    FILE_CONTENTS_V2_LE[:V2_SIZE_OFFSET]
+    + bytes.fromhex("00 00 00 10")
+    + FILE_CONTENTS_V2_LE[V2_SIZE_OFFSET + 4 :]
+)
+
+HANDLER_V1 = AlphaEncimgHandler()
+HANDLER_V2 = AlphaEncimgV2Handler()
+
+
+@pytest.mark.parametrize("padding", [0, 16, 64])
+@pytest.mark.parametrize(
+    "contents, handler, start_offset, end_offset",
+    [
+        (FILE_CONTENTS_V1, HANDLER_V1, 0, 0xD0),
+        (
+            FILE_CONTENTS_V2_LE,
+            HANDLER_V2,
+            -AlphaEncimgV2Handler.PATTERN_MATCH_OFFSET,
+            HANDLER_V2.HEADER_SIZE + 0x10,
+        ),
+        (
+            FILE_CONTENTS_V2_BE,
+            HANDLER_V2,
+            -AlphaEncimgV2Handler.PATTERN_MATCH_OFFSET,
+            HANDLER_V2.HEADER_SIZE + 0x10,
+        ),
+    ],
+)
+def test_chunk_calculation(padding, contents, handler, start_offset, end_offset):
+    file = File.from_bytes(contents + b"\0" * padding)
+    chunk = handler.calculate_chunk(file, 0)
+
+    assert chunk is not None
+    assert chunk.start_offset == start_offset
+    assert chunk.end_offset == end_offset
+
+
+@pytest.mark.parametrize(
+    "contents, error, handler",
+    [
+        (
+            FILE_CONTENTS_V1[:0x38] + b"\xff" * 4 + FILE_CONTENTS_V1[0x3C:],
+            "Invalid file size",
+            HANDLER_V1,
+        ),
+        (
+            b"\0" * HANDLER_V1.HEADER_SIZE,
+            "Device not supported",
+            HANDLER_V1,
+        ),
+        (
+            FILE_CONTENTS_V2_LE[:V2_SIZE_OFFSET]
+            + b"\xff" * 4
+            + FILE_CONTENTS_V2_LE[V2_SIZE_OFFSET + 4 :],
+            "Invalid file size",
+            HANDLER_V2,
+        ),
+        (
+            FILE_CONTENTS_V2_LE[:V2_SIZE_OFFSET]
+            + b"\1\0\0\0"
+            + FILE_CONTENTS_V2_LE[V2_SIZE_OFFSET + 4 :],
+            "not aligned",
+            HANDLER_V2,
+        ),
+    ],
+)
+def test_invalid_chunk(contents, error, handler):
+    file = File.from_bytes(contents)
+    with pytest.raises(InvalidInputFormat, match=error):
+        handler.calculate_chunk(file, 0)

--- a/tests/integration/archive/dlink/alpha_encimg/alpha_encimg_v1/__input__/test.enc
+++ b/tests/integration/archive/dlink/alpha_encimg/alpha_encimg_v1/__input__/test.enc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:364555017ff4aa8358bc354034fd999639f10f4b25beee9a5573c0b0adf822d1
+size 208

--- a/tests/integration/archive/dlink/alpha_encimg/alpha_encimg_v1/__output__/test.enc_extract/wrgac65_dlink.2015_dir842.bin
+++ b/tests/integration/archive/dlink/alpha_encimg/alpha_encimg_v1/__output__/test.enc_extract/wrgac65_dlink.2015_dir842.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e56b864974f480900f47f46db3b41e8ec6ef257ed6a03bc9b9116ac27073b855
+size 208

--- a/tests/integration/archive/dlink/alpha_encimg/alpha_encimg_v2/__input__/test.bin
+++ b/tests/integration/archive/dlink/alpha_encimg/alpha_encimg_v2/__input__/test.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0173be16003c756fc71a115bdfe451b01c9dc8cef16b60d45d5aa88901cfc951
+size 176

--- a/tests/integration/archive/dlink/alpha_encimg/alpha_encimg_v2/__output__/test.bin_extract/wapac30_dkbs_dap2610.bin
+++ b/tests/integration/archive/dlink/alpha_encimg/alpha_encimg_v2/__output__/test.bin_extract/wapac30_dkbs_dap2610.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d6b710ed300e1294233aa271859621382b5aef3495f3434f89ed9359d4b3357
+size 16


### PR DESCRIPTION
Some D-Link devices manufactured by Alpha Networks mangle key and IV of the AES encryption by XORing them with the device name. Every device has a unique device name, key and IV value. Since the first few blocks of the encrypted firmware are constant across versions, it is possible to write signatures even for the encrypted firmware images. The key/IV values originally stem from GPL source releases of D-Link.

References:
- https://github.com/openwrt/openwrt/pull/13930
- https://github.com/devttys0/delink/blob/main/src/encimg.rs
- https://thottysploity.github.io/posts/dir-842/

There are more devices that use this format (e.g. DIR 822 C1, 865L, 880L, 885L, 890L and 895L), but the keys were not released AFAIK (you can retrieve the values from a "middle firmware" image as described in the blog post, though)