### PR TITLE
Memory improvements

### DIFF
--- a/python/unblob/handlers/archive/dlink/shrs.py
+++ b/python/unblob/handlers/archive/dlink/shrs.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from structlog import get_logger
 
-from unblob.file_utils import File, InvalidInputFormat
+from unblob.file_utils import File, InvalidInputFormat, iterate_file
 from unblob.models import (
     Endian,
     Extractor,
@@ -88,10 +88,14 @@ class SHRSHandler(StructHandler):
     def is_valid_header(self, header, file: File) -> bool:
         if header.file_size < len(header):
             return False
-        # we're exactly past the header, we compute the digest
-        digest = hashlib.sha512(file.read(header.file_size_no_padding)).digest()
-        # we seek back to where we were
-        file.seek(-header.file_size_no_padding, io.SEEK_CUR)
+        digest_state = hashlib.sha512()
+        digest_start = file.tell()
+
+        for chunk in iterate_file(file, digest_start, header.file_size_no_padding):
+            digest_state.update(chunk)
+
+        file.seek(digest_start, io.SEEK_SET)
+        digest = digest_state.digest()
         return digest == header.encrypted_digest
 
     def calculate_chunk(self, file: File, start_offset: int) -> ValidChunk | None:

--- a/python/unblob/handlers/archive/netgear/trx.py
+++ b/python/unblob/handlers/archive/netgear/trx.py
@@ -7,7 +7,13 @@ from typing import TYPE_CHECKING, cast
 from structlog import get_logger
 
 from unblob.extractor import carve_chunk_to_file
-from unblob.file_utils import Endian, File, InvalidInputFormat, StructParser
+from unblob.file_utils import (
+    Endian,
+    File,
+    InvalidInputFormat,
+    StructParser,
+    iterate_file,
+)
 from unblob.models import (
     Chunk,
     Extractor,
@@ -88,9 +94,15 @@ class NetgearTRXBase(StructHandler):
         return header.len >= len(header)
 
     def _is_crc_valid(self, file: File, start_offset: int, header) -> bool:
-        file.seek(start_offset + CRC_CONTENT_OFFSET)
-        content = bytearray(file.read(header.len - CRC_CONTENT_OFFSET))
-        computed_crc = (binascii.crc32(content) ^ -1) & 0xFFFFFFFF
+        computed_crc = 0
+        for chunk in iterate_file(
+            file,
+            start_offset + CRC_CONTENT_OFFSET,
+            header.len - CRC_CONTENT_OFFSET,
+        ):
+            computed_crc = binascii.crc32(chunk, computed_crc)
+
+        computed_crc = (computed_crc ^ -1) & 0xFFFFFFFF
         return header.crc32 == computed_crc
 
 

--- a/python/unblob/handlers/archive/par2.py
+++ b/python/unblob/handlers/archive/par2.py
@@ -1,8 +1,7 @@
 import hashlib
-import io
 from pathlib import Path
 
-from unblob.file_utils import Endian, StructParser
+from unblob.file_utils import Endian, StructParser, iterate_file
 from unblob.models import (
     DirectoryHandler,
     Glob,
@@ -54,14 +53,16 @@ class MultiVolumePAR2Handler(DirectoryHandler):
                     return False
 
                 offset_to_recovery_id = 32
-                # seek to beginning of recovery set ID
-                f.seek(offset_to_recovery_id, io.SEEK_SET)
-                packet_content = f.read(
+                packet_checksum_state = hashlib.md5(usedforsecurity=False)
+                packet_content_length = (
                     header.packet_length - len(header) + offset_to_recovery_id
                 )
-                packet_checksum = hashlib.md5(
-                    packet_content, usedforsecurity=False
-                ).digest()
+                for chunk in iterate_file(
+                    f, offset_to_recovery_id, packet_content_length
+                ):
+                    packet_checksum_state.update(chunk)
+
+                packet_checksum = packet_checksum_state.digest()
 
                 if packet_checksum != header.md5_hash:
                     return False

--- a/python/unblob/handlers/filesystem/cramfs.py
+++ b/python/unblob/handlers/filesystem/cramfs.py
@@ -1,9 +1,10 @@
 import binascii
+import io
 import struct
 
 from unblob.extractors import Command
 
-from ...file_utils import Endian, convert_int32, get_endian
+from ...file_utils import get_endian, iterate_file
 from ...models import (
     File,
     HandlerDoc,
@@ -16,6 +17,8 @@ from ...models import (
 
 CRAMFS_FLAG_FSID_VERSION_2 = 0x00000001
 BIG_ENDIAN_MAGIC = 0x28_CD_3D_45
+FSID_CRC_OFFSET = 32
+FSID_CRC_SIZE = 4
 
 
 def swap_int32(i):
@@ -71,7 +74,7 @@ class CramFSHandler(StructHandler):
         header = self.parse_header(file, endian)
         valid_signature = header.signature == b"Compressed ROMFS"
 
-        if valid_signature and self._is_crc_valid(file, start_offset, header, endian):
+        if valid_signature and self._is_crc_valid(file, start_offset, header):
             return ValidChunk(
                 start_offset=start_offset,
                 end_offset=start_offset + header.fs_size,
@@ -83,17 +86,26 @@ class CramFSHandler(StructHandler):
         file: File,
         start_offset: int,
         header,
-        endian: Endian,
     ) -> bool:
         # old cramfs format do not support crc
         if not (header.flags & CRAMFS_FLAG_FSID_VERSION_2):
             return True
-        file.seek(start_offset)
-        content = bytearray(file.read(header.fs_size))
-        file.seek(start_offset + 32)
-        crc_bytes = file.read(4)
-        header_crc = convert_int32(crc_bytes, endian)
-        content[32:36] = b"\x00\x00\x00\x00"
-        computed_crc = binascii.crc32(content)
+
+        file.seek(start_offset, io.SEEK_SET)
+        header_bytes = bytearray(file.read(FSID_CRC_OFFSET + FSID_CRC_SIZE))
+        header_bytes[FSID_CRC_OFFSET : FSID_CRC_OFFSET + FSID_CRC_SIZE] = (
+            b"\x00\x00\x00\x00"
+        )
+        computed_crc = binascii.crc32(header_bytes)
+
+        for chunk in iterate_file(
+            file,
+            start_offset + FSID_CRC_OFFSET + FSID_CRC_SIZE,
+            header.fs_size - FSID_CRC_OFFSET + FSID_CRC_SIZE,
+        ):
+            computed_crc = binascii.crc32(chunk, computed_crc)
+
         # some vendors like their CRC's swapped, don't ask why
-        return header_crc == computed_crc or header_crc == swap_int32(computed_crc)
+        return header.fsid_crc == computed_crc or header.fsid_crc == swap_int32(
+            computed_crc
+        )

--- a/python/unblob/handlers/filesystem/cramfs.py
+++ b/python/unblob/handlers/filesystem/cramfs.py
@@ -101,7 +101,7 @@ class CramFSHandler(StructHandler):
         for chunk in iterate_file(
             file,
             start_offset + FSID_CRC_OFFSET + FSID_CRC_SIZE,
-            header.fs_size - FSID_CRC_OFFSET + FSID_CRC_SIZE,
+            header.fs_size - (FSID_CRC_OFFSET + FSID_CRC_SIZE),
         ):
             computed_crc = binascii.crc32(chunk, computed_crc)
 

--- a/python/unblob/handlers/filesystem/romfs.py
+++ b/python/unblob/handlers/filesystem/romfs.py
@@ -13,6 +13,7 @@ from ...file_utils import (
     Endian,
     FileSystem,
     InvalidInputFormat,
+    iterate_file,
     read_until_past,
     round_up,
 )
@@ -115,14 +116,13 @@ class FileHeader:
         finally:
             self.file.seek(current_position, io.SEEK_SET)
 
-    @property
     def content(self) -> bytes:
-        """Returns the file content. Applicable to files and symlinks."""
+        """Return the file content. Applicable to files and symlinks."""
         try:
             self.file.seek(self.start_offset, io.SEEK_SET)
             return self.file.read(self.size)
         finally:
-            self.file.seek(-self.size, io.SEEK_CUR)
+            self.file.seek(self.start_offset, io.SEEK_SET)
 
     @property
     def mode(self) -> int:
@@ -256,7 +256,7 @@ class RomFSHeader:
         return file_header.next_filehdr
 
     def create_symlink(self, output_path: Path, inode: FileHeader):
-        target_path = Path(inode.content.decode("utf-8"))
+        target_path = Path(inode.content().decode("utf-8"))
         self.fs.create_symlink(src=target_path, dst=output_path)
 
     def create_hardlink(self, output_path: Path, inode: FileHeader):
@@ -277,7 +277,10 @@ class RomFSHeader:
         elif inode.fs_type == FSType.DIRECTORY:
             self.fs.mkdir(output_path, mode=inode.mode, exist_ok=True)
         elif inode.fs_type == FSType.FILE:
-            self.fs.write_bytes(output_path, inode.content)
+            self.fs.write_chunks(
+                output_path,
+                iterate_file(inode.file, inode.start_offset, inode.size),
+            )
         elif inode.fs_type in [FSType.BLOCK_DEV, FSType.CHAR_DEV]:
             self.fs.mknod(output_path, mode=inode.mode, device=inode.dev)
         elif inode.fs_type == FSType.FIFO:

--- a/python/unblob/handlers/filesystem/romfs.py
+++ b/python/unblob/handlers/filesystem/romfs.py
@@ -13,6 +13,7 @@ from ...file_utils import (
     Endian,
     FileSystem,
     InvalidInputFormat,
+    iterate_file,
     read_until_past,
     round_up,
 )
@@ -115,16 +116,19 @@ class FileHeader:
         finally:
             self.file.seek(current_position, io.SEEK_SET)
 
-    @property
     def content(self) -> bytes:
-        """Returns the file content. Applicable to files and symlinks."""
-        if self.start_offset + self.size > self.file.size():
-            raise RomFSError("Inode size extends past the end of the file")
+        """Return the file content. Applicable to files and symlinks."""
+        self.validate_content_bounds()
         try:
             self.file.seek(self.start_offset, io.SEEK_SET)
             return self.file.read(self.size)
         finally:
-            self.file.seek(-self.size, io.SEEK_CUR)
+            self.file.seek(self.start_offset, io.SEEK_SET)
+
+    def validate_content_bounds(self) -> None:
+        """Raise when the inode content extends past the ROMFS image."""
+        if self.start_offset + self.size > self.file.size():
+            raise RomFSError("Inode size extends past the end of the file")
 
     @property
     def mode(self) -> int:
@@ -258,7 +262,7 @@ class RomFSHeader:
         return file_header.next_filehdr
 
     def create_symlink(self, output_path: Path, inode: FileHeader):
-        target_path = Path(inode.content.decode("utf-8"))
+        target_path = Path(inode.content().decode("utf-8"))
         self.fs.create_symlink(src=target_path, dst=output_path)
 
     def create_hardlink(self, output_path: Path, inode: FileHeader):
@@ -279,7 +283,11 @@ class RomFSHeader:
         elif inode.fs_type == FSType.DIRECTORY:
             self.fs.mkdir(output_path, mode=inode.mode, exist_ok=True)
         elif inode.fs_type == FSType.FILE:
-            self.fs.write_bytes(output_path, inode.content)
+            inode.validate_content_bounds()
+            self.fs.write_chunks(
+                output_path,
+                iterate_file(inode.file, inode.start_offset, inode.size),
+            )
         elif inode.fs_type in [FSType.BLOCK_DEV, FSType.CHAR_DEV]:
             self.fs.mknod(output_path, mode=inode.mode, device=inode.dev)
         elif inode.fs_type == FSType.FIFO:

--- a/tests/handlers/filesystem/test_romfs.py
+++ b/tests/handlers/filesystem/test_romfs.py
@@ -1,4 +1,5 @@
 import struct
+from unittest.mock import Mock
 
 import pytest
 
@@ -7,6 +8,7 @@ from unblob.handlers.filesystem.romfs import (
     FileHeader,
     FSType,
     RomFSError,
+    RomFSHeader,
     get_string,
     valid_checksum,
 )
@@ -65,9 +67,20 @@ def test_valid_checksum(content, valid):
 def test_content_rejects_inode_past_eof():
     inode = FileHeader(0, build_inode(size=1000, data=b"A" * 8))
     with pytest.raises(RomFSError):
-        _ = inode.content
+        inode.content()
 
 
 def test_content_reads_inode_within_bounds():
     inode = FileHeader(0, build_inode(size=8, data=b"A" * 8))
-    assert inode.content == b"A" * 8
+    assert inode.content() == b"A" * 8
+
+
+def test_create_inode_rejects_regular_file_past_eof():
+    inode = FileHeader(0, build_inode(size=1000, data=b"A" * 8))
+    header = object.__new__(RomFSHeader)
+    header.fs = Mock()
+
+    with pytest.raises(RomFSError):
+        header.create_inode(inode)
+
+    header.fs.write_chunks.assert_not_called()

--- a/tests/integration/filesystem/cramfs/big_endian/__input__/fruits.cramfs_be.padded
+++ b/tests/integration/filesystem/cramfs/big_endian/__input__/fruits.cramfs_be.padded
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab41cb9723294202e4361f5c5903e24b77b81b5bd9c1e6ba38047263641fb65e
+size 4128

--- a/tests/integration/filesystem/cramfs/big_endian/__input__/fruits.crc_swap.cramfs_be.padded
+++ b/tests/integration/filesystem/cramfs/big_endian/__input__/fruits.crc_swap.cramfs_be.padded
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab41cb9723294202e4361f5c5903e24b77b81b5bd9c1e6ba38047263641fb65e
+size 4128

--- a/tests/integration/filesystem/cramfs/big_endian/__input__/fruits.old.cramfs_be.padded
+++ b/tests/integration/filesystem/cramfs/big_endian/__input__/fruits.old.cramfs_be.padded
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b4e1454f3ae40b19adbf3c0510a18a96a146ef2df8d727c550ca06d7060c769
+size 4128

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.cramfs_be.padded_extract/0-16.padding
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.cramfs_be.padded_extract/0-16.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.cramfs_be.padded_extract/16-4112.cramfs
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.cramfs_be.padded_extract/16-4112.cramfs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de1d6be79d816470ff54836760a0a1574fba6c2efa9ed13108f0669eb329d749
+size 4096

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.cramfs_be.padded_extract/16-4112.cramfs_extract/apple.txt
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.cramfs_be.padded_extract/16-4112.cramfs_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.cramfs_be.padded_extract/16-4112.cramfs_extract/cherry.txt
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.cramfs_be.padded_extract/16-4112.cramfs_extract/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.cramfs_be.padded_extract/4112-4128.padding
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.cramfs_be.padded_extract/4112-4128.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be.padded_extract/0-16.padding
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be.padded_extract/0-16.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be.padded_extract/16-4112.cramfs
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be.padded_extract/16-4112.cramfs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de1d6be79d816470ff54836760a0a1574fba6c2efa9ed13108f0669eb329d749
+size 4096

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be.padded_extract/16-4112.cramfs_extract/apple.txt
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be.padded_extract/16-4112.cramfs_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be.padded_extract/16-4112.cramfs_extract/cherry.txt
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be.padded_extract/16-4112.cramfs_extract/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be.padded_extract/4112-4128.padding
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.crc_swap.cramfs_be.padded_extract/4112-4128.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be.padded_extract/0-16.padding
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be.padded_extract/0-16.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be.padded_extract/16-4112.cramfs
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be.padded_extract/16-4112.cramfs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad4972ed94445a852d88ecee148fe34699b417d9885a84e47d328a300c0d7a37
+size 4096

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be.padded_extract/16-4112.cramfs_extract/apple.txt
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be.padded_extract/16-4112.cramfs_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be.padded_extract/16-4112.cramfs_extract/cherry.txt
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be.padded_extract/16-4112.cramfs_extract/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be.padded_extract/4112-4128.padding
+++ b/tests/integration/filesystem/cramfs/big_endian/__output__/fruits.old.cramfs_be.padded_extract/4112-4128.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16

--- a/tests/integration/filesystem/cramfs/little_endian/__input__/fruits.cramfs_le.padded
+++ b/tests/integration/filesystem/cramfs/little_endian/__input__/fruits.cramfs_le.padded
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6fb0505bfc2739119705dee4966c6d8d991dba0ead03916f73c90ccc9b62f47
+size 4128

--- a/tests/integration/filesystem/cramfs/little_endian/__input__/fruits.crc_swap.cramfs_le.padded
+++ b/tests/integration/filesystem/cramfs/little_endian/__input__/fruits.crc_swap.cramfs_le.padded
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6fb0505bfc2739119705dee4966c6d8d991dba0ead03916f73c90ccc9b62f47
+size 4128

--- a/tests/integration/filesystem/cramfs/little_endian/__input__/fruits.old.cramfs_le.padded
+++ b/tests/integration/filesystem/cramfs/little_endian/__input__/fruits.old.cramfs_le.padded
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7165105b4bf6f71fd77b31fc9d425e8889eca3095b4b323ef43128e957fa454d
+size 4128

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.cramfs_le.padded_extract/0-16.padding
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.cramfs_le.padded_extract/0-16.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.cramfs_le.padded_extract/16-4112.cramfs
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.cramfs_le.padded_extract/16-4112.cramfs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e594657cd8a394eb7abb2a10041681a925edb95e829d37a7a4ac5168f026b9e
+size 4096

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.cramfs_le.padded_extract/16-4112.cramfs_extract/apple.txt
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.cramfs_le.padded_extract/16-4112.cramfs_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.cramfs_le.padded_extract/16-4112.cramfs_extract/cherry.txt
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.cramfs_le.padded_extract/16-4112.cramfs_extract/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.cramfs_le.padded_extract/4112-4128.padding
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.cramfs_le.padded_extract/4112-4128.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le.padded_extract/0-16.padding
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le.padded_extract/0-16.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le.padded_extract/16-4112.cramfs
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le.padded_extract/16-4112.cramfs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e594657cd8a394eb7abb2a10041681a925edb95e829d37a7a4ac5168f026b9e
+size 4096

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le.padded_extract/16-4112.cramfs_extract/apple.txt
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le.padded_extract/16-4112.cramfs_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le.padded_extract/16-4112.cramfs_extract/cherry.txt
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le.padded_extract/16-4112.cramfs_extract/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le.padded_extract/4112-4128.padding
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.crc_swap.cramfs_le.padded_extract/4112-4128.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le.padded_extract/0-16.padding
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le.padded_extract/0-16.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le.padded_extract/16-4112.cramfs
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le.padded_extract/16-4112.cramfs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bd27287c45ce34df662963e1541f5f13cf8b22f30e14942031dabd80a1596ea
+size 4096

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le.padded_extract/16-4112.cramfs_extract/apple.txt
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le.padded_extract/16-4112.cramfs_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le.padded_extract/16-4112.cramfs_extract/cherry.txt
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le.padded_extract/16-4112.cramfs_extract/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le.padded_extract/4112-4128.padding
+++ b/tests/integration/filesystem/cramfs/little_endian/__output__/fruits.old.cramfs_le.padded_extract/4112-4128.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16


### PR DESCRIPTION
Reduced peak memory usage across several handlers by replacing large in-memory reads with chunked processing. cramfs, trx, shrs, par2, and romfs now validate or extract data with streaming reads, so large attacker-controlled regions no longer get copied wholesale into Python memory.