### PR TITLE
reject qnx_deflate block offsets smaller than the header

### DIFF
--- a/python/unblob/handlers/compression/qnx_deflate.py
+++ b/python/unblob/handlers/compression/qnx_deflate.py
@@ -58,6 +58,10 @@ class QNXDeflateExtractor(Extractor):
             with fs.open(Path(f"{inpath.stem}.uncompressed")) as outfile:
                 cmphdr = self._struct_parser.cparser_le.cmphdr_t(file)
                 while cmphdr.next != 0:
+                    if cmphdr.next < 8:
+                        raise InvalidInputFormat(
+                            "QNX deflate block offset is smaller than its header."
+                        )
                     compressed_part = file.read(cmphdr.next - 8)
                     outfile.write(decompressor.decompress(compressed_part))
                     cmphdr = self._struct_parser.cparser_le.cmphdr_t(file)
@@ -93,6 +97,10 @@ class QNXDeflateHandler(StructHandler):
 
         cmphdr = self.cparser_le.cmphdr_t(file)
         while cmphdr.next != 0:
+            if cmphdr.next < 8:
+                raise InvalidInputFormat(
+                    "QNX deflate block offset is smaller than its header."
+                )
             # return from 8 bytes because it parse the cmpheader
             file.seek(cmphdr.next - 8, io.SEEK_CUR)
             cmphdr = self.cparser_le.cmphdr_t(file)

--- a/tests/handlers/compression/test_qnx_deflate.py
+++ b/tests/handlers/compression/test_qnx_deflate.py
@@ -1,0 +1,36 @@
+import struct
+from pathlib import Path
+
+import pytest
+
+from unblob.file_utils import File, InvalidInputFormat
+from unblob.handlers.compression.qnx_deflate import (
+    QNXDeflateExtractor,
+    QNXDeflateHandler,
+)
+
+
+def build_image(next_offset: int) -> bytes:
+    # filehdr_t: signature[8], int32 usize, uint16 blksize, uint8 cmptype, uint8 flags
+    filehdr = b"iwlyfmbp" + struct.pack("<iHBB", 64, 4096, 0, 0)
+    # cmphdr_t: prev, next, pusize, usize
+    cmphdr = struct.pack("<HHHH", 0, next_offset, 0, 0)
+    return filehdr + cmphdr + b"\xab" * 5000
+
+
+@pytest.mark.parametrize("next_offset", [1, 4, 7])
+def test_calculate_chunk_rejects_short_block_offset(next_offset):
+    f = File.from_bytes(build_image(next_offset))
+    f.seek(0)
+    with pytest.raises(InvalidInputFormat):
+        QNXDeflateHandler().calculate_chunk(f, 0)
+
+
+@pytest.mark.parametrize("next_offset", [1, 4, 7])
+def test_extract_rejects_short_block_offset(next_offset, tmp_path: Path):
+    # next < 8 makes `cmphdr.next - 8` negative; mmap.read() would then slurp the
+    # whole remaining file instead of the block bounded by next.
+    inpath = tmp_path / "in.deflated"
+    inpath.write_bytes(build_image(next_offset))
+    with pytest.raises(InvalidInputFormat):
+        QNXDeflateExtractor().extract(inpath, tmp_path)


### PR DESCRIPTION
All QNX deflate block sizes are computed as `cmphdr.next - 8`, but `next` is an unchecked uint16. A value below 8 makes the size negative, and `mmap.read()` then slurps the whole remaining file as a single block instead of stopping at the block boundary. Reject `next < 8` in the chunk walk and the extractor.