### PR TITLE
fix(handlers): skip lzo compressed checksum for stored blocks

### DIFF
--- a/python/unblob/handlers/compression/lzo.py
+++ b/python/unblob/handlers/compression/lzo.py
@@ -146,7 +146,7 @@ class LZOHandler(StructHandler):
             if (
                 header.flags & HeaderFlags.ADLER32_C
                 or header.flags & HeaderFlags.CRC32_C
-            ):
+            ) and compressed_size < uncompressed_size:
                 checksum_size += CHECKSUM_LENGTH
 
             file.seek(checksum_size + compressed_size, io.SEEK_CUR)

--- a/tests/handlers/compression/test_lzo.py
+++ b/tests/handlers/compression/test_lzo.py
@@ -1,0 +1,61 @@
+import struct
+import zlib
+
+from unblob.file_utils import File
+from unblob.handlers.compression.lzo import HeaderFlags, LZOHandler
+
+MAGIC = bytes.fromhex("89 4C 5A 4F 00 0D 0A 1A 0A")
+
+
+def build_lzo(flags: int, uncompressed_size: int, compressed_size: int) -> bytes:
+    """Build a single-block lzo stream.
+
+    A block is stored verbatim (incompressible) when compressed_size equals
+    uncompressed_size, in which case lzop writes no compressed checksum.
+    """
+    body = struct.pack(
+        ">HHHBBIIIIB",
+        0x1030,  # version
+        0x2080,  # libversion
+        0x0940,  # reqversion
+        1,  # method
+        1,  # level
+        flags,
+        0,  # mode
+        0,  # mtime
+        0,  # gmtdiff
+        0,  # filename_len
+    )
+    header = MAGIC + body + struct.pack(">I", zlib.adler32(body) & 0xFFFFFFFF)
+
+    block = struct.pack(">I", uncompressed_size) + struct.pack(">I", compressed_size)
+    stored = compressed_size >= uncompressed_size
+    if not stored and flags & (HeaderFlags.ADLER32_C | HeaderFlags.CRC32_C):
+        block += struct.pack(">I", 0)  # compressed checksum
+    block += b"\xab" * compressed_size
+
+    return header + block + struct.pack(">I", 0)  # zero size terminator
+
+
+def test_calculate_chunk_stored_block_with_compressed_checksum_flag():
+    # A stored (incompressible) block carries no compressed checksum even when
+    # the F_*_C flag is set; the block walk must not skip past one.
+    image = build_lzo(HeaderFlags.CRC32_C, uncompressed_size=32, compressed_size=32)
+    f = File.from_bytes(image)
+    f.seek(0)
+
+    chunk = LZOHandler().calculate_chunk(f, 0)
+
+    assert chunk is not None
+    assert chunk.end_offset == len(image)
+
+
+def test_calculate_chunk_compressed_block_with_compressed_checksum_flag():
+    image = build_lzo(HeaderFlags.CRC32_C, uncompressed_size=64, compressed_size=32)
+    f = File.from_bytes(image)
+    f.seek(0)
+
+    chunk = LZOHandler().calculate_chunk(f, 0)
+
+    assert chunk is not None
+    assert chunk.end_offset == len(image)


### PR DESCRIPTION
**Stored lzo blocks carry no compressed checksum**

`LZOHandler.calculate_chunk` walks each data block by skipping `checksum_size + compressed_size`, and it counts a compressed-block checksum whenever the `F_*_C` flag is set. lzop only writes that checksum for blocks it actually compressed; incompressible blocks are stored verbatim (`compressed_size == uncompressed_size`) with no compressed checksum, so the walk skips four bytes too far and loses sync. A trailing stored block then makes the next size read run past the end and a valid stream gets rejected, and with more data after it the chunk boundary settles on an attacker-influenced offset instead.

Limited the checksum accounting to blocks where `compressed_size < uncompressed_size`, which keeps the common compressed-block path untouched and should be the safer default to reason about.

Added a small regression test building a stored block with the compressed-checksum flag set.