### PR TITLE
fix(handlers): reject unsorted uzip block offset table

### DIFF
--- a/python/unblob/handlers/compression/uzip.py
+++ b/python/unblob/handlers/compression/uzip.py
@@ -1,3 +1,4 @@
+import itertools
 import lzma
 import re
 import zlib
@@ -78,6 +79,10 @@ DECOMPRESS_METHOD: dict[bytes, type[Decompressor]] = {
 }
 
 
+def is_toc_sorted(toc) -> bool:
+    return all(current <= nxt for current, nxt in itertools.pairwise(toc))
+
+
 class UZIPExtractor(Extractor):
     def extract(self, inpath: Path, outdir: Path):
         with File.from_path(inpath) as infile:
@@ -135,6 +140,7 @@ class UZIPHandler(StructHandler):
             header.block_count > 0
             and header.block_size > 0
             and header.block_size % 512 == 0
+            and is_toc_sorted(header.toc)
         )
 
     def calculate_chunk(self, file: File, start_offset: int) -> ValidChunk | None:

--- a/tests/handlers/compression/test_uzip.py
+++ b/tests/handlers/compression/test_uzip.py
@@ -1,0 +1,39 @@
+import struct
+
+import pytest
+
+from unblob.file_utils import File, InvalidInputFormat
+from unblob.handlers.compression.uzip import UZIPHandler
+
+ZLIB_MAGIC = b"#!/bin/sh\x0a#V2.0\x20"
+
+
+def build_image(toc: list[int]) -> bytes:
+    # uzip_header_t: magic[16], format[112], uint32 block_size, uint32 block_count,
+    # uint64 toc[block_count]
+    block_count = len(toc)
+    header = (
+        ZLIB_MAGIC
+        + b"\x00" * 112
+        + struct.pack(">I", 16384)
+        + struct.pack(">I", block_count)
+        + struct.pack(f">{block_count}Q", *toc)
+    )
+    # keep toc[-1] within the file so only the ordering check can reject the image
+    return header + b"\x00" * (max(toc) + 64 - len(header))
+
+
+def test_calculate_chunk_accepts_sorted_toc():
+    f = File.from_bytes(build_image([600, 700, 800]))
+    f.seek(0)
+    chunk = UZIPHandler().calculate_chunk(f, 0)
+    assert chunk is not None
+    assert chunk.end_offset == 800
+
+
+@pytest.mark.parametrize("toc", [[600, 500, 700], [600, 5000, 1000], [800, 700, 600]])
+def test_calculate_chunk_rejects_unsorted_toc(toc):
+    f = File.from_bytes(build_image(toc))
+    f.seek(0)
+    with pytest.raises(InvalidInputFormat):
+        UZIPHandler().calculate_chunk(f, 0)


### PR DESCRIPTION
**Unsorted block offset table in uzip**

The table of contents is read from the header and treated as consecutive `[start, end)` block bounds without checking the offsets ascend, so a descending entry gives a negative `next - current` length that `iterate_file` quietly treats as zero (the block is dropped) and leaves `toc[-1]` no longer marking the end of the block data. The non-decreasing check lives in the header validation and on the extractor path, so a crafted image is rejected rather than silently mis-extracted; samples with a normal sorted table are unaffected.