### PR TITLE
feat(handler) add support for RPM package

### DIFF
--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -62,6 +62,7 @@
     | [`QNX DEFLATE`](#qnx-deflate) | COMPRESSION | :octicons-check-16: |
     | [`RAR`](#rar) | ARCHIVE | :octicons-alert-fill-12: |
     | [`ROMFS`](#romfs) | FILESYSTEM | :octicons-check-16: |
+    | [`RPM`](#rpm) | ARCHIVE | :octicons-check-16: |
     | [`SOLARIS_UFS1`](#solaris_ufs1) | FILESYSTEM | :octicons-check-16: |
     | [`SQUASHFS (V1)`](#squashfs-v1) | FILESYSTEM | :octicons-check-16: |
     | [`SQUASHFS (V2)`](#squashfs-v2) | FILESYSTEM | :octicons-check-16: |
@@ -1103,6 +1104,23 @@
 
         - [RomFS Documentation](https://www.kernel.org/doc/html/latest/filesystems/romfs.html){ target="_blank" }
         - [RomFS Wikipedia](https://en.wikipedia.org/wiki/Romfs){ target="_blank" }
+## RPM
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        RPM (Red Hat Package Manager) is a package archive format used by Red Hat-based Linux distributions. An RPM file contains metadata (signature, header) and a compressed cpio archive as payload.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Red Hat
+
+    === "References"
+
+        - [RPM File Format](https://rpm-software-management.github.io/rpm/manual/format.html){ target="_blank" }
+        - [RPM Package Manager](https://en.wikipedia.org/wiki/RPM_Package_Manager){ target="_blank" }
 ## solaris_ufs1
 
 !!! success "Fully supported"

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -66,6 +66,7 @@
     | [`QNX DEFLATE`](#qnx-deflate) | COMPRESSION | :octicons-check-16: |
     | [`RAR`](#rar) | ARCHIVE | :octicons-alert-fill-12: |
     | [`ROMFS`](#romfs) | FILESYSTEM | :octicons-check-16: |
+    | [`RPM`](#rpm) | ARCHIVE | :octicons-check-16: |
     | [`SOLARIS_UFS1`](#solaris_ufs1) | FILESYSTEM | :octicons-check-16: |
     | [`SQUASHFS (V1)`](#squashfs-v1) | FILESYSTEM | :octicons-check-16: |
     | [`SQUASHFS (V2)`](#squashfs-v2) | FILESYSTEM | :octicons-check-16: |
@@ -1180,6 +1181,23 @@
 
         - [RomFS Documentation](https://www.kernel.org/doc/html/latest/filesystems/romfs.html){ target="_blank" }
         - [RomFS Wikipedia](https://en.wikipedia.org/wiki/Romfs){ target="_blank" }
+## RPM
+
+!!! success "Fully supported"
+
+    === "Description"
+
+        RPM (Red Hat Package Manager) is a package archive format used by Red Hat-based Linux distributions. An RPM file contains metadata (signature, header) and a compressed cpio archive as payload.
+
+        ---
+
+        - **Handler type:** Archive
+        - **Vendor:** Red Hat
+
+    === "References"
+
+        - [RPM File Format](https://rpm.org/docs/4.20.x/manual/format_v4.html){ target="_blank" }
+        - [RPM Package Manager](https://en.wikipedia.org/wiki/RPM_Package_Manager){ target="_blank" }
 ## solaris_ufs1
 
 !!! success "Fully supported"

--- a/python/unblob/handlers/__init__.py
+++ b/python/unblob/handlers/__init__.py
@@ -10,6 +10,7 @@ from .archive import (
     par2,
     partclone,
     rar,
+    rpm,
     sevenzip,
     stuffit,
     tar,
@@ -155,6 +156,7 @@ BUILTIN_HANDLERS: Handlers = (
     ufs.SolarisHandler,
     btrfs_stream.BTRFSStreamHandler,
     sbfh.SBFHHandler,
+    rpm.RPMHandler,
 )
 
 BUILTIN_DIR_HANDLERS: DirectoryHandlers = (

--- a/python/unblob/handlers/__init__.py
+++ b/python/unblob/handlers/__init__.py
@@ -11,6 +11,7 @@ from .archive import (
     par2,
     partclone,
     rar,
+    rpm,
     sevenzip,
     stuffit,
     tar,
@@ -162,6 +163,7 @@ BUILTIN_HANDLERS: Handlers = (
     btrfs_stream.BTRFSStreamHandler,
     sbfh.SBFHHandler,
     airoha.AirohaHandler,
+    rpm.RPMHandler,
 )
 
 BUILTIN_DIR_HANDLERS: DirectoryHandlers = (

--- a/python/unblob/handlers/archive/cpio.py
+++ b/python/unblob/handlers/archive/cpio.py
@@ -27,12 +27,14 @@ from ...models import (
     Reference,
     ValidChunk,
 )
+from ...report import ExtractionProblem
 
 logger = get_logger()
 
 CPIO_TRAILER_NAME = "TRAILER!!!"
 MAX_LINUX_PATH_LENGTH = 0x1000
 
+C_TRAILER = 0o00000
 C_ISBLK = 0o60000
 C_ISCHR = 0o20000
 C_ISDIR = 0o40000
@@ -43,6 +45,7 @@ C_ISCTG = 0o110000
 C_ISREG = 0o100000
 
 C_FILE_TYPES = (
+    C_TRAILER,
     C_ISBLK,
     C_ISCHR,
     C_ISDIR,
@@ -114,130 +117,146 @@ C_DEFINITIONS = r"""
 
 @attrs.define
 class CPIOEntry:
-    start_offset: int
+    header: object
     size: int
-    dev: int
     mode: int
     rdev: int
     path: Path
+    link: str
 
 
 class CPIOParserBase:
     _PAD_ALIGN: int
     _FILE_PAD_ALIGN: int = 512
+    _STRUCT_PARSER = StructParser(C_DEFINITIONS)
     HEADER_STRUCT: str
+    entries: list[CPIOEntry]
 
-    def __init__(self, file: File, start_offset: int):
+    def __init__(self, file: File, start_offset: int, entries: list | None = None):
         self.file = file
         self.start_offset = start_offset
         self.end_offset = -1
-        self.entries = []
-        self.struct_parser = StructParser(C_DEFINITIONS)
+        self.entries = entries if entries is not None else []
 
-    def parse(self):  # noqa: C901
-        current_offset = self.start_offset
+    def read_entry_header(self) -> CPIOEntry | None:
+        """Parse one entry header + name, return None at EOF."""
+        try:
+            header = self._STRUCT_PARSER.parse(
+                self.HEADER_STRUCT, self.file, Endian.LITTLE
+            )
+        except EOFError:
+            return None
+
+        c_filesize = self._calculate_file_size(header)
+        c_namesize = self._calculate_name_size(header)
+
+        # heuristics 1: check the filename
+        if c_namesize > MAX_LINUX_PATH_LENGTH:
+            raise InvalidInputFormat("CPIO entry filename is too long.")
+        if c_namesize == 0:
+            raise InvalidInputFormat("CPIO entry filename empty.")
+
+        padded_header_size = self._pad_header(header, c_namesize)
+        name_padding = padded_header_size - len(header) - c_namesize
+
+        tmp_filename = self.file.read(c_namesize)
+
+        # heuristics 2: check that filename is null-byte terminated
+        if not tmp_filename.endswith(b"\x00"):
+            raise InvalidInputFormat("CPIO entry filename is not null-byte terminated")
+
+        try:
+            filename = snull(tmp_filename).decode("utf-8")
+        except UnicodeDecodeError as e:
+            raise InvalidInputFormat from e
+
+        if name_padding:
+            self.file.read(name_padding)
+
+        c_mode = self._calculate_mode(header)
+        file_type = c_mode & 0o770000
+        sticky_bit = c_mode & 0o7000
+
+        # heuristics 3: check mode field
+        if file_type not in C_FILE_TYPES or sticky_bit not in C_STICKY_BITS:
+            raise InvalidInputFormat("CPIO entry mode is invalid.")
+
+        return CPIOEntry(
+            header=header,
+            path=Path(filename),
+            size=c_filesize,
+            mode=c_mode,
+            rdev=0,
+            link="",
+        )
+
+    def parse(self, fs: FileSystem | None = None):
         while True:
-            self.file.seek(current_offset, io.SEEK_SET)
-            try:
-                header = self.struct_parser.parse(
-                    self.HEADER_STRUCT, self.file, Endian.LITTLE
-                )
-            except EOFError:
+            entry = self.read_entry_header()
+            if entry is None:
                 break
 
-            c_filesize = self._calculate_file_size(header)
-            c_namesize = self._calculate_name_size(header)
+            content_padding = self._pad_content(entry.size) - entry.size
 
-            # heuristics 1: check the filename
-            if c_namesize > MAX_LINUX_PATH_LENGTH:
-                raise InvalidInputFormat("CPIO entry filename is too long.")
-
-            if c_namesize == 0:
-                raise InvalidInputFormat("CPIO entry filename empty.")
-
-            padded_header_size = self._pad_header(header, c_namesize)
-            current_offset += padded_header_size
-
-            tmp_filename = self.file.read(c_namesize)
-
-            # heuristics 2: check that filename is null-byte terminated
-            if not tmp_filename.endswith(b"\x00"):
-                raise InvalidInputFormat(
-                    "CPIO entry filename is not null-byte terminated"
-                )
-
-            try:
-                filename = snull(tmp_filename).decode("utf-8")
-            except UnicodeDecodeError as e:
-                raise InvalidInputFormat from e
-
-            if filename == CPIO_TRAILER_NAME:
-                current_offset += self._pad_content(c_filesize)
+            if entry.path.name == CPIO_TRAILER_NAME:
+                self.file.seek(content_padding, io.SEEK_CUR)
                 break
 
-            c_mode = self._calculate_mode(header)
-
-            file_type = c_mode & 0o770000
-            sticky_bit = c_mode & 0o7000
-
-            # heuristics 3: check mode field
-            is_valid = file_type in C_FILE_TYPES and sticky_bit in C_STICKY_BITS
-            if not is_valid:
-                raise InvalidInputFormat("CPIO entry mode is invalid.")
-
-            if self.valid_checksum(header, current_offset):
-                self.entries.append(
-                    CPIOEntry(
-                        start_offset=current_offset,
-                        size=c_filesize,
-                        dev=self._calculate_dev(header),
-                        mode=c_mode,
-                        rdev=self._calculate_rdev(header),
-                        path=Path(filename),
-                    )
-                )
-            else:
-                logger.warning("Invalid CRC for CPIO entry, skipping.", header=header)
-
-            current_offset += self._pad_content(c_filesize)
-
-        self.end_offset = self._pad_file(current_offset)
-        if self.start_offset == self.end_offset:
-            raise InvalidInputFormat("Invalid CPIO archive.")
-
-    def dump_entries(self, fs: FileSystem):
-        for entry in self.entries:
-            # skip entries with "." as filename
-            if entry.path.name in ("", "."):
+            if entry.path.name in ("", ".", ".."):
+                self.file.seek(entry.size + content_padding, io.SEEK_CUR)
                 continue
 
-            # There are cases where CPIO archives have duplicated entries
-            # We then unlink the files to overwrite them and avoid an error.
-            if not stat.S_ISDIR(entry.mode):
-                fs.unlink(entry.path)
-
-            if stat.S_ISREG(entry.mode):
-                fs.carve(entry.path, self.file, entry.start_offset, entry.size)
-            elif stat.S_ISDIR(entry.mode):
-                fs.mkdir(
-                    entry.path, mode=entry.mode & 0o777, parents=True, exist_ok=True
-                )
-            elif stat.S_ISLNK(entry.mode):
-                link_path = Path(
-                    snull(
-                        self.file[entry.start_offset : entry.start_offset + entry.size]
-                    ).decode("utf-8")
-                )
-                fs.create_symlink(src=link_path, dst=entry.path)
-            elif (
-                stat.S_ISCHR(entry.mode)
-                or stat.S_ISBLK(entry.mode)
-                or stat.S_ISSOCK(entry.mode)
-                or stat.S_ISSOCK(entry.mode)
-            ):
-                fs.mknod(entry.path, mode=entry.mode & 0o777, device=entry.rdev)
+            if fs is not None:
+                self.extract_entry(fs, entry)
             else:
-                logger.warning("unknown file type in CPIO archive")
+                self.file.seek(entry.size, io.SEEK_CUR)
+            self.file.seek(content_padding, io.SEEK_CUR)
+        self.end_offset = self._pad_file(self.file.tell())
+
+    def extract_entry(self, fs: FileSystem, entry: CPIOEntry):
+        # There are cases where CPIO archives have duplicated entries
+        # We then unlink the files to overwrite them and avoid an error.
+        if not stat.S_ISDIR(entry.mode):
+            fs.unlink(entry.path)
+
+        if stat.S_ISREG(entry.mode):
+            fs.write_chunks(
+                entry.path, iterate_file(self.file, self.file.tell(), entry.size)
+            )
+        elif stat.S_ISLNK(entry.mode):
+            link_target = snull(self.file.read(entry.size)).decode("utf-8")
+            fs.create_symlink(src=Path(link_target), dst=entry.path)
+        elif stat.S_ISDIR(entry.mode):
+            fs.mkdir(entry.path, mode=entry.mode & 0o777, parents=True, exist_ok=True)
+            self.file.seek(entry.size, io.SEEK_CUR)
+        elif (
+            stat.S_ISCHR(entry.mode)
+            or stat.S_ISBLK(entry.mode)
+            or stat.S_ISSOCK(entry.mode)
+        ):
+            rdev = self._calculate_rdev(entry.header)
+            fs.mknod(entry.path, mode=entry.mode & 0o777, device=rdev)
+            self.file.seek(entry.size, io.SEEK_CUR)
+        else:
+            logger.warning("unknown file type in CPIO archive")
+            self.file.seek(entry.size, io.SEEK_CUR)
+
+    def record_checksum_mismatch(
+        self, fs: FileSystem, entry: CPIOEntry, calculated_checksum: int
+    ):
+        if self.valid_checksum(entry.header, calculated_checksum):
+            return
+
+        fs.record_problem(
+            ExtractionProblem(
+                problem=(
+                    f"CPIO CRC mismatch: expected {decode_int(entry.header.c_chksum, 16):08x}, "  # pyright: ignore[reportAttributeAccessIssue]
+                    f"got {calculated_checksum:08x}"
+                ),
+                resolution="Extracted anyway.",
+                path=entry.path.as_posix(),
+            )
+        )
 
     def _pad_file(self, end_offset: int) -> int:
         """CPIO archives can have a 512 bytes block padding at the end."""
@@ -274,14 +293,10 @@ class CPIOParserBase:
         raise NotImplementedError
 
     @staticmethod
-    def _calculate_dev(header) -> int:
-        raise NotImplementedError
-
-    @staticmethod
     def _calculate_rdev(header) -> int:
         raise NotImplementedError
 
-    def valid_checksum(self, header, start_offset: int) -> bool:  # noqa: ARG002
+    def valid_checksum(self, header, calculated_checksum: int) -> bool:  # noqa: ARG002
         return True
 
 
@@ -301,10 +316,6 @@ class BinaryCPIOParser(CPIOParserBase):
     @staticmethod
     def _calculate_mode(header) -> int:
         return header.c_mode
-
-    @staticmethod
-    def _calculate_dev(header) -> int:
-        return header.c_dev
 
     @staticmethod
     def _calculate_rdev(header) -> int:
@@ -329,10 +340,6 @@ class PortableOldASCIIParser(CPIOParserBase):
         return decode_int(header.c_mode, 8)
 
     @staticmethod
-    def _calculate_dev(header) -> int:
-        return decode_int(header.c_dev, 8)
-
-    @staticmethod
     def _calculate_rdev(header) -> int:
         return decode_int(header.c_rdev, 8)
 
@@ -354,12 +361,6 @@ class PortableASCIIParser(CPIOParserBase):
         return decode_int(header.c_mode, 16)
 
     @staticmethod
-    def _calculate_dev(header) -> int:
-        return os.makedev(
-            decode_int(header.c_dev_maj, 16), decode_int(header.c_dev_min, 16)
-        )
-
-    @staticmethod
     def _calculate_rdev(header) -> int:
         return os.makedev(
             decode_int(header.c_rdev_maj, 16), decode_int(header.c_rdev_min, 16)
@@ -367,13 +368,40 @@ class PortableASCIIParser(CPIOParserBase):
 
 
 class PortableASCIIWithCRCParser(PortableASCIIParser):
-    def valid_checksum(self, header, start_offset: int) -> bool:
-        header_checksum = decode_int(header.c_chksum, 16)
-        calculated_checksum = 0
-        file_size = self._calculate_file_size(header)
+    def extract_entry(self, fs: FileSystem, entry: CPIOEntry):
+        if not stat.S_ISDIR(entry.mode):
+            fs.unlink(entry.path)
 
-        for chunk in iterate_file(self.file, start_offset, file_size):
-            calculated_checksum += sum(bytearray(chunk))
+        calculated_checksum = 0
+
+        if stat.S_ISREG(entry.mode):
+            with fs.open(entry.path, "wb+") as output:
+                for chunk in iterate_file(self.file, self.file.tell(), entry.size):
+                    calculated_checksum += sum(chunk)
+                    output.write(chunk)
+        elif stat.S_ISLNK(entry.mode):
+            content = bytearray()
+            for chunk in iterate_file(self.file, self.file.tell(), entry.size):
+                calculated_checksum += sum(chunk)
+                content.extend(chunk)
+            link_target = snull(bytes(content)).decode("utf-8")
+            fs.create_symlink(src=Path(link_target), dst=entry.path)
+        elif stat.S_ISDIR(entry.mode):
+            fs.mkdir(entry.path, mode=entry.mode & 0o777, parents=True, exist_ok=True)
+        elif (
+            stat.S_ISCHR(entry.mode)
+            or stat.S_ISBLK(entry.mode)
+            or stat.S_ISSOCK(entry.mode)
+        ):
+            rdev = self._calculate_rdev(entry.header)
+            fs.mknod(entry.path, mode=entry.mode & 0o777, device=rdev)
+        else:
+            logger.warning("unknown file type in CPIO archive")
+
+        self.record_checksum_mismatch(fs, entry, calculated_checksum & 0xFF_FF_FF_FF)
+
+    def valid_checksum(self, header, calculated_checksum: int) -> bool:
+        header_checksum = decode_int(header.c_chksum, 16)
         return header_checksum == calculated_checksum & 0xFF_FF_FF_FF
 
 
@@ -385,8 +413,8 @@ class _CPIOExtractorBase(Extractor):
 
         with File.from_path(inpath) as file:
             parser = self.PARSER(file, 0)
-            parser.parse()
-            parser.dump_entries(fs)
+            parser.parse(fs)
+        return ExtractResult(reports=fs.problems)
 
 
 class BinaryCPIOExtractor(_CPIOExtractorBase):

--- a/python/unblob/handlers/archive/cpio.py
+++ b/python/unblob/handlers/archive/cpio.py
@@ -405,6 +405,47 @@ class PortableASCIIWithCRCParser(PortableASCIIParser):
         return header_checksum == calculated_checksum & 0xFF_FF_FF_FF
 
 
+class StrippedCPIOParser(CPIOParserBase):
+    """Stripped CPIO variant (magic 07070X) used in RPM 4.12+.
+
+    File metadata is supplied at construction from the RPM main header;
+    dump_entries walks the stream forward to extract each entry.
+    """
+
+    _PAD_ALIGN = 4
+    _MAGIC = b"07070X"
+    _HEADER_SIZE = 14  # 6 magic + 8 file index
+
+    def parse(self, fs: FileSystem | None = None):
+        header_padding = self._pad_content(self._HEADER_SIZE) - self._HEADER_SIZE
+        while True:
+            magic = self.file.read(6)
+            # Stripped archives terminate with a standard newc TRAILER entry.
+            if magic in (b"070701", b"070702"):
+                break
+            if magic != self._MAGIC:
+                raise InvalidInputFormat(
+                    f"Bad stripped CPIO magic: {magic} should be 07070X"
+                )
+
+            file_index = int(self.file.read(8), 16)
+            self.file.seek(header_padding, io.SEEK_CUR)
+
+            entry = self.entries[file_index]
+            content_padding = self._pad_content(entry.size) - entry.size
+
+            if entry.path.name in ("", ".", ".."):
+                self.file.seek(entry.size + content_padding, io.SEEK_CUR)
+                continue
+
+            if fs is not None:
+                self.extract_entry(fs, entry)
+            else:
+                self.file.seek(entry.size, io.SEEK_CUR)
+            self.file.seek(content_padding, io.SEEK_CUR)
+        self.end_offset = self._pad_file(self.file.tell())
+
+
 class _CPIOExtractorBase(Extractor):
     PARSER: type[CPIOParserBase]
 

--- a/python/unblob/handlers/archive/cpio.py
+++ b/python/unblob/handlers/archive/cpio.py
@@ -117,7 +117,7 @@ C_DEFINITIONS = r"""
 
 @attrs.define
 class CPIOEntry:
-    header: object
+    header: object | None
     size: int
     mode: int
     rdev: int
@@ -229,7 +229,8 @@ class CPIOParserBase:
                 entry.path, iterate_file(self.file, self.file.tell(), entry.size)
             )
         elif stat.S_ISLNK(entry.mode):
-            link_target = snull(self.file.read(entry.size)).decode("utf-8")
+            payload_link = snull(self.file.read(entry.size)).decode("utf-8")
+            link_target = entry.link or payload_link
             fs.create_symlink(src=Path(link_target), dst=entry.path)
         elif stat.S_ISDIR(entry.mode):
             fs.mkdir(entry.path, mode=entry.mode & 0o777, parents=True, exist_ok=True)
@@ -248,6 +249,8 @@ class CPIOParserBase:
     def verify_checksum_mismatch(
         self, fs: FileSystem, entry: CPIOEntry, calculated_checksum: int
     ):
+        if entry.header is None:
+            raise InvalidInputFormat("CPIO checksum metadata is missing")
         if self.valid_checksum(entry.header, calculated_checksum):
             return
 
@@ -414,6 +417,68 @@ class PortableASCIIWithCRCParser(PortableASCIIParser):
     def valid_checksum(self, header, calculated_checksum: int) -> bool:
         header_checksum = decode_int(header.c_chksum, 16)
         return header_checksum == calculated_checksum & 0xFF_FF_FF_FF
+
+
+class StrippedCPIOParser(CPIOParserBase):
+    """Stripped CPIO variant (magic 07070X) used in RPM 4.12+.
+
+    File metadata is supplied at construction from the RPM main header; the parser
+    walks the stream forward to extract each entry.
+    """
+
+    _PAD_ALIGN = 4
+    _MAGIC = b"07070X"
+    _HEADER_SIZE = 14  # 6 magic + 8 file index
+
+    def parse(self, fs: FileSystem | None = None):
+        header_padding = self._pad_content(self._HEADER_SIZE) - self._HEADER_SIZE
+        while True:
+            magic = self.file.read(6)
+            # Stripped archives terminate with a standard newc TRAILER entry.
+            if magic in (b"070701", b"070702"):
+                self._read_trailer()
+                break
+            if magic != self._MAGIC:
+                raise InvalidInputFormat(
+                    f"Bad stripped CPIO magic: {magic} should be 07070X"
+                )
+
+            entry = self._read_indexed_entry()
+            self.file.seek(header_padding, io.SEEK_CUR)
+            content_padding = self._pad_content(entry.size) - entry.size
+
+            if entry.path.name in ("", ".", ".."):
+                self.file.seek(entry.size + content_padding, io.SEEK_CUR)
+                continue
+
+            if fs is not None:
+                self.extract_entry(fs, entry)
+            else:
+                self.file.seek(entry.size, io.SEEK_CUR)
+            self.file.seek(content_padding, io.SEEK_CUR)
+        self.end_offset = self._pad_file(self.file.tell())
+
+    def _read_trailer(self) -> None:
+        header_rest = self.file.read(104)
+        if len(header_rest) != 104:
+            raise InvalidInputFormat("Truncated stripped CPIO trailer")
+        name_size = decode_int(header_rest[88:96], 16)
+        self._validate_entry_sizes(0, name_size)
+        trailer_name = self.file.read(name_size)
+        if trailer_name != b"TRAILER!!!\x00":
+            raise InvalidInputFormat("Invalid stripped CPIO trailer")
+        trailer_size = 110 + name_size
+        trailer_padding = round_up(trailer_size, self._PAD_ALIGN) - trailer_size
+        self.file.seek(trailer_padding, io.SEEK_CUR)
+
+    def _read_indexed_entry(self) -> CPIOEntry:
+        file_index_bytes = self.file.read(8)
+        if len(file_index_bytes) != 8:
+            raise InvalidInputFormat("Truncated stripped CPIO file index")
+        try:
+            return self.entries[int(file_index_bytes, 16)]
+        except (IndexError, ValueError) as e:
+            raise InvalidInputFormat("Invalid stripped CPIO file index") from e
 
 
 class _CPIOExtractorBase(Extractor):

--- a/python/unblob/handlers/archive/cpio.py
+++ b/python/unblob/handlers/archive/cpio.py
@@ -27,12 +27,14 @@ from ...models import (
     Reference,
     ValidChunk,
 )
+from ...report import ExtractionProblem
 
 logger = get_logger()
 
 CPIO_TRAILER_NAME = "TRAILER!!!"
 MAX_LINUX_PATH_LENGTH = 0x1000
 
+C_TRAILER = 0o00000
 C_ISBLK = 0o60000
 C_ISCHR = 0o20000
 C_ISDIR = 0o40000
@@ -43,6 +45,7 @@ C_ISCTG = 0o110000
 C_ISREG = 0o100000
 
 C_FILE_TYPES = (
+    C_TRAILER,
     C_ISBLK,
     C_ISCHR,
     C_ISDIR,
@@ -114,133 +117,150 @@ C_DEFINITIONS = r"""
 
 @attrs.define
 class CPIOEntry:
-    start_offset: int
+    header: object
     size: int
-    dev: int
     mode: int
     rdev: int
     path: Path
+    link: str
 
 
 class CPIOParserBase:
     _PAD_ALIGN: int
     _FILE_PAD_ALIGN: int = 512
+    _STRUCT_PARSER = StructParser(C_DEFINITIONS)
     HEADER_STRUCT: str
+    entries: list[CPIOEntry]
 
-    def __init__(self, file: File, start_offset: int):
+    def __init__(
+        self, file: File, start_offset: int, entries: list[CPIOEntry] | None = None
+    ):
         self.file = file
         self.start_offset = start_offset
         self.end_offset = -1
-        self.entries = []
-        self.struct_parser = StructParser(C_DEFINITIONS)
+        self.entries = entries if entries is not None else []
 
-    def parse(self):  # noqa: C901
-        current_offset = self.start_offset
+    def read_entry_header(self) -> CPIOEntry | None:
+        """Parse one entry header + name, return None at EOF."""
+        try:
+            header = self._STRUCT_PARSER.parse(
+                self.HEADER_STRUCT, self.file, Endian.LITTLE
+            )
+        except EOFError:
+            return None
+
+        c_filesize = self._calculate_file_size(header)
+        c_namesize = self._calculate_name_size(header)
+        self._validate_entry_sizes(c_filesize, c_namesize)
+
+        padded_header_size = self._pad_header(header, c_namesize)
+        name_padding = padded_header_size - len(header) - c_namesize
+        filename = self._read_entry_filename(c_namesize)
+
+        if name_padding:
+            self.file.read(name_padding)
+
+        c_mode = self._calculate_mode(header)
+        file_type = c_mode & 0o770000
+        sticky_bit = c_mode & 0o7000
+
+        # heuristics 3: check mode field
+        if file_type not in C_FILE_TYPES or sticky_bit not in C_STICKY_BITS:
+            raise InvalidInputFormat("CPIO entry mode is invalid.")
+
+        return CPIOEntry(
+            header=header,
+            path=Path(filename),
+            size=c_filesize,
+            mode=c_mode,
+            rdev=self._calculate_rdev(header),
+            link="",
+        )
+
+    @staticmethod
+    def _validate_entry_sizes(c_filesize: int, c_namesize: int) -> None:
+        if c_namesize > MAX_LINUX_PATH_LENGTH:
+            raise InvalidInputFormat("CPIO entry filename is too long.")
+        if c_namesize <= 0:
+            raise InvalidInputFormat("CPIO entry filename size is invalid.")
+        if c_filesize < 0:
+            raise InvalidInputFormat("CPIO entry file size is invalid.")
+
+    def _read_entry_filename(self, c_namesize: int) -> str:
+        tmp_filename = self.file.read(c_namesize)
+        if len(tmp_filename) != c_namesize or not tmp_filename.endswith(b"\x00"):
+            raise InvalidInputFormat("CPIO entry filename is not null-byte terminated")
+        try:
+            return snull(tmp_filename).decode("utf-8")
+        except UnicodeDecodeError as e:
+            raise InvalidInputFormat from e
+
+    def parse(self, fs: FileSystem | None = None):
         while True:
-            self.file.seek(current_offset, io.SEEK_SET)
-            try:
-                header = self.struct_parser.parse(
-                    self.HEADER_STRUCT, self.file, Endian.LITTLE
-                )
-            except EOFError:
+            entry = self.read_entry_header()
+            if entry is None:
                 break
 
-            c_filesize = self._calculate_file_size(header)
-            c_namesize = self._calculate_name_size(header)
+            content_padding = self._pad_content(entry.size) - entry.size
 
-            # heuristics 1: check the filename
-            if c_namesize > MAX_LINUX_PATH_LENGTH:
-                raise InvalidInputFormat("CPIO entry filename is too long.")
-
-            if c_namesize <= 0:
-                raise InvalidInputFormat("CPIO entry filename size is invalid.")
-
-            if c_filesize < 0:
-                raise InvalidInputFormat("CPIO entry file size is invalid.")
-
-            padded_header_size = self._pad_header(header, c_namesize)
-            current_offset += padded_header_size
-
-            tmp_filename = self.file.read(c_namesize)
-
-            # heuristics 2: check that filename is null-byte terminated
-            if not tmp_filename.endswith(b"\x00"):
-                raise InvalidInputFormat(
-                    "CPIO entry filename is not null-byte terminated"
-                )
-
-            try:
-                filename = snull(tmp_filename).decode("utf-8")
-            except UnicodeDecodeError as e:
-                raise InvalidInputFormat from e
-
-            if filename == CPIO_TRAILER_NAME:
-                current_offset += self._pad_content(c_filesize)
+            if entry.path.name == CPIO_TRAILER_NAME:
+                self.file.seek(content_padding, io.SEEK_CUR)
                 break
 
-            c_mode = self._calculate_mode(header)
-
-            file_type = c_mode & 0o770000
-            sticky_bit = c_mode & 0o7000
-
-            # heuristics 3: check mode field
-            is_valid = file_type in C_FILE_TYPES and sticky_bit in C_STICKY_BITS
-            if not is_valid:
-                raise InvalidInputFormat("CPIO entry mode is invalid.")
-
-            if self.valid_checksum(header, current_offset):
-                self.entries.append(
-                    CPIOEntry(
-                        start_offset=current_offset,
-                        size=c_filesize,
-                        dev=self._calculate_dev(header),
-                        mode=c_mode,
-                        rdev=self._calculate_rdev(header),
-                        path=Path(filename),
-                    )
-                )
-            else:
-                logger.warning("Invalid CRC for CPIO entry, skipping.", header=header)
-
-            current_offset += self._pad_content(c_filesize)
-
-        self.end_offset = self._pad_file(current_offset)
-        if self.start_offset == self.end_offset:
-            raise InvalidInputFormat("Invalid CPIO archive.")
-
-    def dump_entries(self, fs: FileSystem):
-        for entry in self.entries:
-            # skip entries with "." as filename
-            if entry.path.name in ("", "."):
+            if entry.path.name in ("", ".", ".."):
+                self.file.seek(entry.size + content_padding, io.SEEK_CUR)
                 continue
 
-            # There are cases where CPIO archives have duplicated entries
-            # We then unlink the files to overwrite them and avoid an error.
-            if not stat.S_ISDIR(entry.mode):
-                fs.unlink(entry.path)
-
-            if stat.S_ISREG(entry.mode):
-                fs.carve(entry.path, self.file, entry.start_offset, entry.size)
-            elif stat.S_ISDIR(entry.mode):
-                fs.mkdir(
-                    entry.path, mode=entry.mode & 0o777, parents=True, exist_ok=True
-                )
-            elif stat.S_ISLNK(entry.mode):
-                link_path = Path(
-                    snull(
-                        self.file[entry.start_offset : entry.start_offset + entry.size]
-                    ).decode("utf-8")
-                )
-                fs.create_symlink(src=link_path, dst=entry.path)
-            elif (
-                stat.S_ISCHR(entry.mode)
-                or stat.S_ISBLK(entry.mode)
-                or stat.S_ISSOCK(entry.mode)
-                or stat.S_ISSOCK(entry.mode)
-            ):
-                fs.mknod(entry.path, mode=entry.mode & 0o777, device=entry.rdev)
+            if fs is not None:
+                self.extract_entry(fs, entry)
             else:
-                logger.warning("unknown file type in CPIO archive")
+                self.file.seek(entry.size, io.SEEK_CUR)
+            self.file.seek(content_padding, io.SEEK_CUR)
+        self.end_offset = self._pad_file(self.file.tell())
+
+    def extract_entry(self, fs: FileSystem, entry: CPIOEntry):
+        # There are cases where CPIO archives have duplicated entries
+        # We then unlink the files to overwrite them and avoid an error.
+        if not stat.S_ISDIR(entry.mode):
+            fs.unlink(entry.path)
+
+        if stat.S_ISREG(entry.mode):
+            fs.write_chunks(
+                entry.path, iterate_file(self.file, self.file.tell(), entry.size)
+            )
+        elif stat.S_ISLNK(entry.mode):
+            link_target = snull(self.file.read(entry.size)).decode("utf-8")
+            fs.create_symlink(src=Path(link_target), dst=entry.path)
+        elif stat.S_ISDIR(entry.mode):
+            fs.mkdir(entry.path, mode=entry.mode & 0o777, parents=True, exist_ok=True)
+            self.file.seek(entry.size, io.SEEK_CUR)
+        elif (
+            stat.S_ISCHR(entry.mode)
+            or stat.S_ISBLK(entry.mode)
+            or stat.S_ISSOCK(entry.mode)
+        ):
+            fs.mknod(entry.path, mode=entry.mode & 0o777, device=entry.rdev)
+            self.file.seek(entry.size, io.SEEK_CUR)
+        else:
+            logger.warning("unknown file type in CPIO archive")
+            self.file.seek(entry.size, io.SEEK_CUR)
+
+    def verify_checksum_mismatch(
+        self, fs: FileSystem, entry: CPIOEntry, calculated_checksum: int
+    ):
+        if self.valid_checksum(entry.header, calculated_checksum):
+            return
+
+        fs.record_problem(
+            ExtractionProblem(
+                problem=(
+                    f"CPIO CRC mismatch: expected {decode_int(entry.header.c_chksum, 16):08x}, "  # pyright: ignore[reportAttributeAccessIssue]
+                    f"got {calculated_checksum:08x}"
+                ),
+                resolution="Extracted anyway.",
+                path=entry.path.as_posix(),
+            )
+        )
 
     def _pad_file(self, end_offset: int) -> int:
         """CPIO archives can have a 512 bytes block padding at the end."""
@@ -277,14 +297,10 @@ class CPIOParserBase:
         raise NotImplementedError
 
     @staticmethod
-    def _calculate_dev(header) -> int:
-        raise NotImplementedError
-
-    @staticmethod
     def _calculate_rdev(header) -> int:
         raise NotImplementedError
 
-    def valid_checksum(self, header, start_offset: int) -> bool:  # noqa: ARG002
+    def valid_checksum(self, header, calculated_checksum: int) -> bool:  # noqa: ARG002
         return True
 
 
@@ -304,10 +320,6 @@ class BinaryCPIOParser(CPIOParserBase):
     @staticmethod
     def _calculate_mode(header) -> int:
         return header.c_mode
-
-    @staticmethod
-    def _calculate_dev(header) -> int:
-        return header.c_dev
 
     @staticmethod
     def _calculate_rdev(header) -> int:
@@ -332,10 +344,6 @@ class PortableOldASCIIParser(CPIOParserBase):
         return decode_int(header.c_mode, 8)
 
     @staticmethod
-    def _calculate_dev(header) -> int:
-        return decode_int(header.c_dev, 8)
-
-    @staticmethod
     def _calculate_rdev(header) -> int:
         return decode_int(header.c_rdev, 8)
 
@@ -357,12 +365,6 @@ class PortableASCIIParser(CPIOParserBase):
         return decode_int(header.c_mode, 16)
 
     @staticmethod
-    def _calculate_dev(header) -> int:
-        return os.makedev(
-            decode_int(header.c_dev_maj, 16), decode_int(header.c_dev_min, 16)
-        )
-
-    @staticmethod
     def _calculate_rdev(header) -> int:
         return os.makedev(
             decode_int(header.c_rdev_maj, 16), decode_int(header.c_rdev_min, 16)
@@ -370,13 +372,47 @@ class PortableASCIIParser(CPIOParserBase):
 
 
 class PortableASCIIWithCRCParser(PortableASCIIParser):
-    def valid_checksum(self, header, start_offset: int) -> bool:
-        header_checksum = decode_int(header.c_chksum, 16)
-        calculated_checksum = 0
-        file_size = self._calculate_file_size(header)
+    def extract_entry(self, fs: FileSystem, entry: CPIOEntry):
+        if not stat.S_ISDIR(entry.mode):
+            fs.unlink(entry.path)
 
-        for chunk in iterate_file(self.file, start_offset, file_size):
-            calculated_checksum += sum(bytearray(chunk))
+        calculated_checksum = 0
+
+        if stat.S_ISREG(entry.mode):
+            with fs.open(entry.path, "wb+") as output:
+                for chunk in iterate_file(self.file, self.file.tell(), entry.size):
+                    calculated_checksum += sum(chunk)
+                    output.write(chunk)
+        elif stat.S_ISLNK(entry.mode):
+            content = bytearray()
+            for chunk in iterate_file(self.file, self.file.tell(), entry.size):
+                calculated_checksum += sum(chunk)
+                content.extend(chunk)
+            link_target = snull(bytes(content)).decode("utf-8")
+            fs.create_symlink(src=Path(link_target), dst=entry.path)
+        elif stat.S_ISDIR(entry.mode):
+            fs.mkdir(entry.path, mode=entry.mode & 0o777, parents=True, exist_ok=True)
+            calculated_checksum += self._consume_checksum(entry.size)
+        elif (
+            stat.S_ISCHR(entry.mode)
+            or stat.S_ISBLK(entry.mode)
+            or stat.S_ISSOCK(entry.mode)
+        ):
+            fs.mknod(entry.path, mode=entry.mode & 0o777, device=entry.rdev)
+            calculated_checksum += self._consume_checksum(entry.size)
+        else:
+            logger.warning("unknown file type in CPIO archive")
+            calculated_checksum += self._consume_checksum(entry.size)
+
+        self.verify_checksum_mismatch(fs, entry, calculated_checksum & 0xFF_FF_FF_FF)
+
+    def _consume_checksum(self, size: int) -> int:
+        return sum(
+            sum(chunk) for chunk in iterate_file(self.file, self.file.tell(), size)
+        )
+
+    def valid_checksum(self, header, calculated_checksum: int) -> bool:
+        header_checksum = decode_int(header.c_chksum, 16)
         return header_checksum == calculated_checksum & 0xFF_FF_FF_FF
 
 
@@ -388,8 +424,8 @@ class _CPIOExtractorBase(Extractor):
 
         with File.from_path(inpath) as file:
             parser = self.PARSER(file, 0)
-            parser.parse()
-            parser.dump_entries(fs)
+            parser.parse(fs)
+        return ExtractResult(reports=fs.problems)
 
 
 class BinaryCPIOExtractor(_CPIOExtractorBase):

--- a/python/unblob/handlers/archive/rpm.py
+++ b/python/unblob/handlers/archive/rpm.py
@@ -1,0 +1,333 @@
+import bz2
+import gzip
+import io
+import lzma
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+from typing import Any
+
+import pyzstd
+from structlog import get_logger
+
+from ...file_utils import FileSystem, convert_int32, convert_int64, round_up
+from ...models import (
+    Endian,
+    Extractor,
+    ExtractResult,
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    InvalidInputFormat,
+    Reference,
+    StructHandler,
+    StructParser,
+    ValidChunk,
+)
+from .cpio import CPIOEntry, PortableASCIIParser, StrippedCPIOParser
+
+logger = get_logger()
+
+RPM_SIGNATURE_ALIGNMENT = 8
+RPMSIGTAG_SIZE = 1000  # INT32
+RPMSIGTAG_LONGSIZE = 270  # INT64
+RPMTAG_PAYLOADCOMPRESSOR = 1125
+RPMTAG_PAYLOADFLAGS = 1126
+
+RPMTAG_FILEMODES = 1030
+RPMTAG_FILERDEVS = 1033
+RPMTAG_FILELINKTOS = 1036
+RPMTAG_DIRINDEXES = 1116
+RPMTAG_BASENAMES = 1117
+RPMTAG_DIRNAMES = 1118
+RPMTAG_LONGFILESIZES = 5008
+
+
+class RPMType(IntEnum):
+    INT16 = 3
+    INT32 = 4
+    INT64 = 5
+    STRING_ARRAY = 8
+    I18NSTRING_ARRAY = 9
+
+
+C_DEFINITIONS = """
+        typedef struct rpm_lead {
+            char   magic[4];        // ED AB EE DB
+            uint8  major;
+            uint8  minor;
+            uint16 type;
+            uint16 archnum;
+            char   name[66];
+            uint16 osnum;
+            uint16 signature_type;
+            char   reserved[16];
+        } rpm_lead_t;
+
+        // Shared layout for both the Signature header and the Main header.
+        // The variable-length index entries (nindex * 16 bytes) and data
+        // section (hsize bytes) follow immediately after this fixed part.
+        typedef struct rpm_header {
+            char   magic[3];        // 8E AD E8
+            uint8  version;
+            char   reserved[4];
+            uint32 nindex;
+            uint32 hsize;
+        } rpm_header_t;
+
+        typedef struct rpm_index_entry {
+            uint32 tag;
+            uint32 type;
+            uint32 offset;          // offset into the header's data section
+            uint32 count;
+        } rpm_index_entry_t;
+
+        typedef struct rpm_cstring {
+            char value[];
+        } rpm_cstring_t;
+    """
+
+
+class RPMParser:
+    @dataclass(frozen=True)
+    class HeaderSection:
+        header: Any
+        entries: dict[int, Any]
+        offset: int
+        data_offset: int
+        size: int
+
+        @property
+        def end_offset(self) -> int:
+            return self.offset + self.size
+
+    def __init__(self, file: File, start_offset: int):
+        self._file = file
+        self._start_offset = start_offset
+        self._struct_parser = StructParser(C_DEFINITIONS)
+
+        self._lead: Any | None = None
+        self._signature: RPMParser.HeaderSection | None = None
+        self._main_header: RPMParser.HeaderSection | None = None
+        self._package_size: int | None = None
+        self.compressor: str = "none"
+
+    def parse(self):
+        self._file.seek(self._start_offset, io.SEEK_SET)
+        self._lead = self._struct_parser.cparser_be.rpm_lead_t(self._file)
+
+        if self._lead is None:
+            raise InvalidInputFormat("RPM lead is missing or malformed")
+
+        self._signature = self._read_header_section(
+            offset=self._start_offset + len(self._lead),
+            alignment=RPM_SIGNATURE_ALIGNMENT,
+        )
+
+        size_entry = self._signature.entries.get(
+            RPMSIGTAG_LONGSIZE
+        ) or self._signature.entries.get(RPMSIGTAG_SIZE)
+        if not size_entry:
+            raise InvalidInputFormat(
+                "RPM signature header must contain a SIZE or LONGSIZE tag"
+            )
+
+        self._package_size = self._read_entry_integer(self._signature, size_entry)
+
+        self._main_header = self._read_header_section(offset=self._signature.end_offset)
+
+        compressor_entry = self._main_header.entries.get(RPMTAG_PAYLOADCOMPRESSOR)
+        if compressor_entry:
+            self.compressor = self._read_cstring_entry(
+                self._main_header, compressor_entry
+            )
+        else:
+            # if RPMTAG_PAYLOADCOMPRESSOR is absent on v3/v4 rpm file, the default compression is gzip
+            # while w0.ufdio (none compression) packages omit the tag and set PAYLOADFLAGS = "0" instead.
+            payload_flags_entry = self._main_header.entries.get(RPMTAG_PAYLOADFLAGS)
+            payload_flags = (
+                self._read_cstring_entry(self._main_header, payload_flags_entry)
+                if payload_flags_entry
+                else None
+            )
+            self.compressor = "none" if payload_flags == "0" else "gzip"
+
+    def _read_header_section(self, offset: int, alignment: int = 1) -> HeaderSection:
+        self._file.seek(offset, io.SEEK_SET)
+        header = self._struct_parser.cparser_be.rpm_header_t(self._file)
+        entries = {
+            entry.tag: entry
+            for entry in (
+                self._struct_parser.cparser_be.rpm_index_entry_t(self._file)
+                for _ in range(header.nindex)
+            )
+        }
+
+        entry_table_size = (
+            header.nindex * self._struct_parser.cparser_be.rpm_index_entry_t.size
+        )
+        data_size = round_up(header.hsize + entry_table_size, alignment)
+
+        return self.HeaderSection(
+            header=header,
+            entries=entries,
+            offset=offset,
+            data_offset=offset + len(header) + entry_table_size,
+            size=len(header) + data_size,
+        )
+
+    def _read_entry_integer(self, section: HeaderSection, entry: Any) -> int:
+        self._file.seek(section.data_offset + entry.offset, io.SEEK_SET)
+        if entry.tag == RPMSIGTAG_LONGSIZE:
+            return convert_int64(self._file.read(8), Endian.BIG)
+        return convert_int32(self._file.read(4), Endian.BIG)
+
+    def _read_cstring_entry(self, section: HeaderSection, entry: Any) -> str:
+        self._file.seek(section.data_offset + entry.offset, io.SEEK_SET)
+        return self._struct_parser.cparser_be.rpm_cstring_t(self._file).value.decode(
+            "ascii"
+        )
+
+    def _read_array_entry(self, section: HeaderSection, entry: Any) -> list:
+        """Read a fixed-count array tag value, dispatching on the entry's type."""
+        self._file.seek(section.data_offset + entry.offset, io.SEEK_SET)
+        # this line avoid false pylance errors
+        cparser: Any = self._struct_parser.cparser_be
+        match entry.type:
+            case RPMType.INT16:
+                return list(cparser.uint16[entry.count](self._file))
+            case RPMType.INT32:
+                return list(cparser.uint32[entry.count](self._file))
+            case RPMType.INT64:
+                return list(cparser.uint64[entry.count](self._file))
+            case RPMType.STRING_ARRAY | RPMType.I18NSTRING_ARRAY:
+                return [
+                    self._struct_parser.cparser_be.rpm_cstring_t(
+                        self._file
+                    ).value.decode("utf-8", errors="replace")
+                    for _ in range(entry.count)
+                ]
+        raise InvalidInputFormat(f"Unsupported RPM tag type: {entry.type}")
+
+    def build_stripped_entries(self) -> list[CPIOEntry]:
+        """Reconstruct metadata per-file from the main header arrays."""
+        if self._main_header is None:
+            raise InvalidInputFormat("RPM main header has not been parsed")
+        h = self._main_header
+        file_names: list[str] = self._read_array_entry(h, h.entries[RPMTAG_BASENAMES])
+        dirnames: list[str] = self._read_array_entry(h, h.entries[RPMTAG_DIRNAMES])
+        dirindexes: list[int] = self._read_array_entry(h, h.entries[RPMTAG_DIRINDEXES])
+        file_sizes: list[int] = self._read_array_entry(
+            h, h.entries[RPMTAG_LONGFILESIZES]
+        )
+        modes: list[int] = self._read_array_entry(h, h.entries[RPMTAG_FILEMODES])
+        links: list[str] = self._read_array_entry(h, h.entries[RPMTAG_FILELINKTOS])
+        rdevs: list[int] = self._read_array_entry(h, h.entries[RPMTAG_FILERDEVS])
+        self._file.seek(self.payload_offset, io.SEEK_SET)
+        return [
+            CPIOEntry(
+                header=None,
+                path=Path(dirnames[dirindexes[i]] + file_names[i]),
+                size=file_sizes[i],
+                mode=modes[i],
+                rdev=rdevs[i],
+                link=links[i],
+            )
+            for i in range(len(file_names))
+        ]
+
+    @property
+    def payload_offset(self) -> int:
+        if self._main_header is None:
+            raise InvalidInputFormat("RPM main header has not been parsed")
+        return self._main_header.end_offset
+
+    @property
+    def end_offset(self) -> int:
+        if self._main_header is None or self._package_size is None:
+            raise InvalidInputFormat("RPM package has not been parsed")
+        return self._main_header.offset + self._package_size
+
+    @property
+    def has_stripped_payload(self) -> bool:
+        """Stripped CPIO is used whenever LONGFILESIZES is needed (any file >4 GiB)."""
+        if self._main_header is None:
+            raise InvalidInputFormat("RPM main header has not been parsed")
+        return RPMTAG_LONGFILESIZES in self._main_header.entries
+
+
+class RPMExtractor(Extractor):
+    def extract(self, inpath: Path, outdir: Path) -> ExtractResult:
+        fs = FileSystem(outdir)
+        with File.from_path(inpath) as file:
+            parser = RPMParser(file, 0)
+            parser.parse()
+            file.seek(parser.payload_offset, io.SEEK_SET)
+            with RPMExtractor.open_payload_stream(file, parser.compressor) as decoder:
+                if parser.has_stripped_payload:
+                    StrippedCPIOParser(
+                        decoder,  # pyright: ignore[reportArgumentType]
+                        0,
+                        parser.build_stripped_entries(),
+                    ).parse(fs)
+                else:
+                    PortableASCIIParser(decoder, 0).parse(fs)  # pyright: ignore[reportArgumentType]
+        return ExtractResult(reports=fs.problems)
+
+    @staticmethod
+    def open_payload_stream(file: File, compressor: str):
+        """Return a forward-only decompressing reader over the RPM payload.
+
+        The caller must have already positioned `file` at the payload start.
+        """
+        match compressor:
+            case "gzip":
+                return gzip.GzipFile(fileobj=file, mode="rb")
+            case "bzip2":
+                return bz2.BZ2File(file, mode="rb")  # pyright: ignore[reportArgumentType]
+            case "xz" | "lzma":
+                return lzma.LZMAFile(file, mode="rb")  # pyright: ignore[reportArgumentType]
+            case "zstd":
+                return pyzstd.ZstdFile(file, mode="rb")  # pyright: ignore[reportArgumentType]
+            case "none":
+                return file
+        raise InvalidInputFormat(f"Unsupported RPM payload compressor: {compressor}")
+
+
+class RPMHandler(StructHandler):
+    NAME = "rpm"
+    PATTERNS = [
+        HexString(
+            "ED AB EE DB (03 | 04) ?? 00 (00 | 01) ?? ?? [65] 00 ?? ?? 00 05"
+        )  # RPM lead magic + major version (03 or 04) + minor version (?) + type (0x00 or 0x01) + name + signature type (0x5)
+    ]
+    EXTRACTOR = RPMExtractor()
+    C_DEFINITIONS = C_DEFINITIONS
+    HEADER_STRUCT = "rpm_header_t"
+
+    DOC = HandlerDoc(
+        name="RPM",
+        description="RPM (Red Hat Package Manager) is a package archive format used by Red Hat-based Linux distributions. An RPM file contains metadata (signature, header) and a compressed cpio archive as payload.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Red Hat",
+        references=[
+            Reference(
+                title="RPM File Format",
+                url="https://rpm-software-management.github.io/rpm/manual/format.html",
+            ),
+            Reference(
+                title="RPM Package Manager",
+                url="https://en.wikipedia.org/wiki/RPM_Package_Manager",
+            ),
+        ],
+        limitations=[],
+    )
+
+    def calculate_chunk(self, file: File, start_offset: int) -> ValidChunk | None:
+        parser = RPMParser(file, start_offset)
+        parser.parse()
+        return ValidChunk(
+            start_offset=start_offset,
+            end_offset=parser.end_offset,
+        )

--- a/python/unblob/handlers/archive/rpm.py
+++ b/python/unblob/handlers/archive/rpm.py
@@ -1,0 +1,423 @@
+import bz2
+import gzip
+import io
+import lzma
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+from typing import Any
+
+import zstandard
+
+from ...file_utils import FileSystem, convert_int32, convert_int64, round_up
+from ...models import (
+    Endian,
+    Extractor,
+    ExtractResult,
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    InvalidInputFormat,
+    Reference,
+    StructHandler,
+    StructParser,
+    ValidChunk,
+)
+from .cpio import CPIOEntry, PortableASCIIParser, StrippedCPIOParser
+
+RPM_SIGNATURE_ALIGNMENT = 8
+RPMSIGTAG_SIZE = 1000  # INT32
+RPMSIGTAG_LONGSIZE = 270  # INT64
+RPMTAG_PAYLOADCOMPRESSOR = 1125
+RPMTAG_PAYLOADFLAGS = 1126
+
+RPMTAG_FILEMODES = 1030
+RPMTAG_FILERDEVS = 1033
+RPMTAG_FILELINKTOS = 1036
+RPMTAG_DIRINDEXES = 1116
+RPMTAG_BASENAMES = 1117
+RPMTAG_DIRNAMES = 1118
+RPMTAG_LONGFILESIZES = 5008
+
+RPM_HEADER_MAGIC = b"\x8e\xad\xe8"
+RPM_HEADER_MAX_TAGS = 0xFFFF
+RPM_HEADER_MAX_DATA_SIZE = 0x0FFF_FFFF
+RPM_HEADER_MAX_ARRAY_SIZE = 0x000F_FFFF
+
+
+class RPMType(IntEnum):
+    INT16 = 3
+    INT32 = 4
+    INT64 = 5
+    STRING = 6
+    STRING_ARRAY = 8
+    I18NSTRING_ARRAY = 9
+
+
+C_DEFINITIONS = """
+        typedef struct rpm_lead {
+            char   magic[4];        // ED AB EE DB
+            uint8  major;
+            uint8  minor;
+            uint16 type;
+            uint16 archnum;
+            char   name[66];
+            uint16 osnum;
+            uint16 signature_type;
+            char   reserved[16];
+        } rpm_lead_t;
+
+        // Shared layout for both the Signature header and the Main header.
+        // The variable-length index entries (nindex * 16 bytes) and data
+        // section (hsize bytes) follow immediately after this fixed part.
+        typedef struct rpm_header {
+            char   magic[3];        // 8E AD E8
+            uint8  version;
+            char   reserved[4];
+            uint32 nindex;
+            uint32 hsize;
+        } rpm_header_t;
+
+        typedef struct rpm_index_entry {
+            uint32 tag;
+            uint32 type;
+            uint32 offset;          // offset into the header's data section
+            uint32 count;
+        } rpm_index_entry_t;
+
+        typedef struct rpm_cstring {
+            char value[];
+        } rpm_cstring_t;
+    """
+
+
+class RPMParser:
+    @dataclass(frozen=True)
+    class HeaderSection:
+        header: Any
+        entries: dict[int, Any]
+        offset: int
+        data_offset: int
+        size: int
+
+        @property
+        def end_offset(self) -> int:
+            return self.offset + self.size
+
+    def __init__(self, file: File, start_offset: int):
+        self._file = file
+        self._start_offset = start_offset
+        self._struct_parser = StructParser(C_DEFINITIONS)
+
+        self._lead: Any | None = None
+        self._signature: RPMParser.HeaderSection | None = None
+        self._main_header: RPMParser.HeaderSection | None = None
+        self._package_size: int | None = None
+        self.compressor: str = "none"
+
+    def parse(self):
+        self._file.seek(self._start_offset, io.SEEK_SET)
+        self._lead = self._struct_parser.cparser_be.rpm_lead_t(self._file)
+
+        if self._lead is None:
+            raise InvalidInputFormat("RPM lead is missing or malformed")
+
+        self._signature = self._read_header_section(
+            offset=self._start_offset + len(self._lead),
+            alignment=RPM_SIGNATURE_ALIGNMENT,
+        )
+
+        size_entry = self._signature.entries.get(
+            RPMSIGTAG_LONGSIZE
+        ) or self._signature.entries.get(RPMSIGTAG_SIZE)
+        if not size_entry:
+            raise InvalidInputFormat(
+                "RPM signature header must contain a SIZE or LONGSIZE tag"
+            )
+
+        self._package_size = self._read_entry_integer(self._signature, size_entry)
+
+        self._main_header = self._read_header_section(offset=self._signature.end_offset)
+
+        if self.end_offset < self.payload_offset:
+            raise InvalidInputFormat(
+                "RPM package size does not include the main header"
+            )
+        if self.end_offset > len(self._file):
+            raise InvalidInputFormat("RPM package extends beyond the end of the file")
+
+        compressor_entry = self._main_header.entries.get(RPMTAG_PAYLOADCOMPRESSOR)
+        if compressor_entry:
+            self.compressor = self._read_cstring_entry(
+                self._main_header, compressor_entry
+            )
+        else:
+            # if RPMTAG_PAYLOADCOMPRESSOR is absent on v3/v4 rpm file, the default compression is gzip
+            # while w0.ufdio (none compression) packages omit the tag and set PAYLOADFLAGS = "0" instead.
+            payload_flags_entry = self._main_header.entries.get(RPMTAG_PAYLOADFLAGS)
+            payload_flags = (
+                self._read_cstring_entry(self._main_header, payload_flags_entry)
+                if payload_flags_entry
+                else None
+            )
+            self.compressor = "none" if payload_flags == "0" else "gzip"
+
+    def _read_header_section(self, offset: int, alignment: int = 1) -> HeaderSection:
+        header_size = self._struct_parser.cparser_be.rpm_header_t.size
+        if offset < self._start_offset or offset + header_size > len(self._file):
+            raise InvalidInputFormat("RPM header extends beyond the end of the file")
+
+        self._file.seek(offset, io.SEEK_SET)
+        header = self._struct_parser.cparser_be.rpm_header_t(self._file)
+        if (
+            bytes(header.magic) != RPM_HEADER_MAGIC
+            or header.version != 1
+            or bytes(header.reserved) != b"\x00" * 4
+        ):
+            raise InvalidInputFormat("Invalid RPM header record")
+        if header.nindex > RPM_HEADER_MAX_TAGS:
+            raise InvalidInputFormat("RPM header contains too many index entries")
+        if header.hsize > RPM_HEADER_MAX_DATA_SIZE:
+            raise InvalidInputFormat("RPM header data section is too large")
+
+        entry_size = self._struct_parser.cparser_be.rpm_index_entry_t.size
+        entry_table_size = header.nindex * entry_size
+        data_offset = offset + len(header) + entry_table_size
+        section_size = len(header) + round_up(
+            header.hsize + entry_table_size, alignment
+        )
+        if offset + section_size > len(self._file):
+            raise InvalidInputFormat("RPM header extends beyond the end of the file")
+
+        entries = {
+            entry.tag: entry
+            for entry in (
+                self._struct_parser.cparser_be.rpm_index_entry_t(self._file)
+                for _ in range(header.nindex)
+            )
+        }
+        if any(entry.offset > header.hsize for entry in entries.values()):
+            raise InvalidInputFormat("RPM index entry points outside its header")
+
+        return self.HeaderSection(
+            header=header,
+            entries=entries,
+            offset=offset,
+            data_offset=data_offset,
+            size=section_size,
+        )
+
+    def _read_entry_integer(self, section: HeaderSection, entry: Any) -> int:
+        expected_type = (
+            RPMType.INT64 if entry.tag == RPMSIGTAG_LONGSIZE else RPMType.INT32
+        )
+        size = 8 if expected_type == RPMType.INT64 else 4
+        if entry.type != expected_type or entry.count != 1:
+            raise InvalidInputFormat("RPM package size tag has an invalid type")
+        self._validate_entry_bounds(section, entry, size)
+        self._file.seek(section.data_offset + entry.offset, io.SEEK_SET)
+        if entry.tag == RPMSIGTAG_LONGSIZE:
+            return convert_int64(self._file.read(8), Endian.BIG)
+        return convert_int32(self._file.read(4), Endian.BIG)
+
+    def _read_cstring_entry(self, section: HeaderSection, entry: Any) -> str:
+        if entry.type != RPMType.STRING or entry.count != 1:
+            raise InvalidInputFormat("RPM string tag has an invalid type")
+        start = section.data_offset + entry.offset
+        end = section.data_offset + section.header.hsize
+        terminator = self._file.find(b"\x00", start, end)
+        if terminator < 0:
+            raise InvalidInputFormat("RPM string is not null-byte terminated")
+        try:
+            return self._file[start:terminator].decode("ascii")
+        except UnicodeDecodeError as e:
+            raise InvalidInputFormat("RPM string is not ASCII") from e
+
+    def _read_array_entry(self, section: HeaderSection, entry: Any) -> list:
+        """Read a fixed-count array tag value, dispatching on the entry's type."""
+        if entry.count > RPM_HEADER_MAX_ARRAY_SIZE:
+            raise InvalidInputFormat("RPM tag array contains too many values")
+        self._file.seek(section.data_offset + entry.offset, io.SEEK_SET)
+        # this line avoid false pylance errors
+        cparser: Any = self._struct_parser.cparser_be
+        match entry.type:
+            case RPMType.INT16:
+                self._validate_entry_bounds(section, entry, entry.count * 2)
+                return list(cparser.uint16[entry.count](self._file))
+            case RPMType.INT32:
+                self._validate_entry_bounds(section, entry, entry.count * 4)
+                return list(cparser.uint32[entry.count](self._file))
+            case RPMType.INT64:
+                self._validate_entry_bounds(section, entry, entry.count * 8)
+                return list(cparser.uint64[entry.count](self._file))
+            case RPMType.STRING_ARRAY | RPMType.I18NSTRING_ARRAY:
+                values = []
+                end = section.data_offset + section.header.hsize
+                for _ in range(entry.count):
+                    start = self._file.tell()
+                    terminator = self._file.find(b"\x00", start, end)
+                    if terminator < 0:
+                        raise InvalidInputFormat(
+                            "RPM string array is not null-byte terminated"
+                        )
+                    values.append(
+                        self._file[start:terminator].decode("utf-8", errors="replace")
+                    )
+                    self._file.seek(terminator + 1, io.SEEK_SET)
+                return values
+        raise InvalidInputFormat(f"Unsupported RPM tag type: {entry.type}")
+
+    @staticmethod
+    def _validate_entry_bounds(
+        section: HeaderSection, entry: Any, value_size: int
+    ) -> None:
+        if entry.offset + value_size > section.header.hsize:
+            raise InvalidInputFormat("RPM tag value extends outside its header")
+
+    def build_stripped_entries(self) -> list[CPIOEntry]:
+        """Reconstruct metadata per-file from the main header arrays."""
+        if self._main_header is None:
+            raise InvalidInputFormat("RPM main header has not been parsed")
+        h = self._main_header
+        required_tags = {
+            RPMTAG_BASENAMES,
+            RPMTAG_DIRNAMES,
+            RPMTAG_DIRINDEXES,
+            RPMTAG_LONGFILESIZES,
+            RPMTAG_FILEMODES,
+            RPMTAG_FILELINKTOS,
+            RPMTAG_FILERDEVS,
+        }
+        if missing_tags := required_tags.difference(h.entries):
+            raise InvalidInputFormat(
+                f"RPM stripped payload is missing metadata tags: {sorted(missing_tags)}"
+            )
+
+        file_names: list[str] = self._read_array_entry(h, h.entries[RPMTAG_BASENAMES])
+        dirnames: list[str] = self._read_array_entry(h, h.entries[RPMTAG_DIRNAMES])
+        dirindexes: list[int] = self._read_array_entry(h, h.entries[RPMTAG_DIRINDEXES])
+        file_sizes: list[int] = self._read_array_entry(
+            h, h.entries[RPMTAG_LONGFILESIZES]
+        )
+        modes: list[int] = self._read_array_entry(h, h.entries[RPMTAG_FILEMODES])
+        links: list[str] = self._read_array_entry(h, h.entries[RPMTAG_FILELINKTOS])
+        rdevs: list[int] = self._read_array_entry(h, h.entries[RPMTAG_FILERDEVS])
+        file_count = len(file_names)
+        if any(
+            len(values) != file_count
+            for values in (dirindexes, file_sizes, modes, links, rdevs)
+        ):
+            raise InvalidInputFormat(
+                "RPM per-file metadata arrays have different sizes"
+            )
+        if any(index >= len(dirnames) for index in dirindexes):
+            raise InvalidInputFormat("RPM directory index is out of range")
+
+        self._file.seek(self.payload_offset, io.SEEK_SET)
+        return [
+            CPIOEntry(
+                header=None,
+                path=Path(dirnames[dirindexes[i]]) / file_names[i],
+                size=file_sizes[i],
+                mode=modes[i],
+                rdev=rdevs[i],
+                link=links[i],
+            )
+            for i in range(len(file_names))
+        ]
+
+    @property
+    def payload_offset(self) -> int:
+        if self._main_header is None:
+            raise InvalidInputFormat("RPM main header has not been parsed")
+        return self._main_header.end_offset
+
+    @property
+    def end_offset(self) -> int:
+        if self._main_header is None or self._package_size is None:
+            raise InvalidInputFormat("RPM package has not been parsed")
+        return self._main_header.offset + self._package_size
+
+    @property
+    def has_stripped_payload(self) -> bool:
+        """Stripped CPIO is used whenever LONGFILESIZES is needed (any file >4 GiB)."""
+        if self._main_header is None:
+            raise InvalidInputFormat("RPM main header has not been parsed")
+        return RPMTAG_LONGFILESIZES in self._main_header.entries
+
+
+class RPMExtractor(Extractor):
+    def extract(self, inpath: Path, outdir: Path) -> ExtractResult:
+        fs = FileSystem(outdir)
+        with File.from_path(inpath) as file:
+            parser = RPMParser(file, 0)
+            parser.parse()
+            file.seek(parser.payload_offset, io.SEEK_SET)
+            with RPMExtractor.open_payload_stream(file, parser.compressor) as decoder:
+                if parser.has_stripped_payload:
+                    StrippedCPIOParser(
+                        decoder,  # pyright: ignore[reportArgumentType]
+                        0,
+                        parser.build_stripped_entries(),
+                    ).parse(fs)
+                else:
+                    PortableASCIIParser(decoder, 0).parse(fs)  # pyright: ignore[reportArgumentType]
+        return ExtractResult(reports=fs.problems)
+
+    @staticmethod
+    def open_payload_stream(file: File, compressor: str):
+        """Return a forward-only decompressing reader over the RPM payload.
+
+        The caller must have already positioned `file` at the payload start.
+        """
+        match compressor:
+            case "gzip":
+                return gzip.GzipFile(fileobj=file, mode="rb")
+            case "bzip2":
+                return bz2.BZ2File(file, mode="rb")  # pyright: ignore[reportArgumentType]
+            case "xz" | "lzma":
+                return lzma.LZMAFile(file, mode="rb")  # pyright: ignore[reportArgumentType]
+            case "zstd":
+                return zstandard.open(file, mode="rb")  # pyright: ignore[reportArgumentType]
+            case "none":
+                return file
+        raise InvalidInputFormat(f"Unsupported RPM payload compressor: {compressor}")
+
+
+class RPMHandler(StructHandler):
+    NAME = "rpm"
+    PATTERNS = [
+        HexString(
+            "ED AB EE DB (03 | 04) ?? 00 (00 | 01) ?? ?? [65] 00 ?? ?? 00 05"
+        )  # RPM lead magic + major version (03 or 04) + minor version (?) + type (0x00 or 0x01) + name + signature type (0x5)
+    ]
+    EXTRACTOR = RPMExtractor()
+    C_DEFINITIONS = C_DEFINITIONS
+    HEADER_STRUCT = "rpm_header_t"
+
+    DOC = HandlerDoc(
+        name="RPM",
+        description="RPM (Red Hat Package Manager) is a package archive format used by Red Hat-based Linux distributions. An RPM file contains metadata (signature, header) and a compressed cpio archive as payload.",
+        handler_type=HandlerType.ARCHIVE,
+        vendor="Red Hat",
+        references=[
+            Reference(
+                title="RPM File Format",
+                url="https://rpm.org/docs/4.20.x/manual/format_v4.html",
+            ),
+            Reference(
+                title="RPM Package Manager",
+                url="https://en.wikipedia.org/wiki/RPM_Package_Manager",
+            ),
+        ],
+        limitations=[],
+    )
+
+    def calculate_chunk(self, file: File, start_offset: int) -> ValidChunk | None:
+        parser = RPMParser(file, start_offset)
+        parser.parse()
+        return ValidChunk(
+            start_offset=start_offset,
+            end_offset=parser.end_offset,
+        )

--- a/tests/handlers/archive/test_cpio.py
+++ b/tests/handlers/archive/test_cpio.py
@@ -1,7 +1,15 @@
+import stat
+from pathlib import Path
+
 import pytest
 
-from unblob.file_utils import File, InvalidInputFormat
-from unblob.handlers.archive.cpio import PortableASCIIParser, PortableOldASCIIParser
+from unblob.file_utils import File, FileSystem, InvalidInputFormat
+from unblob.handlers.archive.cpio import (
+    CPIOEntry,
+    PortableASCIIParser,
+    PortableOldASCIIParser,
+    StrippedCPIOParser,
+)
 
 
 def old_ascii_entry(
@@ -25,6 +33,12 @@ def new_ascii_entry(
         + namesize
         + b"00000000"
     )
+
+
+def stripped_archive(payload: bytes, file_index: bytes = b"00000000") -> bytes:
+    entry_padding = b"\x00" * (-len(payload) % 4)
+    trailer = new_ascii_entry(namesize=b"0000000b") + b"TRAILER!!!\x00" + b"\x00" * 3
+    return b"07070X" + file_index + b"\x00" * 2 + payload + entry_padding + trailer
 
 
 @pytest.mark.parametrize(
@@ -63,3 +77,31 @@ def test_parse_rejects_negative_filesize(parser, entry):
 
     with pytest.raises(InvalidInputFormat):
         parser(file, 0).parse()
+
+
+def test_stripped_parser_uses_rpm_symlink_metadata(tmp_path: Path) -> None:
+    payload_target = b"target-from-payload"
+    entry = CPIOEntry(
+        header=None,
+        size=len(payload_target),
+        mode=stat.S_IFLNK | 0o777,
+        rdev=0,
+        path=Path("link"),
+        link="target-from-header",
+    )
+    archive = stripped_archive(payload_target)
+    parser = StrippedCPIOParser(File.from_bytes(archive), 0, [entry])
+
+    parser.parse(FileSystem(tmp_path))
+
+    assert (tmp_path / "link").readlink() == Path("target-from-header")
+    assert parser.end_offset == len(archive)
+
+
+def test_stripped_parser_rejects_out_of_range_file_index() -> None:
+    parser = StrippedCPIOParser(
+        File.from_bytes(stripped_archive(b"", file_index=b"00000001")), 0, []
+    )
+
+    with pytest.raises(InvalidInputFormat, match="file index"):
+        parser.parse()

--- a/tests/handlers/archive/test_rpm.py
+++ b/tests/handlers/archive/test_rpm.py
@@ -1,0 +1,47 @@
+import struct
+
+import pytest
+
+from unblob.file_utils import File, InvalidInputFormat
+from unblob.handlers.archive.rpm import RPMHandler
+
+
+def build_minimal_rpm(package_size: int = 16) -> bytes:
+    lead = struct.pack(
+        ">4sBBHH66sHH16s",
+        b"\xed\xab\xee\xdb",
+        3,
+        0,
+        0,
+        1,
+        b"minimal",
+        1,
+        5,
+        b"",
+    )
+    signature = (
+        struct.pack(">3sB4sII", b"\x8e\xad\xe8", 1, b"", 1, 4)
+        + struct.pack(">IIII", 1000, 4, 0, 1)
+        + struct.pack(">I", package_size)
+        + b"\x00" * 4
+    )
+    main_header = struct.pack(">3sB4sII", b"\x8e\xad\xe8", 1, b"", 0, 0)
+    return lead + signature + main_header
+
+
+def test_rpm_chunk_supports_nonzero_start_offset() -> None:
+    prefix = b"arbitrary-prefix"
+    rpm = build_minimal_rpm()
+
+    chunk = RPMHandler().calculate_chunk(File.from_bytes(prefix + rpm), len(prefix))
+
+    assert chunk is not None
+    assert chunk.start_offset == len(prefix)
+    assert chunk.end_offset == len(prefix) + len(rpm)
+
+
+def test_rpm_chunk_rejects_size_beyond_eof() -> None:
+    rpm = build_minimal_rpm(package_size=17)
+
+    with pytest.raises(InvalidInputFormat, match="beyond the end"):
+        RPMHandler().calculate_chunk(File.from_bytes(rpm), 0)

--- a/tests/integration/archive/rpm/__input__/fruits-bz.rpm
+++ b/tests/integration/archive/rpm/__input__/fruits-bz.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6739f7f872babb32db941635611287bf7b384111a123d838b6ca332c6a3eea4e
+size 6461

--- a/tests/integration/archive/rpm/__input__/fruits-gz.rpm
+++ b/tests/integration/archive/rpm/__input__/fruits-gz.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b96d489103276ebe58c9792329b3d56db8e54db6a328002281964ae487befab
+size 6399

--- a/tests/integration/archive/rpm/__input__/fruits-legacy.rpm
+++ b/tests/integration/archive/rpm/__input__/fruits-legacy.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43712722d3759cda746a8d62c5506b8736edc03c3995b6296083dcd18fbd66c4
+size 6399

--- a/tests/integration/archive/rpm/__input__/fruits-none.rpm
+++ b/tests/integration/archive/rpm/__input__/fruits-none.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34b69e9d0137a689e9025fe8598d4d6f71ee848315bcad511a91ef8a81f95cba
+size 6797

--- a/tests/integration/archive/rpm/__input__/fruits-xz.rpm
+++ b/tests/integration/archive/rpm/__input__/fruits-xz.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94887f7cbb69be174f69b53ed4264f4c90bb9ee88f4434781b8996bb173930a9
+size 6493

--- a/tests/integration/archive/rpm/__input__/fruits-zst.rpm
+++ b/tests/integration/archive/rpm/__input__/fruits-zst.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:caaa15fb73b4851425c438ecefa268dd08bd7c512e02bce2e908a7a1408f358a
+size 6428

--- a/tests/integration/archive/rpm/__output__/fruits-bz.rpm_extract/fruits/apple.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-bz.rpm_extract/fruits/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c80737a74021aaff7cd57523af4a2fa96d8d3d23ccd2d3946f85513ee21ba80a
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-bz.rpm_extract/fruits/banana.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-bz.rpm_extract/fruits/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:831ae84797fcb934b1552aa33297d930443f48a1b1df57192a30b4ee5049b985
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-bz.rpm_extract/fruits/cherry.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-bz.rpm_extract/fruits/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14fb3abdedccd5783a6a8a2fb60f7a704eb364ae809616c4052bce5350f74883
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-gz.rpm_extract/fruits/apple.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-gz.rpm_extract/fruits/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c80737a74021aaff7cd57523af4a2fa96d8d3d23ccd2d3946f85513ee21ba80a
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-gz.rpm_extract/fruits/banana.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-gz.rpm_extract/fruits/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:831ae84797fcb934b1552aa33297d930443f48a1b1df57192a30b4ee5049b985
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-gz.rpm_extract/fruits/cherry.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-gz.rpm_extract/fruits/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14fb3abdedccd5783a6a8a2fb60f7a704eb364ae809616c4052bce5350f74883
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-legacy.rpm_extract/fruits/apple.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-legacy.rpm_extract/fruits/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c80737a74021aaff7cd57523af4a2fa96d8d3d23ccd2d3946f85513ee21ba80a
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-legacy.rpm_extract/fruits/banana.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-legacy.rpm_extract/fruits/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:831ae84797fcb934b1552aa33297d930443f48a1b1df57192a30b4ee5049b985
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-legacy.rpm_extract/fruits/cherry.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-legacy.rpm_extract/fruits/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14fb3abdedccd5783a6a8a2fb60f7a704eb364ae809616c4052bce5350f74883
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-none.rpm_extract/fruits/apple.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-none.rpm_extract/fruits/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c80737a74021aaff7cd57523af4a2fa96d8d3d23ccd2d3946f85513ee21ba80a
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-none.rpm_extract/fruits/banana.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-none.rpm_extract/fruits/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:831ae84797fcb934b1552aa33297d930443f48a1b1df57192a30b4ee5049b985
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-none.rpm_extract/fruits/cherry.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-none.rpm_extract/fruits/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14fb3abdedccd5783a6a8a2fb60f7a704eb364ae809616c4052bce5350f74883
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-xz.rpm_extract/fruits/apple.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-xz.rpm_extract/fruits/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c80737a74021aaff7cd57523af4a2fa96d8d3d23ccd2d3946f85513ee21ba80a
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-xz.rpm_extract/fruits/banana.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-xz.rpm_extract/fruits/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:831ae84797fcb934b1552aa33297d930443f48a1b1df57192a30b4ee5049b985
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-xz.rpm_extract/fruits/cherry.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-xz.rpm_extract/fruits/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14fb3abdedccd5783a6a8a2fb60f7a704eb364ae809616c4052bce5350f74883
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-zst.rpm_extract/fruits/apple.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-zst.rpm_extract/fruits/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c80737a74021aaff7cd57523af4a2fa96d8d3d23ccd2d3946f85513ee21ba80a
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-zst.rpm_extract/fruits/banana.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-zst.rpm_extract/fruits/banana.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:831ae84797fcb934b1552aa33297d930443f48a1b1df57192a30b4ee5049b985
+size 14

--- a/tests/integration/archive/rpm/__output__/fruits-zst.rpm_extract/fruits/cherry.txt
+++ b/tests/integration/archive/rpm/__output__/fruits-zst.rpm_extract/fruits/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14fb3abdedccd5783a6a8a2fb60f7a704eb364ae809616c4052bce5350f74883
+size 14


### PR DESCRIPTION
RPM (Red Hat Package Manager) packages are standard binary or source files (.rpm) used for installing, updating, and managing software on Linux distributions like RHEL, CentOS, Fedora, and openSUSE. They contain compressed software, configuration files, and metadata (dependencies, version info)

# Format 
RPM files are encoded in **big-endian**

### Lead (96 bytes)

Magic : ED AB EE DB
Major, minor : (03, 04) format version
Type : 0 = binary package, 1 = source
Arch, OS : target architecture and OS identifiers
Name : 66-byte null-padded package name
Signature type : 5 for the header-based signatures used by modern RPMs

### Signature header (16 bytes)
Magic : 8E AD E8
Version : 1 byte
Reserved : 4 bytes
nindex : number of index entries (4 bytes)
hsize : size of the data section (4 bytes)

Each index entry has the shape { tag, type, offset, count }, each field is a uint32. 

### Main header
Same structure as the signature header, but carries metadata tags about the package. The one we need:

- **RPMTAG_PAYLOADCOMPRESSOR** (1125)  C string naming the payload compressor: gzip, bzip2, xz, zstd. If this tag is absent, the payload is uncompressed (ufdio).
- 
### Payload
A CPIO archive  compressed with the algorithm named by PAYLOADCOMPRESSOR. Starts right after the main header's data section and runs to EOF.

So i had to change the behavior of `CPIO.py` to be able to handle stream input, otherwise it would be inefficient to keep all the information in memory.

# Sample : 
We can get grab rpm files over the internet from the [Fedora mirror](https://src.fedoraproject.org/)

or we can build ourselves with `rpmbuild` by : 
- defining a `.spec` file containing data, and instruction to recreate files, [information here](https://rpm-packaging-guide.github.io/#working-with-spec-files)
- using this rpm command with the spec file `rpmbuild -bb --define "_topdir $PWD" --define "_binary_payload <compression>" <your-file>.spec`

`_binary_payload` values: `w9.gzdio` (gzip) · `w9.bzdio` (bzip2) · `w2.xzdio `(xz) · `w19.zstdio` (zstd) · `w0.ufdio `(uncompressed).

# Reference : 
https://rpm-packaging-guide.github.io/#what-is-an-rpm
https://refspecs.linuxbase.org/LSB_3.1.0/LSB-Core-generic/LSB-Core-generic/pkgformat.html
https://rpm.org/docs/6.0.x/man/rpm-payloadflags.7