### PR TITLE
extfs: handle output paths containing quotes

### DIFF
--- a/python/unblob/handlers/filesystem/extfs.py
+++ b/python/unblob/handlers/filesystem/extfs.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from structlog import get_logger
 
 from unblob.file_utils import InvalidInputFormat
@@ -29,6 +31,25 @@ OS_LIST = [
         "Other",
     ),  # Other "Lites" (BSD4.4-Lite derivatives such as NetBSD, OpenBSD, XNU/Darwin, etc.)
 ]
+
+
+class ExtFSExtractor(Command):
+    """``debugfs -R`` extractor that is safe for output paths with metacharacters.
+
+    ``debugfs`` parses the ``-R`` request through libss, which re-tokenises the
+    string: whitespace separates arguments, double quotes group whitespace, and
+    a literal ``"`` inside a quoted token must be written as ``""``. The output
+    directory is interpolated into a quoted token (``rdump / "{outdir}"``), so
+    without escaping an ``outdir`` containing a ``"`` produces an
+    "Unbalanced quotes in command line" parse error. ``debugfs`` then exits 0
+    having run nothing, which would make unblob silently skip the whole ext
+    filesystem (no error reported). Escaping keeps the request well-formed for
+    any directory name produced during recursive extraction.
+    """
+
+    def _make_extract_command(self, inpath: Path, outdir: Path):
+        escaped_outdir = Path(str(outdir).replace('"', '""'))
+        return super()._make_extract_command(inpath, escaped_outdir)
 
 
 class EXTHandler(StructHandler):
@@ -70,7 +91,7 @@ class EXTHandler(StructHandler):
 
     PATTERN_MATCH_OFFSET = -MAGIC_OFFSET
 
