### PR TITLE
fix(handlers): bound sbfh mrvl segment reads to the firmware region

### DIFF
--- a/python/unblob/handlers/archive/tesla/sbfh.py
+++ b/python/unblob/handlers/archive/tesla/sbfh.py
@@ -68,13 +68,17 @@ class SBFHExtractor(Extractor):
             base_vaddr = min(seg.virtual_address for seg in segments)
             image_path = Path(f"firmware_{base_vaddr:08x}.bin")
 
+            # The segment data lives in the firmware region the header declares
+            # (header_size + firmware_size), which is also the chunk boundary.
+            data_end = sbfh.header_size + sbfh.firmware_size
+
             with fs.open(image_path, "wb+") as outfile:
                 for seg in segments:
                     crc = 0xFFFFFFFF
+                    seg_start = sbfh.header_size + seg.offset
+                    seg_size = max(0, min(seg.seg_size, data_end - seg_start))
                     outfile.seek(seg.virtual_address - base_vaddr, io.SEEK_SET)
-                    for chunk in iterate_file(
-                        file, sbfh.header_size + seg.offset, seg.seg_size
-                    ):
+                    for chunk in iterate_file(file, seg_start, seg_size):
                         crc = binascii.crc32(chunk, crc)
                         outfile.write(chunk)
                     if (crc ^ -1) & 0xFFFFFFFF != seg.crc_checksum:

--- a/tests/handlers/archive/test_sbfh.py
+++ b/tests/handlers/archive/test_sbfh.py
@@ -1,0 +1,41 @@
+import struct
+from pathlib import Path
+
+from unblob.handlers.archive.tesla.sbfh import SBFHExtractor
+
+HEADER_SIZE = 0x11C  # fixed sbfh_header_t size
+
+
+def build_image(seg_size: int) -> bytes:
+    # sbfh_header_t: magic[4], header_size, unk[7], firmware_size, padding[265]
+    # firmware region = [HEADER_SIZE, HEADER_SIZE + firmware_size); here the MRVL
+    # header (20) + one segment header (20) + 4 bytes of segment data == 44 bytes
+    firmware_size = 44
+    sbfh = (
+        b"SBFH"
+        + struct.pack("<I", HEADER_SIZE)
+        + b"\x00" * 7
+        + struct.pack("<I", firmware_size)
+        + b"\x00" * 265
+    )
+    # mrvl_header_t: magic[4], unk_const, creation_time, num_segments, elf_version
+    mrvl = b"MRVL" + struct.pack("<IIII", 0x2E9CF17B, 0, 1, 0x1F000000)
+    # mrvl_segment_header_t: type, offset (rel. to MRVL start), seg_size, vaddr, crc
+    # data starts at MRVL-relative offset 40 (right after the segment header)
+    seg = struct.pack("<IIIII", 2, 40, seg_size, 0, 0xDEADBEEF)
+    return sbfh + mrvl + seg + b"AAAA" + b"LEAK"
+
+
+def test_extract_bounds_segment_to_firmware_region(tmp_path: Path):
+    # seg_size 8 declares 4 bytes more than the segment actually holds; without a
+    # bound the read crosses the firmware region into the trailing "LEAK" bytes and
+    # writes them into the reassembled image.
+    inpath = tmp_path / "in.sbfh"
+    inpath.write_bytes(build_image(seg_size=8))
+
+    SBFHExtractor().extract(inpath, tmp_path)
+
+    (image,) = tmp_path.glob("firmware_*.bin")
+    data = image.read_bytes()
+    assert b"LEAK" not in data
+    assert data == b"AAAA"


### PR DESCRIPTION
The SBFH extractor reassembles the Marvell MRVL image by reading each segment from the input at header_size + offset for seg_size bytes, where both offset and seg_size come straight from the per-segment header. Neither is checked against firmware_size, the data length the SBFH header declares and the same value that bounds the carved chunk. On a crafted image a segment whose offset+seg_size runs past that region keeps reading into whatever follows the firmware blob, and those bytes are written into the reassembled firmware_<vaddr>.bin even though the per-segment CRC then fails, since that path only records a problem and writes the segment anyway. I noticed it whilst comparing the segment read with the header_size + firmware_size bound already used for the chunk. Clamping each segment read to that region closes it, and segments that already fit are left untouched. I kept the change inside the segment loop so the rest of the reassembly path does not shift.