### PR TITLE
fix(handlers): bound moxa frm file read to its section

### DIFF
--- a/python/unblob/handlers/archive/moxa/frm.py
+++ b/python/unblob/handlers/archive/moxa/frm.py
@@ -91,14 +91,17 @@ class MoxaFRMExtractor(Extractor):
             case SectionTypes.FW_BINARY:
                 fs.carve(Path("firmware.bin"), file, section.offset, section.length)
             case SectionTypes.FILESYSTEM:
-                self._extract_fs_section(file, fs, section.offset)
+                self._extract_fs_section(file, fs, section.offset, section.length)
             case _:
                 raise InvalidInputFormat(f"Unknown section type: {section.type}")
 
-    def _extract_fs_section(self, file: File, fs: FileSystem, section_offset: int):
+    def _extract_fs_section(
+        self, file: File, fs: FileSystem, section_offset: int, section_length: int
+    ):
         file.seek(section_offset, io.SEEK_SET)
         fs_header = self._struct_parser.parse("frm_fs_header_t", file, Endian.LITTLE)
 
+        section_end = section_offset + section_length
         file_table_offset = section_offset + fs_header.file_table_offset
         for index in range(fs_header.file_count or fs_header.file_count2):
             entry_offset = file_table_offset + index * fs_header.file_header_length
@@ -109,8 +112,13 @@ class MoxaFRMExtractor(Extractor):
             if not name:
                 continue
 
-            file.seek(section_offset + entry.data_offset, io.SEEK_SET)
-            raw = file.read(entry.file_length)
+            data_start = section_offset + entry.data_offset
+            if data_start >= section_end:
+                continue
+            read_length = min(entry.file_length, section_end - data_start)
+
+            file.seek(data_start, io.SEEK_SET)
+            raw = file.read(read_length)
             self._write_file(fs, Path(name.decode("ascii", errors="replace")), raw)
 
     @staticmethod

--- a/tests/handlers/archive/test_frm.py
+++ b/tests/handlers/archive/test_frm.py
@@ -1,5 +1,8 @@
+import struct
+from pathlib import Path
+
 from unblob.file_utils import File
-from unblob.handlers.archive.moxa.frm import MoxaFRMHandler
+from unblob.handlers.archive.moxa.frm import MoxaFRMExtractor, MoxaFRMHandler
 from unblob.testing import unhex
 
 FILE_CONTENTS = unhex(
@@ -26,3 +29,65 @@ def test_chunk_calculation():
     assert chunk is not None
     assert chunk.start_offset == 0
     assert chunk.end_offset == 0xE92CC
+
+
+CONTENT = b"GOOD"
+TRAILING = b"SECRETFW"
+
+
+def build_frm(file_length: int) -> bytes:
+    """Build an FRM with one file at the very end of its FILESYSTEM section, then trailing bytes."""
+    fs_header = (
+        b"device".ljust(32, b"\x00")
+        + struct.pack("<I", 0)  # unknown1
+        + struct.pack("<I", 0)  # timestamp
+        + struct.pack("<I", 0)  # unknown2
+        + struct.pack("<I", 0)  # unknown3
+        + struct.pack("<I", 76)  # file_table_offset
+        + struct.pack("<I", 64)  # file_table_length
+        + struct.pack("<H", 64)  # file_header_length
+        + struct.pack("<H", 1)  # file_count
+        + struct.pack("<I", len(CONTENT))  # data_length
+        + struct.pack("<H", 0)  # unknown4
+        + struct.pack("<H", 0)  # file_count2
+        + struct.pack("<I", 0)  # file_table_length2
+        + struct.pack("<I", 0)  # unknown5
+    )
+    assert len(fs_header) == 76
+
+    data_offset = len(fs_header) + 64  # content sits right after the file table
+    file_entry = (
+        b"data.bin".ljust(48, b"\x00")
+        + b"\x00" * 8  # unknown
+        + struct.pack("<I", file_length)
+        + struct.pack("<I", data_offset)
+    )
+    section = fs_header + file_entry + CONTENT
+
+    section_offset = 64 + 16  # container header + one section entry
+    container = (
+        b"*FRM"
+        + struct.pack("<I", 1)  # unknown1
+        + struct.pack("<I", section_offset + len(section))  # total_length
+        + struct.pack("<H", 0x60)  # header_length
+        + struct.pack("<H", 1)  # section_count
+        + b"\x00" * 48  # unknown2
+    )
+    section_entry = struct.pack(
+        "<IIII", 2, section_offset, len(section), 0
+    )  # type=FILESYSTEM
+    return container + section_entry + section + TRAILING
+
+
+def test_extract_bounds_file_to_section(tmp_path: Path):
+    # file_length is taken straight from the entry; an oversized value reads past
+    # the section (and to EOF), so the trailing bytes outside the section must not
+    # leak into the extracted file.
+    inpath = tmp_path / "in.frm"
+    inpath.write_bytes(build_frm(file_length=0x10000))
+
+    MoxaFRMExtractor().extract(inpath, tmp_path)
+
+    extracted = (tmp_path / "data.bin").read_bytes()
+    assert extracted == CONTENT
+    assert TRAILING not in extracted


### PR DESCRIPTION
**Unbounded file read in moxa FRM extraction**

`_extract_fs_section` reads each entry with `file.read(entry.file_length)`, and `file_length` is taken straight from the file table with no check against the section, so a crafted oversized value reads past the filesystem section into the following section (the firmware binary) or to EOF and writes those bytes into the extracted file. Bounded the read to the section length, the same boundary already trusted when carving the `FW_BINARY` section, so valid images stay unaffected.