-    EXTRACTOR = Command("debugfs", "-R", 'rdump / "{outdir}"', "{inpath}")
+    EXTRACTOR = ExtFSExtractor("debugfs", "-R", 'rdump / "{outdir}"', "{inpath}")
 
     DOC = HandlerDoc(
         name="ExtFS",

--- a/tests/handlers/filesystem/test_extfs.py
+++ b/tests/handlers/filesystem/test_extfs.py
@@ -2,7 +2,42 @@ from pathlib import Path
 
 from unblob.file_utils import File
 from unblob.finder import search_chunks
-from unblob.handlers.filesystem.extfs import EXTHandler
+from unblob.handlers.filesystem.extfs import ExtFSExtractor, EXTHandler
+
+
+def _request_token(argv):
+    """Return the libss request string passed to ``debugfs -R``."""
+    return argv[argv.index("-R") + 1]
+
+
+def test_extfs_handler_uses_escaping_extractor():
+    assert isinstance(EXTHandler.EXTRACTOR, ExtFSExtractor)
+
+
+def test_extfs_extractor_escapes_double_quote_in_outdir():
+    # An output directory whose name contains a literal " (legal in filenames
+    # and reachable through recursive extraction) must not break the debugfs
+    # request. libss requires a literal " inside a quoted token to be doubled.
+    extractor = ExtFSExtractor("debugfs", "-R", 'rdump / "{outdir}"', "{inpath}")
+    argv = extractor._make_extract_command(  # noqa: SLF001
+        Path("/in/0-1024.extfs"), Path('/out/evil"dir/x_extract')
+    )
+    request = _request_token(argv)
+    # Stays balanced (even number of quotes) -> libss accepts it.
+    assert request.count('"') % 2 == 0
+    # The path's " was escaped to "" so it round-trips to the intended path.
+    assert 'evil""dir' in request
+    # The image path is a plain argv element, not part of the -R request.
+    assert "/in/0-1024.extfs" in argv
+    assert "/in/0-1024.extfs" not in request
+
+
+def test_extfs_extractor_leaves_plain_outdir_unchanged():
+    extractor = ExtFSExtractor("debugfs", "-R", 'rdump / "{outdir}"', "{inpath}")
+    argv = extractor._make_extract_command(  # noqa: SLF001
+        Path("/in/0-1024.extfs"), Path("/out/plain/x_extract")
+    )
+    assert _request_token(argv) == 'rdump / "/out/plain/x_extract"'
 
 
 def test_reduced_oss_fuzz_extfs_input_is_rejected_without_exception_reports(

--- a/tests/integration/filesystem/extfs/__input__/debugfs.quoting.img
+++ b/tests/integration/filesystem/extfs/__input__/debugfs.quoting.img
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81284672a5b37e87016bdc6b2066bbef7cf9c3775b52aa84bc8fd80ecdb1d9aa
+size 2099200

--- a/tests/integration/filesystem/extfs/__output__/debugfs.quoting.img_extract/evil"dir/nested.ext
+++ b/tests/integration/filesystem/extfs/__output__/debugfs.quoting.img_extract/evil"dir/nested.ext
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3fc448de321bb912726202aac71aeced562280e473a61998b297eec716549ff
+size 2097152

--- a/tests/integration/filesystem/extfs/__output__/debugfs.quoting.img_extract/evil"dir/nested.ext_extract/marker.txt
+++ b/tests/integration/filesystem/extfs/__output__/debugfs.quoting.img_extract/evil"dir/nested.ext_extract/marker.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4169ac586761c1e922c624e2655466dea2b3266c3c9af4c88b08908f8a12ce8
+size 7


### PR DESCRIPTION
The `extfs` handler extracts ext2/3/4 images by shelling out to `debugfs -R 'rdump / "{outdir}"' {inpath}`. `debugfs` parses the `-R` request through **libss**, which re-tokenises the string (whitespace splits arguments;
double quotes group whitespace; a literal `"` must be written as `""`). The output directory is interpolated into that quoted request **without escaping**.

During recursive extraction, `{outdir}` includes directory/file names produced by a previous extraction step, which can legally contain a `"`. When it does, the rendered request has an unbalanced quote, so `debugfs` prints:

```
debugfs: Unbalanced quotes in command line
```

…and exits 0 without running `rdump`. Because unblob's `Command` treats a non-zero exit code as the failure signal, this means the nested ext filesystem is not extracted and no extraction error is surfaced for that handler.

This is specific to `extfs.py`: it is the only handler that embeds `{outdir}` inside a tool's quoted sub-language; other handlers pass `{outdir}` as a plain argv token.

## Reproduce

```console
# a tiny populated ext2 image
mkdir d && echo marker > d/marker.txt
dd if=/dev/zero of=nested.ext bs=1M count=2
mke2fs -F -q -d d nested.ext

# place it under a directory whose name contains a double quote, in a tar
mkdir -p 'evil"dir' && cp nested.ext 'evil"dir/nested.ext'
tar -cf bad.tar 'evil"dir'

unblob -e out bad.tar
# -> out/bad.tar_extract/evil"dir/nested.ext is identified as extfs,
#    but out/.../nested.ext_extract is not created.
# Control: the same image under a name without a quote extracts normally.
```

## Fix

Escape the output path for libss before it is placed in the request (a literal `"` becomes `""` inside a double-quoted token). Implemented as a small `Command` subclass so the change is contained to the `extfs` handler:

```python
class ExtFSExtractor(Command):
    """debugfs -R extractor that is safe for output paths with metacharacters."""

    def _make_extract_command(self, inpath: Path, outdir: Path):
        escaped_outdir = Path(str(outdir).replace('"', '""'))
        return super()._make_extract_command(inpath, escaped_outdir)

...
    EXTRACTOR = ExtFSExtractor("debugfs", "-R", 'rdump / "{outdir}"', "{inpath}")
```

(An alternative — running `debugfs` with `cwd=outdir` and a request of `rdump / .`, removing the path from the request entirely — would also work but needs a `cwd` option on `Command`; happy to take that route if preferred.)

## Tests

Added behaviour-pinning unit tests in `tests/handlers/filesystem/test_extfs.py`:
- the handler uses the escaping extractor;
- an `outdir` containing `"` renders a balanced request that round-trips
  (`evil"dir` → `evil""dir` inside the quotes);
- a plain `outdir` is unchanged.

## Verification done locally

- New unit tests: 3 passed.
- End-to-end A/B in a container (e2fsprogs + unblob built from source): the `evil"dir` case now extracts `marker.txt`; the safe-named control is unchanged.
- `ruff check` / `ruff format --check` (pinned `ruff==0.15.13`): clean on both changed files.