### PR TITLE
fix(handlers): reject ufs inode numbers outside the inode table

### DIFF
--- a/python/unblob/handlers/filesystem/ufs.py
+++ b/python/unblob/handlers/filesystem/ufs.py
@@ -330,6 +330,9 @@ class UFSParser:
         self.super_block = self._struct_parser.parse(
             "ufs_superblock_t", self.file, Endian.LITTLE
         )
+        self.inode_count = (
+            self.super_block.fs_inodes_per_group * self.super_block.fs_ncg
+        )
 
     def walk_extract(self, fs: FileSystem, ino_num: int, path: Path):  # noqa: C901
         inode = self.read_inode(ino_num)
@@ -432,6 +435,8 @@ class UFSParser:
         return chunk[: inode.size].decode("utf-8", errors="replace")
 
     def read_inode(self, ino_number: int):
+        if not 1 <= ino_number < self.inode_count:
+            raise InvalidInputFormat(f"Inode number out of range: {ino_number}")
         cylinder_group = ino_number // self.super_block.fs_inodes_per_group
         index = ino_number % self.super_block.fs_inodes_per_group
         offset = (

--- a/tests/handlers/filesystem/test_ufs.py
+++ b/tests/handlers/filesystem/test_ufs.py
@@ -1,0 +1,57 @@
+import stat
+import struct
+
+import pytest
+
+from unblob.file_utils import File, InvalidInputFormat, StructParser
+from unblob.handlers.filesystem.ufs import UFS_C_DEFINITION, UFS2Parser
+
+FSIZE = 512
+IBLKNO = 4
+INODES_PER_GROUP = 16
+FRAGS_PER_GROUP = 8
+
+# inode number whose cylinder group does not exist (16 // 16 == 1, but fs_ncg == 1)
+OUT_OF_RANGE_INO = INODES_PER_GROUP
+# byte offset read_inode() computes for OUT_OF_RANGE_INO, past the inode table
+FAKE_INODE_OFFSET = (FRAGS_PER_GROUP + IBLKNO) * FSIZE
+
+
+def _build_image(*, inodes_per_group: int = INODES_PER_GROUP) -> bytes:
+    cs = StructParser(UFS_C_DEFINITION).cparser_le
+    superblock = cs.ufs_superblock_t(bytes(bytearray(cs.ufs_superblock_t.size)))
+    superblock.fs_fsize = FSIZE
+    superblock.fs_bsize = FSIZE
+    superblock.fs_frag = 1
+    superblock.fs_ncg = 1
+    superblock.fs_inodes_per_group = inodes_per_group
+    superblock.fs_iblkno = IBLKNO
+    superblock.fs_frags_per_group = FRAGS_PER_GROUP
+
+    image = bytearray(superblock.dumps())
+    image += b"\x00" * (FAKE_INODE_OFFSET + 256 - len(image))
+
+    # plant a structurally valid regular-file inode where an out-of-range inode
+    # number resolves, so an unguarded read would happily parse it
+    fake_inode = bytearray(256)
+    struct.pack_into("<H", fake_inode, 0, stat.S_IFREG | 0o644)
+    struct.pack_into("<Q", fake_inode, 16, 32)  # size
+    image[FAKE_INODE_OFFSET : FAKE_INODE_OFFSET + 256] = fake_inode
+    return bytes(image)
+
+
+def test_read_inode_rejects_out_of_range_number():
+    parser = UFS2Parser(File.from_bytes(_build_image()), 0)
+
+    # in-range inode is still readable
+    assert parser.read_inode(2) is not None
+
+    with pytest.raises(InvalidInputFormat, match="Inode number out of range"):
+        parser.read_inode(OUT_OF_RANGE_INO)
+
+
+def test_read_inode_rejects_zero_inodes_per_group():
+    parser = UFS2Parser(File.from_bytes(_build_image(inodes_per_group=0)), 0)
+
+    with pytest.raises(InvalidInputFormat, match="Inode number out of range"):
+        parser.read_inode(2)


### PR DESCRIPTION
**Out-of-range inode number in `read_inode`**
The inode number comes straight from directory entries but is never checked against the inode table, so a crafted entry makes `read_inode` seek to an arbitrary offset and parse unrelated bytes as an inode (and a zero `fs_inodes_per_group` divides by zero). Bounded it to the filesystem's inode count before use, matching the guard `minixfs` already has.