### PR TITLE
fix(handlers): correct first yaffs chunk data offset

### DIFF
--- a/python/unblob/handlers/filesystem/yaffs.py
+++ b/python/unblob/handlers/filesystem/yaffs.py
@@ -232,9 +232,9 @@ def iterate_over_file(
 
     while len(page) == config.page_size and len(spare) == config.spare_size:
         yield (start_offset, page, spare)
+        start_offset = file.tell()
         page = file.read(config.page_size)
         spare = file.read(config.spare_size)
-        start_offset = file.tell()
 
 
 def decode_file_size(high: int, low: int) -> int:
@@ -301,9 +301,7 @@ class YAFFSParser:
         entries = 0
         for offset, page, spare in iterate_over_file(self.file, self.config):
             try:
-                data_chunk = self.build_chunk(
-                    spare, offset - self.config.page_size - self.config.spare_size
-                )
+                data_chunk = self.build_chunk(spare, offset)
             except EOFError:
                 break
 

--- a/tests/handlers/filesystem/test_yaffs.py
+++ b/tests/handlers/filesystem/test_yaffs.py
@@ -1,3 +1,5 @@
+import struct
+
 import pytest
 
 from unblob.file_utils import Endian, File
@@ -43,3 +45,50 @@ def test_file_chunk_byte_count_bounded_to_page_size(byte_count: int):
 
     assert len(content) == expected_size
     assert content == page[:expected_size]
+
+
+def test_first_chunk_data_offset_not_negative():
+    # When the very first chunk of the image is a file data chunk (chunk_id != 0),
+    # iterate_over_file used to yield a pre-read offset for it only, so parse()
+    # computed a negative data offset and get_file_chunks sliced from the end of
+    # the image, mixing foreign bytes into the extracted file.
+    page_size = 2048  # large enough to hold a yaffs2 object header
+    spare_size = 64
+    config = YAFFSConfig(
+        endianness=Endian.LITTLE,
+        page_size=page_size,
+        spare_size=spare_size,
+        ecc=False,
+    )
+
+    def tags(seq: int, object_id: int, chunk_id: int, byte_count: int) -> bytes:
+        # first 2 bytes are dropped for the non-ecc spare layout
+        spare = bytearray(spare_size)
+        struct.pack_into("<IIII", spare, 2, seq, object_id, chunk_id, byte_count)
+        return bytes(spare)
+
+    def header(object_type: YaffsObjectType, parent: int, name: bytes) -> bytes:
+        page = bytearray(page_size)
+        struct.pack_into("<I", page, 0, int(object_type))  # type
+        struct.pack_into("<I", page, 4, parent)  # parent_obj_id
+        struct.pack_into("<H", page, 8, 0xFFFF)  # sum_no_longer_used
+        page[10 : 10 + len(name)] = name  # name[256]
+        return bytes(page)
+
+    payload = b"A" * 16
+    page0 = payload + b"\x00" * (page_size - len(payload))
+    image = (
+        page0
+        + tags(seq=1, object_id=5, chunk_id=1, byte_count=len(payload))
+        + header(YaffsObjectType.FILE, parent=1, name=b"f")
+        + tags(seq=1, object_id=5, chunk_id=0, byte_count=0)
+    )
+
+    parser = YAFFS2Parser(File.from_bytes(image), config)
+    parser.parse(store=True)
+
+    assert parser.data_chunks[5][0].offset == 0
+    entry = parser.get_entry(5)
+    assert entry is not None
+    content = b"".join(parser.get_file_chunks(entry))
+    assert content == payload


### PR DESCRIPTION
**Off-by-one in the first yaffs chunk offset**

`iterate_over_file` captures `start_offset` before the first page and spare are read, so `parse` derives a data offset of `-(page_size + spare_size)` for the opening chunk while later chunks are correct; a crafted image whose first chunk is a file data chunk then makes `get_file_chunks` slice from the end of the image and pull unrelated trailing bytes into the extracted file. Reading the offset after the page and spare keeps the first chunk consistent with the rest, and valid images are unaffected since their first chunk is an object header whose offset is never used.