### PR TITLE
fix(handlers): bound xiaomi hdr crc to the image data

### DIFF
--- a/python/unblob/handlers/archive/xiaomi/hdr.py
+++ b/python/unblob/handlers/archive/xiaomi/hdr.py
@@ -154,7 +154,7 @@ class HDRHandlerBase(StructHandler):
         computed_crc = calculate_crc(
             file,
             start_offset=start_offset + CRC_CONTENT_OFFSET,
-            size=end_offset - start_offset + CRC_CONTENT_OFFSET,
+            size=end_offset - start_offset - CRC_CONTENT_OFFSET,
         )
         return header.crc32 == computed_crc
 

--- a/tests/integration/archive/xiaomi/hdr/hdr1/__input__/sample.bin.padded
+++ b/tests/integration/archive/xiaomi/hdr/hdr1/__input__/sample.bin.padded
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:038f11e61645a037bcb28660dfc16932df19f8bf7f4e1598153b51ee11fe478c
+size 1072

--- a/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1
+++ b/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d05b0fa037678a9ead854c7881ef08779d48f82aaaa8b43e9c95be3053e34d89
+size 1056

--- a/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob0
+++ b/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c2fa298a10bbfed53d1742e2ed9aa6bbdc01e40de4706067ab42dcaa20a2292
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob1
+++ b/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42e0a62ab7ed0173e513344b4cdfa9bc3353b357f92e2b7246a74afd10750e28
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob2
+++ b/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7eda3a441c45c07f9ae4368ec30c7abf7481ac87116d397f9a6a46e048e41f87
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob3
+++ b/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d2aae5d82a8ccf65b1a92e772c8df9f2d81a9814fe1339050cbd2a1e576c38a
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob4
+++ b/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5cb93c12ec7ce846880ff289fdc3946acf41fa18aa3344e8731b1c26eae9c03
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob5
+++ b/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81fada56ec5b06e042f863dcfbe8eeea652d6d20994e91fe52bf5d2dec080997
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob6
+++ b/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob6
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e77f94411db504aa4d5db507c76327615d3989296f38a1df42e3b1dd301c9bb
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob7
+++ b/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/0-1056.hdr1_extract/blob7
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb67d594754b545e5879fcd08ef90493d4985a538fcc3c73d2fefcddc56e2b41
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/1056-1072.padding
+++ b/tests/integration/archive/xiaomi/hdr/hdr1/__output__/sample.bin.padded_extract/1056-1072.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16

--- a/tests/integration/archive/xiaomi/hdr/hdr2/__input__/sample.bin.padded
+++ b/tests/integration/archive/xiaomi/hdr/hdr2/__input__/sample.bin.padded
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:132866b02b2dc1f84c4755d2cd71de7bf5cc7015e96cb99b7d8c2a9e529ada4b
+size 1096

--- a/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2
+++ b/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:053c0fa871896c6955e77bfd038cbaaff22a3e12d1caaf9e72a65e96a43cfb5b
+size 1080

--- a/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob0
+++ b/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob0
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c2fa298a10bbfed53d1742e2ed9aa6bbdc01e40de4706067ab42dcaa20a2292
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob1
+++ b/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob1
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42e0a62ab7ed0173e513344b4cdfa9bc3353b357f92e2b7246a74afd10750e28
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob2
+++ b/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7eda3a441c45c07f9ae4368ec30c7abf7481ac87116d397f9a6a46e048e41f87
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob3
+++ b/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d2aae5d82a8ccf65b1a92e772c8df9f2d81a9814fe1339050cbd2a1e576c38a
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob4
+++ b/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5cb93c12ec7ce846880ff289fdc3946acf41fa18aa3344e8731b1c26eae9c03
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob5
+++ b/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81fada56ec5b06e042f863dcfbe8eeea652d6d20994e91fe52bf5d2dec080997
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob6
+++ b/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob6
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e77f94411db504aa4d5db507c76327615d3989296f38a1df42e3b1dd301c9bb
+size 41

--- a/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob7
+++ b/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/0-1080.hdr2_extract/blob7
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32f1c9e35b9788717b0b9b23f09c1e8673fd69e4f9cf1405a44a5bb2c4a0bc1c
+size 36

--- a/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/1080-1096.padding
+++ b/tests/integration/archive/xiaomi/hdr/hdr2/__output__/sample.bin.padded_extract/1080-1096.padding
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:991204fba2b6216d476282d375ab88d20e6108d109aecded97ef424ddd114706
+size 16


### PR DESCRIPTION
**CRC range over-read in `_is_crc_valid`**

The checksum size is `end_offset - start_offset + CRC_CONTENT_OFFSET`, but the content starts `CRC_CONTENT_OFFSET` bytes in, so that term should be subtracted rather than added. As written the CRC runs 24 bytes past `end_offset` into whatever follows the image. A standalone file hides this since the extra bytes are past EOF and dropped, but an HDR1/HDR2 image embedded in a larger blob gets checksummed over adjacent trailing bytes and is wrongly rejected, and the read also crosses the validated chunk boundary. Flipped the sign so the CRC covers the image only; both handlers share the helper.
