### PR TITLE
bound yaffs file chunk reads to the page size

### DIFF
--- a/python/unblob/handlers/filesystem/yaffs.py
+++ b/python/unblob/handlers/filesystem/yaffs.py
@@ -469,7 +469,8 @@ class YAFFSParser:
 
     def get_file_chunks(self, entry: YAFFSEntry) -> Iterable[bytes]:
         for chunk in self.get_chunks(entry.object_id):
-            yield self.file[chunk.offset : chunk.offset + chunk.byte_count]
+            byte_count = min(chunk.byte_count, self.config.page_size)
+            yield self.file[chunk.offset : chunk.offset + byte_count]
 
     def extract(self, fs: FileSystem):
         for entry in [

--- a/tests/handlers/filesystem/test_yaffs.py
+++ b/tests/handlers/filesystem/test_yaffs.py
@@ -1,0 +1,45 @@
+import pytest
+
+from unblob.file_utils import Endian, File
+from unblob.handlers.filesystem.yaffs import (
+    YAFFS2Chunk,
+    YAFFS2Entry,
+    YAFFS2Parser,
+    YAFFSConfig,
+    YaffsObjectType,
+)
+
+PAGE_SIZE = 512
+
+
+def make_parser(data: bytes) -> YAFFS2Parser:
+    config = YAFFSConfig(
+        endianness=Endian.LITTLE,
+        page_size=PAGE_SIZE,
+        spare_size=16,
+        ecc=False,
+    )
+    return YAFFS2Parser(File.from_bytes(data), config)
+
+
+@pytest.mark.parametrize("byte_count", [PAGE_SIZE - 1, PAGE_SIZE, PAGE_SIZE + 1])
+def test_file_chunk_byte_count_bounded_to_page_size(byte_count: int):
+    page = b"A" * PAGE_SIZE
+    data = page + b"B" * PAGE_SIZE
+    parser = make_parser(data)
+    parser.data_chunks[5] = [
+        YAFFS2Chunk(
+            chunk_id=1,
+            offset=0,
+            byte_count=byte_count,
+            object_id=5,
+            seq_number=1,
+        )
+    ]
+    entry = YAFFS2Entry(object_type=YaffsObjectType.FILE, object_id=5, parent_obj_id=1)
+
+    content = b"".join(parser.get_file_chunks(entry))
+    expected_size = min(byte_count, PAGE_SIZE)
+
+    assert len(content) == expected_size
+    assert content == page[:expected_size]


### PR DESCRIPTION
**Unbounded chunk read in get_file_chunks**

A chunk's `byte_count` is taken from the YAFFS spare tags (a full uint32 on YAFFS2, a 10-bit field on YAFFS1) and never bounded against the page size, so a crafted image can make the slice run from the chunk start to EOF and pull neighbouring chunks into the extracted file. Capped it to one page, which is the most a single chunk can hold; valid images are unaffected.
