### PR TITLE
fix(handlers): make UnblobTarInfo work with python 3.13.13+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,9 +590,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom",

--- a/python/unblob/handlers/archive/_safe_tarfile.py
+++ b/python/unblob/handlers/archive/_safe_tarfile.py
@@ -16,8 +16,12 @@ MAX_PATH_LEN = 255
 
 class UnblobTarInfo(tarfile.TarInfo):
     @classmethod
-    def frombuf(cls, buf, encoding, errors):  # noqa: C901
+    def frombuf(cls, buf, encoding, errors):
         """Parse GNU headers without treating the prefix field as a pathname."""
+        return cls._frombuf(buf, encoding, errors)
+
+    @classmethod
+    def _frombuf(cls, buf, encoding, errors, *, dircheck=True):  # noqa: C901
         if len(buf) == 0:
             raise tarfile.EmptyHeaderError("empty header")  # pyright: ignore[reportAttributeAccessIssue]
         if len(buf) != tarfile.BLOCKSIZE:
@@ -46,7 +50,7 @@ class UnblobTarInfo(tarfile.TarInfo):
         prefix = tarfile.nts(buf[345:500], encoding, errors)  # pyright: ignore[reportAttributeAccessIssue]
         magic = buf[257:265]
 
-        if obj.type == tarfile.AREGTYPE and obj.name.endswith("/"):
+        if dircheck and obj.type == tarfile.AREGTYPE and obj.name.endswith("/"):
             obj.type = tarfile.DIRTYPE
 
         if obj.type == tarfile.GNUTYPE_SPARSE:

--- a/tests/handlers/archive/test_tar.py
+++ b/tests/handlers/archive/test_tar.py
@@ -5,7 +5,11 @@ import warnings
 import pytest
 
 from unblob.file_utils import File
-from unblob.handlers.archive._safe_tarfile import SafeTarFile, open_safe_tarfile
+from unblob.handlers.archive._safe_tarfile import (
+    SafeTarFile,
+    UnblobTarInfo,
+    open_safe_tarfile,
+)
 from unblob.handlers.archive.tar import (
     TarUnixHandler,
     TarUstarHandler,
@@ -404,6 +408,18 @@ def test_extractall_ignores_gnu_timestamp_prefix(tmp_path):
     assert caught == []
     assert (tmp_path / "extract" / "Vagrantfile").is_file()
     assert not (tmp_path / "extract" / "13327342752").exists()
+
+
+def test_unblob_tarinfo__frombuf_ignores_gnu_timestamp_prefix():
+    archive = _build_gnu_tar_with_timestamp_prefix()
+
+    with open_safe_tarfile(fileobj=io.BytesIO(archive), mode="r:") as tf:
+        member = UnblobTarInfo._frombuf(  # noqa: SLF001
+            archive[: tarfile.BLOCKSIZE], tf.encoding, tf.errors
+        )
+
+    assert member.name == "Vagrantfile"
+    assert member.mtime == int("13327342752", 8)
 
 
 def test_open_safe_tarfile_keeps_ustar_prefix_paths():


### PR DESCRIPTION
In CPython **3.13.13**, tarfile changed its internal parsing path¹: `TarInfo.fromtarfile()` now goes through a new` _fromtarfile()` helper, which calls `cls._frombuf(...)` instead of `cls.frombuf(...)`.

Our workaround in `python/unblob/handlers/archive/_safe_tarfile.py` only overrode `frombuf()`, so on **3.13.13** it was silently bypassed and stdlib parsing came back.

We patched `UnblobTarInfo` to override `_frombuf()` as well, and made `frombuf()` delegate to it so both **3.13.12** and **3.13.13+** use the same GNU-prefix fix.

Also added a direct regression test in for `_frombuf()` so future CPython refactors won't bypass the workaround unnoticed.

1 - https://github.com/python/cpython/commit/ae99fe3a33b43e303a05f012815cef60b611a9c7