### PR TITLE
feat(handler) add LVM2 support

### DIFF
--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -38,6 +38,7 @@
     | [`ISO 9660`](#iso-9660) | FILESYSTEM | :octicons-check-16: |
     | [`JFFS2 (NEW)`](#jffs2-new) | FILESYSTEM | :octicons-check-16: |
     | [`JFFS2 (OLD)`](#jffs2-old) | FILESYSTEM | :octicons-check-16: |
+    | [`LVM2`](#lvm2) | FILESYSTEM | :octicons-alert-fill-12: |
     | [`LZ4`](#lz4) | COMPRESSION | :octicons-check-16: |
     | [`LZ4 (LEGACY)`](#lz4-legacy) | COMPRESSION | :octicons-check-16: |
     | [`LZ4 (SKIPPABLE)`](#lz4-skippable) | COMPRESSION | :octicons-check-16: |
@@ -701,6 +702,27 @@
 
         - [JFFS2 Documentation](https://sourceware.org/jffs2/){ target="_blank" }
         - [JFFS2 Wikipedia](https://en.wikipedia.org/wiki/JFFS2){ target="_blank" }
+## LVM2
+
+!!! warning "Partially supported"
+
+    === "Description"
+
+        LVM2 (Logical Volume Manager 2) is a volume management system for Linux block storage, grouping physical volumes (PVs) into volume groups (VGs) that expose logical volumes (LVs) as resizable virtual block devices. Each PV carries text-format metadata describing the VG layout and a data area holding LV contents as fixed-size physical extents.
+
+        ---
+
+        - **Handler type:** FileSystem
+        
+
+    === "References"
+
+        - [LVM2 on-disk format (libvslvm)](https://github.com/libyal/libvslvm/blob/main/documentation/Logical%20Volume%20Manager%20(LVM)%20format.asciidoc){ target="_blank" }
+
+    === "Limitations"
+
+        - Multi-PV volume groups produce one partial LV image per PV chunk. The data is preserved across all extractions, but combining the partials into a single LV image is left to the user.
+        - Only linear segments (striped with stripe_count=1) are supported. Other segment types (multi-stripe, mirror, raid, thin, snapshot, cache) require cross-PV reassembly or a separate format parser
 ## LZ4
 
 !!! success "Fully supported"

--- a/python/unblob/handlers/__init__.py
+++ b/python/unblob/handlers/__init__.py
@@ -50,6 +50,7 @@ from .filesystem import (
     fat,
     iso9660,
     jffs2,
+    lvm,
     minixfs,
     ntfs,
     romfs,
@@ -155,6 +156,7 @@ BUILTIN_HANDLERS: Handlers = (
     ufs.SolarisHandler,
     btrfs_stream.BTRFSStreamHandler,
     sbfh.SBFHHandler,
+    lvm.LVM2Handler,
 )
 
 BUILTIN_DIR_HANDLERS: DirectoryHandlers = (

--- a/python/unblob/handlers/filesystem/lvm.py
+++ b/python/unblob/handlers/filesystem/lvm.py
@@ -1,0 +1,291 @@
+import io
+from pathlib import Path
+
+from unblob.file_utils import (
+    Endian,
+    FileSystem,
+    InvalidInputFormat,
+    StructParser,
+    iterate_file,
+)
+from unblob.models import (
+    Extractor,
+    ExtractResult,
+    File,
+    HandlerDoc,
+    HandlerType,
+    HexString,
+    Reference,
+    StructHandler,
+    ValidChunk,
+)
+from unblob.report import ExtractionProblem
+
+C_DEFINITION = r"""
+        typedef struct lvm_label_header {
+            char     signature[8];   // "LABELONE"
+            uint64   sector;         // sector number of this label header, usually 1
+            uint32   crc;            // CRC of fields below to end of sector
+            uint32   header_size;    // size of this header; pv_header follows immediately
+            char     type[8];        // "LVM2 001"
+        } lvm_label_header_t;
+
+        typedef struct lvm_pv_header {
+            char     uuid[32];       // PV UUID, ASCII
+            uint64   device_size;    // PV size in bytes
+        } lvm_pv_header_t;
+
+        typedef struct lvm_data_area_descriptor {
+            uint64   area_offset;    // relative to start of the PV
+            uint64   area_size;      // 0 = unbounded
+        } lvm_data_area_descriptor_t;
+
+        typedef struct lvm_raw_location_descriptor {
+            uint64   data_offset;    // relative to start of metadata area
+            uint64   data_size;
+            uint32   crc;
+            uint32   flags;          // 0x1 = ignored
+        } lvm_raw_location_descriptor_t;
+
+        typedef struct lvm_metadata_area_header {
+            uint32                          crc;
+            char                            magic[16];   // "\x20LVM2\x20x[5A%r0N*>" signature
+            uint32                          version;
+            uint64                          offset;      // metadata area offset from PV start
+            uint64                          size;        // metadata area size
+            lvm_raw_location_descriptor_t   locns[4];
+            char                            padding[376];
+        } lvm_metadata_area_header_t;
+
+    """
+
+SECTOR_SIZE = 512  # LVM2 format constant
+LABEL_HEADER_SIZE = 32
+
+
+def parse_lvm_metadata(text: str) -> dict:
+    """Parse LVM2 text metadata into nested dicts.
+
+    Grammar (per libvslvm §5.5):
+        section { ... }                section opens a named scope
+        key = value                    int, "string", or [list]
+        # ...                          comment to end of line
+    Lists may span multiple lines until ']'.
+    """
+    root: dict = {}
+    stack: list[dict] = [root]
+    lines = _clean(text)
+
+    for line in lines:
+        if line == "}":
+            stack.pop()
+        elif line.endswith("{"):
+            section: dict = {}
+            stack[-1][line[:-1].strip()] = section
+            stack.append(section)
+        elif "=" in line:
+            key, _, value = (s.strip() for s in line.partition("="))
+            if value.startswith("[") and "]" not in value:
+                value = _consume_list(value, lines)
+            stack[-1][key] = _parse_value(value)
+
+    return root
+
+
+def _clean(text: str):
+    """Yield non-empty, comment-stripped lines."""
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            yield line
+
+
+def _consume_list(first: str, lines) -> str:
+    """Join continuation lines until ']' is seen, return the full list value as one string."""
+    parts = [first]
+    for line in lines:
+        parts.append(line)
+        if "]" in line:
+            break
+    return " ".join(parts)
+
+
+def _parse_value(text: str) -> int | str | list:
+    if text.startswith('"') and text.endswith('"'):
+        return text[1:-1]
+    if text.startswith("[") and text.endswith("]"):
+        items = [chunk.strip() for chunk in text[1:-1].split(",")]
+        return [_parse_value(item) for item in items if item]
+    if text.lstrip("-").isdigit():
+        return int(text)
+    return text
+
+
+class LVM2Extractor(Extractor):
+    def __init__(self):
+        self._struct_parser = StructParser(C_DEFINITION)
+
+    def extract(self, inpath: Path, outdir: Path) -> ExtractResult:
+        fs = FileSystem(outdir)
+        with File.from_path(inpath) as file:
+            file.seek(SECTOR_SIZE, io.SEEK_SET)
+            label = self._struct_parser.parse("lvm_label_header_t", file, Endian.LITTLE)
+
+            file.seek(SECTOR_SIZE + label.header_size, io.SEEK_SET)
+            pv_header = self._struct_parser.parse(
+                "lvm_pv_header_t", file, Endian.LITTLE
+            )
+
+            data_areas = self._read_descriptors(file)
+            metadata_areas = self._read_descriptors(file)
+            mda_offset = metadata_areas[0].area_offset
+
+            file.seek(mda_offset, io.SEEK_SET)
+            mda = self._struct_parser.parse(
+                "lvm_metadata_area_header_t", file, Endian.LITTLE
+            )
+
+            locn = mda.locns[0]
+            file.seek(mda_offset + locn.data_offset, io.SEEK_SET)
+            text = file.read(locn.data_size).decode("utf-8")
+            metadata = parse_lvm_metadata(text)
+
+            vg = self._get_vg(metadata)
+            pv_name = self._get_pv_name(vg, pv_header.uuid.decode("ascii"))
+            extent_bytes = vg["extent_size"] * SECTOR_SIZE
+            pe_start = data_areas[0].area_offset
+
+            for lv_name, lv in vg.get("logical_volumes", {}).items():
+                self._extract_lv(file, fs, lv_name, lv, pv_name, pe_start, extent_bytes)
+
+        return ExtractResult(reports=fs.problems)
+
+    @staticmethod
+    def _get_vg(metadata: dict) -> dict:
+        """Locate the VG block — the only top-level value that is a dict."""
+        for body in metadata.values():
+            if isinstance(body, dict):
+                return body
+        raise InvalidInputFormat("LVM metadata has no volume group block.")
+
+    @staticmethod
+    def _get_pv_name(vg: dict, pv_uuid: str) -> str:
+        """Match the binary PV UUID to the metadata's physical_volumes entry."""
+        for name, body in vg["physical_volumes"].items():
+            if body["id"].replace("-", "") == pv_uuid:
+                return name
+        raise InvalidInputFormat("PV UUID not found in volume group metadata.")
+
+    def _extract_lv(
+        self,
+        file: File,
+        fs: FileSystem,
+        lv_name: str,
+        lv: dict,
+        pv_name: str,
+        pe_start: int,
+        extent_bytes: int,
+    ):
+        out_path = Path(f"{lv_name}.img")
+        with fs.open(out_path, "wb+") as outfile:
+            for key, seg in lv.items():
+                # filter to segment sub-sections; "segment_count" also matches the prefix but is an int
+                if not (key.startswith("segment") and isinstance(seg, dict)):
+                    continue
+                # stripe_count == 1 is the only directly extractable shape (linear); anything else needs reassembly
+                if seg.get("stripe_count") != 1:
+                    fs.record_problem(
+                        ExtractionProblem(
+                            problem=f"{lv_name}/{key}: unsupported segment (type={seg.get('type')!r})",
+                            resolution="Segment skipped, output file will have a gap.",
+                        )
+                    )
+                    continue
+                if seg["stripes"][0] != pv_name:
+                    fs.record_problem(
+                        ExtractionProblem(
+                            problem=f"{lv_name}/{key}: segment lives on foreign PV {seg['stripes'][0]!r}",
+                            resolution="Segment skipped, output file will have a gap.",
+                        )
+                    )
+                    continue
+
+                pe_index = seg["stripes"][1]
+                start_extent = seg["start_extent"]
+                extent_count = seg["extent_count"]
+
+                src = pe_start + pe_index * extent_bytes
+                dst = start_extent * extent_bytes
+                length = extent_count * extent_bytes
+
+                outfile.seek(dst, io.SEEK_SET)
+                for chunk in iterate_file(file, src, length):
+                    outfile.write(chunk)
+
+    def _read_descriptors(self, file: File) -> list:
+        descs = []
+        while True:
+            d = self._struct_parser.parse(
+                "lvm_data_area_descriptor_t", file, Endian.LITTLE
+            )
+            if d.area_offset == 0 and d.area_size == 0:
+                return descs
+            descs.append(d)
+
+
+class LVM2Handler(StructHandler):
+    NAME = "lvm2"
+
+    PATTERNS = [
+        HexString("""
+                  4c 41 42 45 4c 4f 4e 45 // LABELONE
+                   [16] // sector(8) + crc(4) + data_offset(4)
+                  4c 56 4d 32 20 30 30 31 // LVM2 001
+                  """),
+    ]
+    EXTRACTOR = LVM2Extractor()
+    C_DEFINITIONS = C_DEFINITION
+
+    HEADER_STRUCT = "lvm_label_header_t"
+
+    DOC = HandlerDoc(
+        name="LVM2",
+        description="LVM2 (Logical Volume Manager 2) is a volume management system for Linux block storage, grouping physical volumes (PVs) into volume groups (VGs) that expose logical volumes (LVs) as resizable virtual block devices. Each PV carries text-format metadata describing the VG layout and a data area holding LV contents as fixed-size physical extents.",
+        handler_type=HandlerType.FILESYSTEM,
+        vendor=None,
+        references=[
+            Reference(
+                title="LVM2 on-disk format (libvslvm)",
+                url="https://github.com/libyal/libvslvm/blob/main/documentation/Logical%20Volume%20Manager%20(LVM)%20format.asciidoc",
+            ),
+        ],
+        limitations=[
+            "Multi-PV volume groups produce one partial LV image per PV chunk. The data is preserved across all extractions, but combining the partials into a single LV image is left to the user.",
+            "Only linear segments (striped with stripe_count=1) are supported. Other segment types (multi-stripe, mirror, raid, thin, snapshot, cache) require cross-PV reassembly or a separate format parser",
+        ],
+    )
+
+    def is_valid_header(self, header, start_offset: int) -> bool:
+        return (
+            LABEL_HEADER_SIZE <= header.header_size <= SECTOR_SIZE
+            and header.sector * SECTOR_SIZE <= start_offset
+        )
+
+    def calculate_chunk(self, file: File, start_offset: int) -> ValidChunk | None:
+        header = self.parse_header(file, Endian.LITTLE)
+
+        if not self.is_valid_header(header, start_offset):
+            raise InvalidInputFormat("Invalid LVM label header.")
+
+        pv_start = start_offset - header.sector * SECTOR_SIZE
+
+        file.seek(start_offset + header.header_size, io.SEEK_SET)
+        pv_header = self.cparser_le.lvm_pv_header_t(file)
+
+        if pv_header.device_size == 0:
+            raise InvalidInputFormat("LVM PV has zero device size.")
+
+        return ValidChunk(
+            start_offset=pv_start,
+            end_offset=pv_start + pv_header.device_size,
+        )

--- a/tests/integration/filesystem/lvm/__input__/lvm_multipv.img
+++ b/tests/integration/filesystem/lvm/__input__/lvm_multipv.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb6e6238e20cfd3f6aa6efff88dfa72ac9fe433139c86c8be49abba9e90c304e
+size 16777216

--- a/tests/integration/filesystem/lvm/__input__/lvm_single.img
+++ b/tests/integration/filesystem/lvm/__input__/lvm_single.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6253289c95da8abd76ed8342eb3ee4996f78c7b82c5f26eb8b3bcf7ce8cbe818
+size 8388608

--- a/tests/integration/filesystem/lvm/__output__/lvm_multipv.img_extract/0-8388608.lvm2_extract/bigdata.img
+++ b/tests/integration/filesystem/lvm/__output__/lvm_multipv.img_extract/0-8388608.lvm2_extract/bigdata.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab8d7eb552c9403d601a5e10948d5dd4b3dd57bee604a9b7ce16e84ec3389453
+size 7340032

--- a/tests/integration/filesystem/lvm/__output__/lvm_multipv.img_extract/8388608-16777216.lvm2_extract/bigdata.img
+++ b/tests/integration/filesystem/lvm/__output__/lvm_multipv.img_extract/8388608-16777216.lvm2_extract/bigdata.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f1a6ecb8e8c5aba6d1dc47440c553813fb227a6509b28908614c940b50fc853
+size 10485760

--- a/tests/integration/filesystem/lvm/__output__/lvm_multipv.img_extract/8388608-16777216.lvm2_extract/smalldata.img
+++ b/tests/integration/filesystem/lvm/__output__/lvm_multipv.img_extract/8388608-16777216.lvm2_extract/smalldata.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b64eac2eb3c9461171d282f490b4b0b123b0101c387c5db8e684bfd45103ad0
+size 2097152

--- a/tests/integration/filesystem/lvm/__output__/lvm_multipv.img_extract/8388608-16777216.lvm2_extract/smalldata.img_extract/greeting
+++ b/tests/integration/filesystem/lvm/__output__/lvm_multipv.img_extract/8388608-16777216.lvm2_extract/smalldata.img_extract/greeting
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bda91a7b12c13944334c4fb3cda9e8dbd4e1e4ba294461c50ffe53f0e5bef33
+size 21

--- a/tests/integration/filesystem/lvm/__output__/lvm_single.img_extract/apple.img
+++ b/tests/integration/filesystem/lvm/__output__/lvm_single.img_extract/apple.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b9f7ace18d6e7644bb775998d8e6b28643a804437a76ccc3d6c32cbba098c63
+size 4194304

--- a/tests/integration/filesystem/lvm/__output__/lvm_single.img_extract/apple.img_extract/0-2097152.extfs_extract/greeting
+++ b/tests/integration/filesystem/lvm/__output__/lvm_single.img_extract/apple.img_extract/0-2097152.extfs_extract/greeting
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d4fb0dc35ced4bc37428e2b87b4c7c24c399f45f27b084552af24f34b5b341e
+size 17

--- a/tests/integration/filesystem/lvm/__output__/lvm_single.img_extract/apple.img_extract/2097152-4194304.padding
+++ b/tests/integration/filesystem/lvm/__output__/lvm_single.img_extract/apple.img_extract/2097152-4194304.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5647f05ec18958947d32874eeb788fa396a05d0bab7c1b71f112ceb7e9b31eee
+size 2097152

--- a/tests/integration/filesystem/lvm/__output__/lvm_single.img_extract/orange.img
+++ b/tests/integration/filesystem/lvm/__output__/lvm_single.img_extract/orange.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b638e99426ff29de14320b1750d25ed513409be3a15efd55c905cf1666ec3220
+size 1048576

--- a/tests/integration/filesystem/lvm/__output__/lvm_single.img_extract/orange.img_extract/greeting
+++ b/tests/integration/filesystem/lvm/__output__/lvm_single.img_extract/orange.img_extract/greeting
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f746b43dbc334ecb6a88aaeb420d7a657690a08c74200101bc7024ef92e3f7a
+size 18


### PR DESCRIPTION
LVM2 (Logical Volume Manager 2) is Linux's volume management layer for grouping physical volumes (PVs) into volume groups (VGs) that expose logical volumes (LVs) as resizable virtual block devices. Each PV pairs a text-format metadata area (describing the VG and its LVs) with a data area holding LV contents as fixed-size physical extents.

all the **useful information** can be found [here](https://github.com/libyal/libvslvm/blob/main/documentation/Logical%20Volume%20Manager%20(LVM)%20format.asciidoc), thanks to  Joachim Metz who wrote this wonderful documentation. :)

## Format

All binary fields are **little-endian**.

Each Physical volume (PV) self-describes through structures placed at the start of the device.

#### Label header (sector 1, 32 bytes)

- signature (8 bytes): `LABELONE`
- sector (8 bytes): sector where this label lives (usually 1)
- crc, header_size (4 + 4 bytes)
- type (8 bytes): `LVM2 001`

#### PV header (immediately after label header)

- uuid (32 bytes ASCII, dash-less; the text metadata stores it dash-separated)
- device_size (8 bytes)
- Variable-length list of data area descriptors, terminated by an all-zero descriptor
- Variable-length list of metadata area descriptors, same termination

#### Metadata area header

Found at the offset given by the first metadata area descriptor. Carries four raw location descriptors (`locns[0..3]`), points to the text metadata.

#### Text metadata

Describes the VG in ASCII text, its `physical_volumes` (each entry carries the same UUID as the PV header, dash-separated), and its `logical_volumes`. Each LV is one or more **segments**, where a segment is a mapping `{ start_extent, extent_count, type, stripe_count, stripes = [pv_name, pe_index, ...] }`.

#### Data area

Physical extents (size = `extent_size * SECTOR_SIZE`) holding LV contents. Each linear segment maps `[start_extent, extent_count)` of an LV to `[pe_index, pe_index + extent_count)` on the named PV.

## Handler ability

- **Single-PV VGs** are extracted as complete logical volumes.
- **Multi-PV VGs** produce one partial LV image per PV chunk. The data is preserved across all PV extractions, but combining the partials into a single LV image is left to the user for now.
- **Only linear segments** (striped) are supported, because they're the only shape where the LV's bytes map to a single contiguous range on a single PV.  Other shapes either: split data across multiple PVs and would need cross-chunk reassembly.

### Samples

Generated locally with `losetup` + LVM2 tools, the steps are also described in the documentation mentioned before.

## References 

- https://github.com/libyal/libvslvm/blob/main/documentation/Logical%20Volume%20Manager%20(LVM)%20format.asciidoc
- https://sourceware.org/git/?p=lvm2.git