### PR TITLE
feat(handler): add APFS container handler

### DIFF
--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -5,6 +5,7 @@
     | [`AIROHA BT FIRMWARE`](#airoha-bt-firmware) | ARCHIVE | :octicons-alert-fill-12: |
     | [`ANDROID EROFS`](#android-erofs) | FILESYSTEM | :octicons-check-16: |
     | [`ANDROID SPARSE`](#android-sparse) | FILESYSTEM | :octicons-check-16: |
+    | [`APFS`](#apfs) | FILESYSTEM | :octicons-check-16: |
     | [`AR`](#ar) | ARCHIVE | :octicons-check-16: |
     | [`ARC`](#arc) | ARCHIVE | :octicons-check-16: |
     | [`ARJ`](#arj) | ARCHIVE | :octicons-check-16: |
@@ -166,6 +167,22 @@
 
         - [Android Sparse Image Format Documentation](https://formats.kaitai.io/android_sparse/){ target="_blank" }
         - [simg2img Tool](https://github.com/anestisb/android-simg2img){ target="_blank" }
+## APFS
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Apple File System (APFS) is Apple's proprietary filesystem introduced in macOS High Sierra and iOS 10.3, replacing HFS+. It features copy-on-write semantics, space sharing between volumes, native encryption, snapshots, and sparse files.
+
+        ---
+
+        - **Handler type:** FileSystem
+        - **Vendor:** Apple
+
+    === "References"
+
+        - [Apple File System Reference](https://developer.apple.com/support/downloads/Apple-File-System-Reference.pdf){ target="_blank" }
 ## AR
 
 !!! success "Fully supported"

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -5,6 +5,7 @@
     | [`AIROHA BT FIRMWARE`](#airoha-bt-firmware) | ARCHIVE | :octicons-alert-fill-12: |
     | [`ANDROID EROFS`](#android-erofs) | FILESYSTEM | :octicons-check-16: |
     | [`ANDROID SPARSE`](#android-sparse) | FILESYSTEM | :octicons-check-16: |
+    | [`APFS`](#apfs) | FILESYSTEM | :octicons-check-16: |
     | [`AR`](#ar) | ARCHIVE | :octicons-check-16: |
     | [`ARC`](#arc) | ARCHIVE | :octicons-check-16: |
     | [`ARJ`](#arj) | ARCHIVE | :octicons-check-16: |
@@ -170,6 +171,22 @@
 
         - [Android Sparse Image Format Documentation](https://formats.kaitai.io/android_sparse/){ target="_blank" }
         - [simg2img Tool](https://github.com/anestisb/android-simg2img){ target="_blank" }
+## APFS
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Apple File System (APFS) is Apple's proprietary filesystem introduced in macOS High Sierra and iOS 10.3, replacing HFS+. It features copy-on-write semantics, space sharing between volumes, native encryption, snapshots, and sparse files.
+
+        ---
+
+        - **Handler type:** FileSystem
+        - **Vendor:** Apple
+
+    === "References"
+
+        - [Apple File System Reference](https://developer.apple.com/support/downloads/Apple-File-System-Reference.pdf){ target="_blank" }
 ## AR
 
 !!! success "Fully supported"

--- a/python/unblob/handlers/__init__.py
+++ b/python/unblob/handlers/__init__.py
@@ -46,6 +46,7 @@ from .compression import (
 )
 from .executable import elf, xalz
 from .filesystem import (
+    apfs,
     btrfs_stream,
     cramfs,
     extfs,
@@ -71,6 +72,7 @@ __all__ = [
 ]
 
 BUILTIN_HANDLERS: Handlers = (
+    apfs.APFSHandler,
     cramfs.CramFSHandler,
     deafbead.DeafBeadHandler,
     extfs.EXTHandler,

--- a/python/unblob/handlers/__init__.py
+++ b/python/unblob/handlers/__init__.py
@@ -48,6 +48,7 @@ from .compression import (
 )
 from .executable import elf, macho, xalz
 from .filesystem import (
+    apfs,
     btrfs_stream,
     cramfs,
     extfs,
@@ -74,6 +75,7 @@ __all__ = [
 ]
 
 BUILTIN_HANDLERS: Handlers = (
+    apfs.APFSHandler,
     cramfs.CramFSHandler,
     deafbead.DeafBeadHandler,
     extfs.EXTHandler,

--- a/python/unblob/handlers/filesystem/apfs.py
+++ b/python/unblob/handlers/filesystem/apfs.py
@@ -1,0 +1,101 @@
+import io
+
+from unblob.extractors import Command
+from unblob.file_utils import InvalidInputFormat
+from unblob.models import (
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
+
+_MIN_BLOCK_SIZE = 512
+_MAX_BLOCK_SIZE = 1024 * 1024  # 1 MB sanity cap
+
+
+def _fletcher64_valid(block: bytes) -> bool:
+    mod = 0xFFFFFFFF
+    sum1 = sum2 = 0
+    for offset in range(8, len(block), 4):
+        sum1 = (sum1 + int.from_bytes(block[offset : offset + 4], "little")) % mod
+        sum2 = (sum2 + sum1) % mod
+    check1 = mod - ((sum1 + sum2) % mod)
+    check2 = mod - ((sum1 + check1) % mod)
+    expected = check1 | (check2 << 32)
+    return expected == int.from_bytes(block[0:8], "little")
+
+
+class APFSHandler(StructHandler):
+    NAME = "apfs"
+
+    PATTERNS = [
+        # Match the superblock's object header, not just the "NXSB" magic, so we don't
+        # fire on every occurrence of that string:
+        #   01 00 00 80    o_type = 0x80000001 (NX_SUPERBLOCK | PHYSICAL flag), little-endian
+        #   ?? ?? ?? ??    o_subtype
+        #   4E 58 53 42    nx_magic "NXSB"
+        HexString("01 00 00 80 ?? ?? ?? ?? 4E 58 53 42"),
+    ]
+
+    # The match starts at o_type, 24 bytes into the superblock; shift start back to block 0.
+    PATTERN_MATCH_OFFSET = -24
+
+    # APFS container superblock layout (all fields little-endian):
+    #   offset  0: obj_phys_t (32 bytes) — Fletcher-64 checksum + oid + xid + type + subtype
+    #   offset 32: nx_magic    uint32  "NXSB" (0x4253584e)
+    #   offset 36: nx_block_size  uint32
+    #   offset 40: nx_block_count uint64
+    C_DEFINITIONS = r"""
+        typedef struct apfs_nx_superblock {
+            char    o_cksum[8];     // Fletcher-64 checksum
+            uint64  o_oid;          // object identifier
+            uint64  o_xid;          // transaction identifier
+            uint32  o_type;         // object type
+            uint32  o_subtype;      // object subtype
+            char    nx_magic[4];    // "NXSB"
+            uint32  nx_block_size;  // block size in bytes
+            uint64  nx_block_count; // number of blocks in the container
+        } apfs_nx_superblock_t;
+    """
+    HEADER_STRUCT = "apfs_nx_superblock_t"
+
+    EXTRACTOR = Command("7z", "x", "-y", "{inpath}", "-o{outdir}")
+
+    DOC = HandlerDoc(
+        name="APFS",
+        description="Apple File System (APFS) is Apple's proprietary filesystem introduced in macOS High Sierra and iOS 10.3, replacing HFS+. It features copy-on-write semantics, space sharing between volumes, native encryption, snapshots, and sparse files.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor="Apple",
+        references=[
+            Reference(
+                title="Apple File System Reference",
+                url="https://developer.apple.com/support/downloads/Apple-File-System-Reference.pdf",
+            ),
+        ],
+        limitations=[],
+    )
+
+    def is_valid_header(self, header) -> bool:
+        # o_type is already guaranteed by PATTERNS; only the container geometry needs checking.
+        return (
+            _MIN_BLOCK_SIZE <= header.nx_block_size <= _MAX_BLOCK_SIZE
+            and header.nx_block_count > 0
+        )
+
+    def calculate_chunk(self, file: File, start_offset: int) -> ValidChunk | None:
+        header = self.parse_header(file)
+
+        if not self.is_valid_header(header):
+            raise InvalidInputFormat("Invalid APFS container superblock")
+
+        file.seek(start_offset, io.SEEK_SET)
+        if not _fletcher64_valid(file.read(header.nx_block_size)):
+            raise InvalidInputFormat("APFS superblock Fletcher-64 checksum mismatch")
+
+        return ValidChunk(
+            start_offset=start_offset,
+            end_offset=start_offset + header.nx_block_size * header.nx_block_count,
+        )

--- a/tests/integration/filesystem/apfs/__input__/apfs.img
+++ b/tests/integration/filesystem/apfs/__input__/apfs.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7930b3dcb6a198cea696b7bd44f1ceea2491e17f0d686af759242b20d59d9d01
+size 8388608

--- a/tests/integration/filesystem/apfs/__input__/apfs_padding.img
+++ b/tests/integration/filesystem/apfs/__input__/apfs_padding.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cdc3b9050fb182a5ba445763659c051fb6428bab94095cafafa3d71b2d1a5f5
+size 8389120

--- a/tests/integration/filesystem/apfs/__output__/apfs.img_extract/apple.txt
+++ b/tests/integration/filesystem/apfs/__output__/apfs.img_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/apfs/__output__/apfs.img_extract/banana.txt
+++ b/tests/integration/filesystem/apfs/__output__/apfs.img_extract/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/apfs/__output__/apfs.img_extract/dir/cherry.txt
+++ b/tests/integration/filesystem/apfs/__output__/apfs.img_extract/dir/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/filesystem/apfs/__output__/apfs_padding.img_extract/0-512.padding
+++ b/tests/integration/filesystem/apfs/__output__/apfs_padding.img_extract/0-512.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:076a27c79e5ace2a3d47f9dd2e83e4ff6ea8872b3c2218f66c92b89b55f36560
+size 512

--- a/tests/integration/filesystem/apfs/__output__/apfs_padding.img_extract/512-8389120.apfs
+++ b/tests/integration/filesystem/apfs/__output__/apfs_padding.img_extract/512-8389120.apfs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7930b3dcb6a198cea696b7bd44f1ceea2491e17f0d686af759242b20d59d9d01
+size 8388608

--- a/tests/integration/filesystem/apfs/__output__/apfs_padding.img_extract/512-8389120.apfs_extract/apple.txt
+++ b/tests/integration/filesystem/apfs/__output__/apfs_padding.img_extract/512-8389120.apfs_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/filesystem/apfs/__output__/apfs_padding.img_extract/512-8389120.apfs_extract/banana.txt
+++ b/tests/integration/filesystem/apfs/__output__/apfs_padding.img_extract/512-8389120.apfs_extract/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7

--- a/tests/integration/filesystem/apfs/__output__/apfs_padding.img_extract/512-8389120.apfs_extract/dir/cherry.txt
+++ b/tests/integration/filesystem/apfs/__output__/apfs_padding.img_extract/512-8389120.apfs_extract/dir/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7


### PR DESCRIPTION
Adds a handler for Apple File System (APFS) container images. Parses the NX superblock to determine container geometry (block size and block count) and delegates extraction to 7zz.