### PR TITLE
fix(handlers): reject romfs inode size past end of file

### DIFF
--- a/python/unblob/handlers/filesystem/romfs.py
+++ b/python/unblob/handlers/filesystem/romfs.py
@@ -118,6 +118,8 @@ class FileHeader:
     @property
     def content(self) -> bytes:
         """Returns the file content. Applicable to files and symlinks."""
+        if self.start_offset + self.size > self.file.size():
+            raise RomFSError("Inode size extends past the end of the file")
         try:
             self.file.seek(self.start_offset, io.SEEK_SET)
             return self.file.read(self.size)

--- a/tests/handlers/filesystem/test_romfs.py
+++ b/tests/handlers/filesystem/test_romfs.py
@@ -1,7 +1,26 @@
+import struct
+
 import pytest
 
 from unblob.file_utils import File
-from unblob.handlers.filesystem.romfs import get_string, valid_checksum
+from unblob.handlers.filesystem.romfs import (
+    FileHeader,
+    FSType,
+    RomFSError,
+    get_string,
+    valid_checksum,
+)
+
+
+def build_inode(size: int, data: bytes) -> File:
+    header = (
+        struct.pack(">I", FSType.FILE)
+        + struct.pack(">I", 0)
+        + struct.pack(">I", size)
+        + struct.pack(">I", 0)
+    )
+    filename = b"file" + b"\x00" * 12
+    return File.from_bytes(header + filename + data)
 
 
 @pytest.mark.parametrize(
@@ -41,3 +60,14 @@ def test_get_string(content, expected):
 )
 def test_valid_checksum(content, valid):
     assert valid_checksum(content) == valid
+
+
+def test_content_rejects_inode_past_eof():
+    inode = FileHeader(0, build_inode(size=1000, data=b"A" * 8))
+    with pytest.raises(RomFSError):
+        _ = inode.content
+
+
+def test_content_reads_inode_within_bounds():
+    inode = FileHeader(0, build_inode(size=8, data=b"A" * 8))
+    assert inode.content == b"A" * 8


### PR DESCRIPTION
**Unbounded inode size in romfs content**
The inode size is read straight from the file header and never checked against the image, so content() reads from the inode data start all the way to EOF, pulling neighbouring inodes into the extracted file, and the following seek(-size) underflows to a negative offset and raises SeekError. Added a bound rejecting any inode whose data runs past the end of the file.