### PR TITLE
reject btrfs encoded_write data length underflow

### DIFF
--- a/python/unblob/handlers/filesystem/btrfs_stream.py
+++ b/python/unblob/handlers/filesystem/btrfs_stream.py
@@ -520,6 +520,10 @@ class BTRFSParser:
             "tlv_header_type_only_t", self.file, Endian.LITTLE
         )
         data_len = cmd_header.data_len - len(command) - len(tlv_type)
+        if data_len < 0:
+            raise InvalidInputFormat(
+                "BTRFS encoded_write data length is smaller than its command header."
+            )
 
         # data_len is bounded by BTRFS_MAX_COMPRESSED (128 KiB); large files are
         # split into multiple encoded_write commands, so reading at once is safe

--- a/tests/handlers/filesystem/test_btrfs_stream.py
+++ b/tests/handlers/filesystem/test_btrfs_stream.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pytest
+
+from unblob.file_utils import (
+    Endian,
+    File,
+    FileSystem,
+    InvalidInputFormat,
+    StructParser,
+)
+from unblob.handlers.filesystem.btrfs_stream import C_DEFINITIONS, BTRFSParser
+
+STREAM_HEADER = b"btrfs-stream\x00" + (2).to_bytes(4, "little")
+
+
+def tlv(tlv_type: int, value: bytes) -> bytes:
+    return tlv_type.to_bytes(2, "little") + len(value).to_bytes(2, "little") + value
+
+
+def test_encoded_write_rejects_data_len_underflow(tmp_path: Path):
+    # cmd_header.data_len is smaller than the bytes the ENCODED_WRITE command
+    # consumes, so `data_len` turns negative and File.read() would return the
+    # whole rest of the mapping instead of the declared payload.
+    encoded_write = (
+        tlv(15, b"file")  # path
+        + tlv(0, bytes(8))  # file_offset
+        + tlv(0, bytes(8))  # unencoded_file_len
+        + tlv(0, bytes(8))  # unencoded_len
+        + tlv(0, bytes(8))  # unencoded_offset
+        + tlv(0, bytes(4))  # compression (NONE)
+        + tlv(0, bytes(4))  # encryption
+        + (24).to_bytes(2, "little")  # DATA tlv type, no length in v2
+    )
+    cmd_header = (0).to_bytes(4, "little") + (25).to_bytes(2, "little") + bytes(4)
+    file = File.from_bytes(STREAM_HEADER + cmd_header + encoded_write + b"\xff" * 4096)
+
+    parser = BTRFSParser(file, 0)
+    header = StructParser(C_DEFINITIONS).parse("cmd_header_t", file, Endian.LITTLE)
+    with pytest.raises(InvalidInputFormat):
+        parser.replay_encoded_write(FileSystem(tmp_path), header)


### PR DESCRIPTION
replay_encoded_write() derives the DATA length as `cmd_header.data_len - len(command) - len(tlv_type)`. `data_len` is an untrusted uint32 and the command carries a variable-length path TLV, so a small value makes the result negative and `File.read()` (mmap) returns the whole rest of the file straight into the zlib/zstd/LZO decompressor instead of the declared block. The sibling `replay_write()` runs the same subtraction through `iterate_file()`, which skips negatives, so only the encoded-write path over-reads. Reject the underflow before the read.