### PR TITLE
reject par2 packet length smaller than the header

### DIFF
--- a/python/unblob/handlers/archive/par2.py
+++ b/python/unblob/handlers/archive/par2.py
@@ -53,6 +53,9 @@ class MultiVolumePAR2Handler(DirectoryHandler):
                 if header.magic != PAR2_MAGIC:
                     return False
 
+                if header.packet_length < len(header):
+                    return False
+
                 offset_to_recovery_id = 32
                 # seek to beginning of recovery set ID
                 f.seek(offset_to_recovery_id, io.SEEK_SET)

--- a/tests/handlers/archive/test_par2.py
+++ b/tests/handlers/archive/test_par2.py
@@ -1,0 +1,23 @@
+import struct
+from pathlib import Path
+
+import pytest
+
+from unblob.handlers.archive.par2 import PAR2_MAGIC, MultiVolumePAR2Handler
+
+
+def build_packet(packet_length: int, tail: bytes = b"\xab" * 4096) -> bytes:
+    # par2_header_t: magic[8], packet_length u64, md5_hash[16],
+    # recovery_set_id[16], type[16] -> 64 bytes, followed by trailing data.
+    header = PAR2_MAGIC + struct.pack("<Q", packet_length) + b"\x00" * 48
+    return header + tail
+
+
+@pytest.mark.parametrize("packet_length", [0, 20, 31, 63])
+def test_is_valid_header_rejects_short_packet_length(packet_length, tmp_path: Path):
+    # packet_length below the 64-byte header makes `packet_length - len(header) + 32`
+    # negative; read(-1) then slurps the rest of the file past the packet boundary
+    # and smaller values raise ValueError.
+    path = tmp_path / "short.par2"
+    path.write_bytes(build_packet(packet_length))
+    assert MultiVolumePAR2Handler().is_valid_header([path]) is False


### PR DESCRIPTION
`is_valid_header` reads each packet body as `f.read(header.packet_length - len(header) + offset_to_recovery_id)`, where `packet_length` is an attacker-controlled uint64, `len(header)` is 64 and `offset_to_recovery_id` is 32. Only the magic is checked. A `packet_length` of 31 makes the read length -1, and `read(-1)` slurps the rest of the file past the packet boundary into the md5 (the controlled `md5_hash` then lets it validate); smaller values raise `ValueError`. Reject `packet_length < len(header)` before the read.