### PR TITLE
reject sparse chunk sizes smaller than the chunk header

### DIFF
--- a/python/unblob/handlers/filesystem/android/sparse.py
+++ b/python/unblob/handlers/filesystem/android/sparse.py
@@ -4,7 +4,7 @@ from structlog import get_logger
 
 from unblob.extractors.command import Command
 
-from ....file_utils import Endian
+from ....file_utils import Endian, InvalidInputFormat
 from ....models import (
     File,
     HandlerDoc,
@@ -93,6 +93,10 @@ class SparseHandler(StructHandler):
             if chunk_header.chunk_type not in VALID_CHUNK_TYPES:
                 logger.warning("Invalid chunk type in Android sparse image. Aborting.")
                 return None
+            if chunk_header.total_sz < len(chunk_header):
+                raise InvalidInputFormat(
+                    "Android sparse chunk size smaller than the chunk header."
+                )
             file.seek(chunk_header.total_sz - len(chunk_header), io.SEEK_CUR)
             count += 1
 


### PR DESCRIPTION
calculate_chunk in android/sparse.py skips each chunk with file.seek(chunk_header.total_sz - len(chunk_header), io.SEEK_CUR), but total_sz is an attacker-controlled uint32 with no lower bound, so a value below the 12-byte chunk header underflows to a negative SEEK_CUR and walks the parser backwards over the mmap. Reject total_sz smaller than the chunk header before the seek.