### PR TITLE
feat(handler): add support for Moxa FRM archives

### DIFF
--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -48,6 +48,7 @@
     | [`MINIX FS (V1)`](#minix-fs-v1) | FILESYSTEM | :octicons-check-16: |
     | [`MINIX FS (V2)`](#minix-fs-v2) | FILESYSTEM | :octicons-check-16: |
     | [`MINIX FS (V3)`](#minix-fs-v3) | FILESYSTEM | :octicons-check-16: |
+    | [`MOXA FRM`](#moxa-frm) | ARCHIVE | :octicons-check-16: |
     | [`MSI`](#msi) | ARCHIVE | :octicons-alert-fill-12: |
     | [`MULTI-SEVENZIP`](#multi-sevenzip) | ARCHIVE | :octicons-check-16: |
     | [`NETGEAR CHK`](#netgear-chk) | ARCHIVE | :octicons-check-16: |
@@ -871,6 +872,20 @@
         - [Official website](https://www.minix3.org/){ target="_blank" }
         - [Linux headers (minix_fs.h)](https://github.com/torvalds/linux/blob/master/include/uapi/linux/minix_fs.h){ target="_blank" }
         - [Official tool for creating MINIX filesystems](https://github.com/Stichting-MINIX-Research-Foundation/minix/tree/master/minix/usr.sbin/mkfs.mfs){ target="_blank" }
+## Moxa FRM
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        Firmware container format used in Moxa firmware (e.g. NPort, MGate and MiiNePort devices).
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Moxa
+
+    === "References"
 ## MSI
 
 !!! warning "Partially supported"

--- a/python/unblob/handlers/__init__.py
+++ b/python/unblob/handlers/__init__.py
@@ -22,6 +22,7 @@ from .archive.dlink import alpha_encimg, deafbead, encrpted_img, fpkg, shrs
 from .archive.engeniustech import engenius
 from .archive.hp import bdl, ipkg
 from .archive.instar import bneg, instar_hd
+from .archive.moxa import frm
 from .archive.netgear import chk, trx
 from .archive.qnap import qnap_nas, qnap_networking
 from .archive.xiaomi import hdr
@@ -83,6 +84,7 @@ BUILTIN_HANDLERS: Handlers = (
     ubi.UBIHandler,
     ubi.UBIFSHandler,
     yaffs.YAFFSHandler,
+    frm.MoxaFRMHandler,
     chk.NetgearCHKHandler,
     trx.NetgearTRXv1Handler,
     trx.NetgearTRXv2Handler,

--- a/python/unblob/handlers/archive/moxa/frm.py
+++ b/python/unblob/handlers/archive/moxa/frm.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import gzip
+import io
+from enum import IntEnum
+from pathlib import Path
+
+from unblob.file_utils import Endian, File, FileSystem, InvalidInputFormat, StructParser
+from unblob.models import (
+    Extractor,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    StructHandler,
+    ValidChunk,
+)
+
+C_DEFINITIONS = r"""
+    typedef struct frm_container_header {
+        char    magic[4];       /* *FRM */
+        uint32  unknown1;       /* version maybe, only 00 00 00 01 observed */
+        uint32  total_length;   /* the size of the whole container (should equal the sum of the section sizes + header_length) */
+        uint16  header_length;  /* only 60 00 observed -> size 0x60 = 96 */
+        uint16  section_count;  /* only 02 00 observed -> 2 section entries (webserver FS and FW binary) */
+        uint8   unknown2[48];   /* optional unknown entries; empty in some samples */
+    } frm_container_header_t;
+
+    typedef struct frm_section_entry {
+        uint32  type;   /* probably type; values 1 (FW binary) and 2 (webserver FS) observed */
+        uint32  offset;
+        uint32  length;
+        uint32  unknown;
+    } frm_section_entry_t;
+
+    typedef struct frm_fs_header {
+        char    device_name[32];
+        uint8   unknown1[4];        /* version maybe? */
+        uint32  timestamp;          /* creation time (UNIX timestamp) */
+        uint32  unknown2;
+        uint32  unknown3;           /* maybe checksum? */
+        uint32  file_table_offset;  /* offset of the file table; only 0x100 observed -> usually starts at 0x160 */
+        uint32  file_table_length;  /* size of the file table (= file_header_length * file_count) */
+        uint16  file_header_length; /* size of each entry; only 0x40 (64) observed */
+        uint16  file_count;         /* the number of table entries (files) */
+        uint32  data_length;        /* the length of the file content data */
+        uint16  unknown4;
+        uint16  file_count2;        /* for some devices (e.g. Nport 5600) this field contains the file count and file_count is 0 */
+        uint32  file_table_length2;
+        uint32  unknown5;
+    } frm_fs_header_t;
+
+    typedef struct frm_file_header {
+        char    name[48];
+        uint8   unknown[8];    /* could be the creation time */
+        uint32  file_length;
+        uint32  data_offset;
+    } frm_file_header_t;
+"""
+
+MAGIC = b"*FRM"
+GZIP_MAGIC = bytes.fromhex("1f 8b")
+
+
+class SectionTypes(IntEnum):
+    FW_BINARY = 1
+    FILESYSTEM = 2
+
+
+class MoxaFRMExtractor(Extractor):
+    def __init__(self):
+        self._struct_parser = StructParser(C_DEFINITIONS)
+
+    def extract(self, inpath: Path, outdir: Path):
+        fs = FileSystem(outdir)
+        with File.from_path(inpath) as file:
+            header = self._struct_parser.parse(
+                "frm_container_header_t", file, Endian.LITTLE
+            )
+            sections = self._parse_section_table(file, header.section_count)
+            for section in sections:
+                self._extract_section(section, file, fs)
+
+    def _parse_section_table(self, file: File, section_count: int):
+        return [
+            self._struct_parser.parse("frm_section_entry_t", file, Endian.LITTLE)
+            for _ in range(section_count)
+        ]
+
+    def _extract_section(self, section, file: File, fs: FileSystem):
+        match section.type:
+            case SectionTypes.FW_BINARY:
+                fs.carve(Path("firmware.bin"), file, section.offset, section.length)
+            case SectionTypes.FILESYSTEM:
+                self._extract_fs_section(file, fs, section.offset)
+            case _:
+                raise InvalidInputFormat(f"Unknown section type: {section.type}")
+
+    def _extract_fs_section(self, file: File, fs: FileSystem, section_offset: int):
+        file.seek(section_offset, io.SEEK_SET)
+        fs_header = self._struct_parser.parse("frm_fs_header_t", file, Endian.LITTLE)
+
+        file_table_offset = section_offset + fs_header.file_table_offset
+        for index in range(fs_header.file_count or fs_header.file_count2):
+            entry_offset = file_table_offset + index * fs_header.file_header_length
+            file.seek(entry_offset, io.SEEK_SET)
+            entry = self._struct_parser.parse("frm_file_header_t", file, Endian.LITTLE)
+
+            name = bytes(entry.name).rstrip(b"\x00")
+            if not name:
+                continue
+
+            file.seek(section_offset + entry.data_offset, io.SEEK_SET)
+            raw = file.read(entry.file_length)
+            self._write_file(fs, Path(name.decode("ascii", errors="replace")), raw)
+
+    @staticmethod
+    def _write_file(fs: FileSystem, file_path: Path, file_contents: bytes):
+        # some (but usually not all) files are GZIP compressed
+        if file_contents[:2] == GZIP_MAGIC:
+            file_contents = gzip.decompress(file_contents)
+        fs.write_bytes(file_path, file_contents)
+
+
+class MoxaFRMHandler(StructHandler):
+    NAME = "moxa_frm"
+
+    PATTERNS = [HexString("2A 46 52 4D 00 00 00 01 [4] 60 00 02 00")]
+
+    DOC = HandlerDoc(
+        name="Moxa FRM",
+        description=(
+            "Firmware container format used in Moxa firmware (e.g. NPort, MGate and MiiNePort devices)."
+        ),
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Moxa",
+        references=[],
+        limitations=[],
+    )
+
+    C_DEFINITIONS = C_DEFINITIONS
+    HEADER_STRUCT = "frm_container_header_t"
+    EXTRACTOR = MoxaFRMExtractor()
+
+    def calculate_chunk(self, file: File, start_offset: int) -> ValidChunk | None:
+        header = self.parse_header(file)
+        return ValidChunk(
+            start_offset=start_offset, end_offset=start_offset + header.total_length
+        )

--- a/tests/handlers/archive/test_frm.py
+++ b/tests/handlers/archive/test_frm.py
@@ -1,0 +1,28 @@
+from unblob.file_utils import File
+from unblob.handlers.archive.moxa.frm import MoxaFRMHandler
+from unblob.testing import unhex
+
+FILE_CONTENTS = unhex(
+    """\
+00000000: 2a46 524d 0000 0001 cc92 0e00 6000 0200  *FRM........`...
+00000010: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00000020: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00000030: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00000040: 0200 0000 6000 0000 d08c 0300 0000 0000  ....`...........
+00000050: 0100 0000 308d 0300 9c05 0b00 0000 0000  ....0...........
+00000060: 5265 6461 6374 6564 0000 0000 0000 0000  Redacted........
+00000070: 0000 0000 0000 0000 0000 0000 0000 0000  ................
+00000080: 0000 0103 5d74 4668 101d 0200 2e79 1f01  ....]tFh.....y..
+00000090: 0001 0000 000f 0000 4000 3c00 d07c 0300  ........@.<..|..
+"""
+)
+handler = MoxaFRMHandler()
+
+
+def test_chunk_calculation():
+    file = File.from_bytes(FILE_CONTENTS)
+    chunk = handler.calculate_chunk(file, 0)
+
+    assert chunk is not None
+    assert chunk.start_offset == 0
+    assert chunk.end_offset == 0xE92CC

--- a/tests/integration/archive/moxa/frm/moxa_frm/__input__/test.frm
+++ b/tests/integration/archive/moxa/frm/moxa_frm/__input__/test.frm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91d68c12cb810a8b22c957ad7d9e57b0844eec701638acd0a6b450072d5f4e03
+size 631

--- a/tests/integration/archive/moxa/frm/moxa_frm/__output__/test.frm_extract/apple.txt
+++ b/tests/integration/archive/moxa/frm/moxa_frm/__output__/test.frm_extract/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/archive/moxa/frm/moxa_frm/__output__/test.frm_extract/cherry.txt
+++ b/tests/integration/archive/moxa/frm/moxa_frm/__output__/test.frm_extract/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7

--- a/tests/integration/archive/moxa/frm/moxa_frm/__output__/test.frm_extract/firmware.bin
+++ b/tests/integration/archive/moxa/frm/moxa_frm/__output__/test.frm_extract/firmware.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4d414f214364807ba28e290410a6ad85e0b066adaf88f4396e937242de5033f
+size 7

--- a/tests/integration/archive/moxa/frm/moxa_frm/__output__/test.frm_extract/fruit/banana.txt
+++ b/tests/integration/archive/moxa/frm/moxa_frm/__output__/test.frm_extract/fruit/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a81483d96b0bc15ad19af7f5a662e14b275729fbc05579b18513e7f550016b1
+size 7


### PR DESCRIPTION
Adds support for Moxa FRM archives.
This format is used in Moxa firmware of NPort, MGate and MiiNePort devices (e.g. NPort IA5000).
These archives seem to contain files for a web server (optionally GZIP compressed).

Samples can be found here: https://www.moxa.com/en/support/product-support/software-and-documentation