### PR TITLE
reject shrs file_size_no_padding larger than file_size

### DIFF
--- a/python/unblob/handlers/archive/dlink/shrs.py
+++ b/python/unblob/handlers/archive/dlink/shrs.py
@@ -88,6 +88,9 @@ class SHRSHandler(StructHandler):
     def is_valid_header(self, header, file: File) -> bool:
         if header.file_size < len(header):
             return False
+        # file_size_no_padding drives the read and the negative rewind below
+        if header.file_size_no_padding > header.file_size:
+            return False
         # we're exactly past the header, we compute the digest
         digest = hashlib.sha512(file.read(header.file_size_no_padding)).digest()
         # we seek back to where we were


### PR DESCRIPTION
Noticed is_valid_header rewinds with file.seek(-header.file_size_no_padding, io.SEEK_CUR) after reading that many bytes for the digest, but only file_size is range-checked. file_size_no_padding is an unvalidated uint32 from the header, so a value above file_size reads past the firmware and the negative SEEK_CUR walks the mmap-backed File position back before the header. Reject file_size_no_padding > file_size before the read and seek.