### PR TITLE
fix(handlers): validate xiaomi hdr blob header magic

### DIFF
--- a/python/unblob/handlers/archive/xiaomi/hdr.py
+++ b/python/unblob/handlers/archive/xiaomi/hdr.py
@@ -28,7 +28,7 @@ from unblob.models import (
 logger = get_logger()
 CRC_CONTENT_OFFSET = 12  # The CRC32 value is located after 12 byte in the header
 SIGNATURE_LEN = 272  # signature_header_t contains 4 bytes of size + 12 bytes for padding x3 + 0x100 is 256 in decimal
-BLOB_MAGIC = 0x000000BEBA  # Blob header magic
+BLOB_MAGIC = 0x0000BABE  # Blob header magic (little-endian: be ba 00 00)
 
 # https://lxr.openwrt.org/source/firmware-utils/src/xiaomifw.c
 C_DEFINITIONS = r"""
@@ -77,7 +77,7 @@ def calculate_crc(file: File, start_offset: int, size: int) -> int:
 
 
 def is_valid_blob_header(blob_header) -> bool:
-    if blob_header.magic == BLOB_MAGIC:
+    if blob_header.magic != BLOB_MAGIC:
         return False
     if not blob_header.blob_size:
         return False

--- a/tests/handlers/archive/test_hdr.py
+++ b/tests/handlers/archive/test_hdr.py
@@ -1,0 +1,38 @@
+import struct
+
+import pytest
+
+from unblob.file_utils import File, InvalidInputFormat
+from unblob.handlers.archive.xiaomi.hdr import HDRExtractor
+
+VALID_BLOB_MAGIC = b"\xbe\xba\x00\x00"  # 0x0000babe, little-endian
+INVALID_BLOB_MAGIC = b"\xde\xad\xbe\xef"
+
+BLOB_OFFSET = 0x30
+
+
+def build_hdr1(blob_magic: bytes) -> bytes:
+    header = b"HDR1"
+    header += struct.pack("<I", BLOB_OFFSET)  # signature_offset
+    header += struct.pack("<I", 0)  # crc32 (checked by calculate_chunk, not parse)
+    header += struct.pack("<HH", 0, 0)  # unused, device_id
+    header += struct.pack("<8I", BLOB_OFFSET, 0, 0, 0, 0, 0, 0, 0)  # blob_offsets
+
+    blob = blob_magic
+    blob += struct.pack("<I", 0)  # flash_offset
+    blob += struct.pack("<I", 41)  # blob_size
+    blob += struct.pack("<HH", 7, 0)  # type, unused
+    blob += b"blob0".ljust(32, b"\x00")  # name
+    return header + blob
+
+
+def test_blob_with_magic_is_parsed():
+    file = File.from_bytes(build_hdr1(VALID_BLOB_MAGIC))
+    blobs = list(HDRExtractor("hdr1_header_t").parse(file))
+    assert len(blobs) == 1
+
+
+def test_blob_without_magic_is_rejected():
+    file = File.from_bytes(build_hdr1(INVALID_BLOB_MAGIC))
+    with pytest.raises(InvalidInputFormat):
+        list(HDRExtractor("hdr1_header_t").parse(file))


### PR DESCRIPTION
**Blob magic never validated in is_valid_blob_header**

The check compares `blob_header.magic` against a byte-swapped constant (`0x000000BEBA`) and rejects on a match instead of a mismatch, so the documented `0x0000babe` is never actually enforced and a header whose `blob_offsets[]` point at arbitrary data is accepted whenever a non-zero size word and a decodable name sit there. Corrected the constant and the comparison so blobs without the magic are rejected; the bundled hdr1/hdr2 samples are unaffected and the added test covers both cases.