### PR TITLE
feat(handler): Add support for QNAP networking device firmware

### DIFF
--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -53,6 +53,7 @@
     | [`PAR2 (MULTI-VOLUME)`](#par2-multi-volume) | ARCHIVE | :octicons-check-16: |
     | [`PARTCLONE`](#partclone) | ARCHIVE | :octicons-check-16: |
     | [`QNAP NAS`](#qnap-nas) | ARCHIVE | :octicons-check-16: |
+    | [`QNAP NETWORKING`](#qnap-networking) | ARCHIVE | :octicons-check-16: |
     | [`RAR`](#rar) | ARCHIVE | :octicons-alert-fill-12: |
     | [`ROMFS`](#romfs) | FILESYSTEM | :octicons-check-16: |
     | [`SQUASHFS (V1)`](#squashfs-v1) | FILESYSTEM | :octicons-check-16: |
@@ -933,6 +934,23 @@
         - **Vendor:** QNAP
 
     === "References"
+## QNAP Networking
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        QNAP networking device firmware encrypted with the PC1 cipher. The encryption key is self-describing: it is stored as the device_id in the 74-byte 'icpnas' footer appended to the image, unlike NAS firmware which uses a shared secret prefix.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** QNAP
+
+    === "References"
+
+        - [Pwn2Own Ireland 2024: QNAP Qhora-322](https://neodyme.io/en/blog/pwn2own-2024_qhora/){ target="_blank" }
+        - [QNAP firmware encryption/decryption (PC1)](https://gist.github.com/galaxy4public/0420c7c9a8e3ff860c8d5dce430b2669){ target="_blank" }
 ## RAR
 
 !!! warning "Partially supported"

--- a/python/unblob/handlers/__init__.py
+++ b/python/unblob/handlers/__init__.py
@@ -23,7 +23,7 @@ from .archive.engeniustech import engenius
 from .archive.hp import bdl, ipkg
 from .archive.instar import bneg, instar_hd
 from .archive.netgear import chk, trx
-from .archive.qnap import qnap_nas
+from .archive.qnap import qnap_nas, qnap_networking
 from .archive.xiaomi import hdr
 from .compression import (
     bzip2,
@@ -87,6 +87,7 @@ BUILTIN_HANDLERS: Handlers = (
     hdr.HDR1Handler,
     hdr.HDR2Handler,
     qnap_nas.QnapHandler,
+    qnap_networking.QnapNetworkingHandler,
     bneg.BNEGHandler,
     bdl.HPBDLHandler,
     instar_hd.InstarHDHandler,

--- a/python/unblob/handlers/archive/qnap/_qnap.py
+++ b/python/unblob/handlers/archive/qnap/_qnap.py
@@ -1,0 +1,121 @@
+# Shared infrastructure for QNAP firmware handlers.
+import io
+from pathlib import Path
+
+from unblob.file_utils import File, FileSystem, iterate_file
+from unblob.models import (
+    Endian,
+    Extractor,
+    ExtractResult,
+    StructParser,
+)
+
+FOOTER_LEN = 74
+
+NAS_DEVICE_ID_PREFIX = "QNAPNAS"
+
+C_DEFINITIONS = """
+    typedef struct qnap_header {
+        char    magic[6];
+        uint32  encrypted_len;
+        char    device_id[16];
+        char    file_version[16];
+        char    firmware_date[16];
+        char    revision[16];
+    } qnap_header_t;
+"""
+
+
+# https://gist.github.com/ulidtko/966277a465f1856109b2d2674dcee741#file-qnap-qts-fw-cryptor-py-L114
+class Cryptor:
+    def __init__(self, secret):
+        self.secret = list(bytes(secret, "ascii"))
+        self.n = len(secret) // 2
+        if self.n % 2 == 0:
+            self.secret.append(0)
+        self.precompute_k()
+        self.acc = 0
+        self.y = 0
+        self.z = 0
+
+    def scan(self, f, xs, s0):
+        s = s0
+        for x in xs:
+            w, s = f(s, x)
+            yield w
+
+    def promote(self, char):
+        return char if char < 0x80 else char - 0x101
+
+    def precompute_k(self):
+        self.k = {acc: self.table_for_acc(acc) for acc in range(256)}
+
+    def table_for_acc(self, a):
+        ks = [
+            0xFFFFFFFF
+            & (
+                (self.promote(self.secret[2 * i] ^ a) << 8)
+                + (self.secret[2 * i + 1] ^ a)
+            )
+            for i in range(self.n)
+        ]
+
+        def kstep(st, q):
+            x = st ^ q
+            y = self.lcg(x)
+            z = 0xFFFF & (0x15A * x)
+            return (z, y), y
+
+        return list(self.scan(kstep, ks, 0))
+
+    def lcg(self, x):
+        return 0xFFFF & (0x4E35 * x + 1)
+
+    def kdf(self):
+        """self.secret -> 8bit hash (+ state effects)."""
+        tt = self.k[self.acc]
+        res = 0
+        for i in range(self.n):
+            yy = self.y
+            self.y, t2 = tt[i]
+            self.z = 0xFFFF & (self.y + yy + 0x4E35 * (self.z + i))
+            res = res ^ t2 ^ self.z
+        hi, lo = res >> 8, res & 0xFF
+        return hi ^ lo
+
+    def decrypt_byte(self, v):
+        k = self.kdf()
+        r = 0xFF & (v ^ k)
+        self.acc = self.acc ^ r
+        return r
+
+    def decrypt_chunk(self, chunk):
+        return bytes(map(self.decrypt_byte, chunk))
+
+
+class QnapExtractor(Extractor):
+    def __init__(self):
+        self._struct_parser = StructParser(C_DEFINITIONS)
+
+    def _get_secret(self, header) -> str:
+        raise NotImplementedError
+
+    def extract(self, inpath: Path, outdir: Path) -> ExtractResult:
+        fs = FileSystem(outdir)
+        with (
+            File.from_path(inpath) as infile,
+            fs.open(Path(f"{inpath.name}.decrypted"), "wb+") as outfile,
+        ):
+            infile.seek(-FOOTER_LEN, io.SEEK_END)
+            header = self._struct_parser.parse("qnap_header_t", infile, Endian.LITTLE)
+            cryptor = Cryptor(self._get_secret(header))
+            for chunk in iterate_file(infile, 0, header.encrypted_len, 1024):
+                outfile.write(cryptor.decrypt_chunk(chunk))
+            for chunk in iterate_file(
+                infile,
+                header.encrypted_len,
+                infile.size() - FOOTER_LEN - header.encrypted_len,
+                1024,
+            ):
+                outfile.write(chunk)
+        return ExtractResult(reports=fs.problems)

--- a/python/unblob/handlers/archive/qnap/qnap_nas.py
+++ b/python/unblob/handlers/archive/qnap/qnap_nas.py
@@ -1,14 +1,12 @@
 import io
-from pathlib import Path
 
 import attrs
 from pyperscan import Flag, Pattern, Scan, StreamDatabase
 from structlog import get_logger
 
-from unblob.file_utils import File, iterate_file, stream_scan
+from unblob.file_utils import File, stream_scan
 from unblob.models import (
     Endian,
-    Extractor,
     Handler,
     HandlerDoc,
     HandlerType,
@@ -17,21 +15,12 @@ from unblob.models import (
     ValidChunk,
 )
 
+from ._qnap import C_DEFINITIONS, QnapExtractor
+
 logger = get_logger()
 
-FOOTER_LEN = 74
 SECRET = "QNAPNASVERSION"  # noqa: S105
 
-C_DEFINITIONS = """
-    typedef struct qnap_header {
-        char    magic[6];
-        uint32  encrypted_len;
-        char    device_id[16];
-        char    file_version[16];
-        char    firmware_date[16];
-        char    revision[16];
-    } qnap_header_t;
-"""
 FOOTER_PATTERN = [
     HexString("69 63 70 6e 61 73"),  # encrypted gzip stream start bytes
 ]
@@ -81,27 +70,9 @@ def build_stream_end_scan_db(pattern_list):
 hyperscan_stream_end_magic_db = build_stream_end_scan_db(FOOTER_PATTERN)
 
 
-class QnapExtractor(Extractor):
-    def __init__(self):
-        self._struct_parser = StructParser(C_DEFINITIONS)
-
-    def extract(self, inpath: Path, outdir: Path):
-        outpath = outdir.joinpath(f"{inpath.name}.decrypted")
-        with File.from_path(inpath) as file:
-            file.seek(-FOOTER_LEN, io.SEEK_END)
-            header = self._struct_parser.parse("qnap_header_t", file, Endian.LITTLE)
-            eof = file.tell()
-            cryptor = Cryptor(SECRET + header.file_version.decode("utf-8")[0])
-            with outpath.open("wb") as outfile:
-                for chunk in iterate_file(file, 0, header.encrypted_len, 1024):
-                    outfile.write(cryptor.decrypt_chunk(chunk))
-                for chunk in iterate_file(
-                    file,
-                    header.encrypted_len,
-                    eof - FOOTER_LEN - header.encrypted_len,
-                    1024,
-                ):
-                    outfile.write(chunk)
+class QnapNasExtractor(QnapExtractor):
+    def _get_secret(self, header) -> str:
+        return SECRET + header.file_version.decode("utf-8")[0]
 
 
 class QnapHandler(Handler):
@@ -110,7 +81,7 @@ class QnapHandler(Handler):
     PATTERNS = [
         HexString("F5 7B 47 03"),
     ]
-    EXTRACTOR = QnapExtractor()
+    EXTRACTOR = QnapNasExtractor()
 
     DOC = HandlerDoc(
         name="QNAP NAS",
@@ -135,70 +106,3 @@ class QnapHandler(Handler):
         if context.end_offset > 0:
             return ValidChunk(start_offset=start_offset, end_offset=context.end_offset)
         return None
-
-
-# https://gist.github.com/ulidtko/966277a465f1856109b2d2674dcee741#file-qnap-qts-fw-cryptor-py-L114
-class Cryptor:
-    def __init__(self, secret):
-        self.secret = list(bytes(secret, "ascii"))
-        self.n = len(secret) // 2
-        if self.n % 2 == 0:
-            self.secret.append(0)
-        self.precompute_k()
-        self.acc = 0
-        self.y = 0
-        self.z = 0
-
-    def scan(self, f, xs, s0):
-        s = s0
-        for x in xs:
-            w, s = f(s, x)
-            yield w
-
-    def promote(self, char):
-        return char if char < 0x80 else char - 0x101
-
-    def precompute_k(self):
-        self.k = {acc: self.table_for_acc(acc) for acc in range(256)}
-
-    def table_for_acc(self, a):
-        ks = [
-            0xFFFFFFFF
-            & (
-                (self.promote(self.secret[2 * i] ^ a) << 8)
-                + (self.secret[2 * i + 1] ^ a)
-            )
-            for i in range(self.n)
-        ]
-
-        def kstep(st, q):
-            x = st ^ q
-            y = self.lcg(x)
-            z = 0xFFFF & (0x15A * x)
-            return (z, y), y
-
-        return list(self.scan(kstep, ks, 0))
-
-    def lcg(self, x):
-        return 0xFFFF & (0x4E35 * x + 1)
-
-    def kdf(self):
-        """self.secret -> 8bit hash (+ state effects)."""
-        tt = self.k[self.acc]
-        res = 0
-        for i in range(self.n):
-            yy = self.y
-            self.y, t2 = tt[i]
-            self.z = 0xFFFF & (self.y + yy + 0x4E35 * (self.z + i))
-            res = res ^ t2 ^ self.z
-        hi, lo = res >> 8, res & 0xFF
-        return hi ^ lo
-
-    def decrypt_byte(self, v):
-        k = self.kdf()
-        r = 0xFF & (v ^ k)
-        self.acc = self.acc ^ r
-        return r
-
-    def decrypt_chunk(self, chunk):
-        return bytes(map(self.decrypt_byte, chunk))

--- a/python/unblob/handlers/archive/qnap/qnap_networking.py
+++ b/python/unblob/handlers/archive/qnap/qnap_networking.py
@@ -1,0 +1,65 @@
+from unblob.file_utils import File
+from unblob.models import (
+    Endian,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
+
+from ._qnap import C_DEFINITIONS, FOOTER_LEN, NAS_DEVICE_ID_PREFIX, QnapExtractor
+
+
+class QnapNetworkingExtractor(QnapExtractor):
+    def _get_secret(self, header) -> str:
+        return header.device_id.rstrip(b"\x00").decode("ascii")
+
+
+class QnapNetworkingHandler(StructHandler):
+    NAME = "qnap_networking"
+
+    PATTERNS = [
+        HexString("69 63 70 6e 61 73"),  # "icpnas" footer signature
+    ]
+    C_DEFINITIONS = C_DEFINITIONS
+    HEADER_STRUCT = "qnap_header_t"
+    EXTRACTOR = QnapNetworkingExtractor()
+
+    DOC = HandlerDoc(
+        name="QNAP Networking",
+        description=(
+            "QNAP networking device firmware encrypted with the PC1 cipher. "
+            "The encryption key is self-describing: it is stored as the "
+            "device_id in the 74-byte 'icpnas' footer appended to the image, "
+            "unlike NAS firmware which uses a shared secret prefix."
+        ),
+        handler_type=HandlerType.ARCHIVE,
+        vendor="QNAP",
+        references=[
+            Reference(
+                title="Pwn2Own Ireland 2024: QNAP Qhora-322",
+                url="https://neodyme.io/en/blog/pwn2own-2024_qhora/",
+            ),
+            Reference(
+                title="QNAP firmware encryption/decryption (PC1)",
+                url="https://gist.github.com/galaxy4public/0420c7c9a8e3ff860c8d5dce430b2669",
+            ),
+        ],
+        limitations=[],
+    )
+
+    def calculate_chunk(self, file: File, start_offset: int) -> ValidChunk | None:
+        if start_offset != file.size() - FOOTER_LEN:
+            return None
+        header = self.parse_header(file, endian=Endian.LITTLE)
+
+        if header.encrypted_len == 0 or header.encrypted_len > start_offset:
+            return None
+
+        device_id = header.device_id.rstrip(b"\x00").decode("ascii", errors="replace")
+        if device_id.upper().startswith(NAS_DEVICE_ID_PREFIX):
+            return None
+
+        return ValidChunk(start_offset=0, end_offset=start_offset + FOOTER_LEN)

--- a/tests/integration/archive/qnap/qnap_networking/__input__/sample.img
+++ b/tests/integration/archive/qnap/qnap_networking/__input__/sample.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6abee30d6fbb0576f8b1d20f8977ef5bd266f9ef5df591c820f523a14db18115
+size 219

--- a/tests/integration/archive/qnap/qnap_networking/__output__/sample.img_extract/sample.img.decrypted
+++ b/tests/integration/archive/qnap/qnap_networking/__output__/sample.img_extract/sample.img.decrypted
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3e506dd3bf06bcb0f4734c3a20cb578ded8d53faa2df6a8f14393f17a23d637
+size 145

--- a/tests/integration/archive/qnap/qnap_networking/__output__/sample.img_extract/sample.img.decrypted_extract/gzip.uncompressed
+++ b/tests/integration/archive/qnap/qnap_networking/__output__/sample.img_extract/sample.img.decrypted_extract/gzip.uncompressed
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9913f7db663926c49a78de817cd878c21c325303666cbd749c31566d7735f50a
+size 10240

--- a/tests/integration/archive/qnap/qnap_networking/__output__/sample.img_extract/sample.img.decrypted_extract/gzip.uncompressed_extract/testfile.txt
+++ b/tests/integration/archive/qnap/qnap_networking/__output__/sample.img_extract/sample.img.decrypted_extract/gzip.uncompressed_extract/testfile.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2035bae46e4534401cf0ad56e38524502304b99e9292e6a35e0eae1667848a0c
+size 21


### PR DESCRIPTION
QNAP networking devices use the same PC1 cipher as NAS firmware but derive the decryption key directly from the last 74 bytes of the encrypted firmware itself rather than a hardcoded secret prefix. 
Refactors shared cipher and struct definitions into _qnap.py.