### PR TITLE
fix(handlers): bound minixfs data zone index to the filesystem

### DIFF
--- a/python/unblob/handlers/filesystem/minixfs.py
+++ b/python/unblob/handlers/filesystem/minixfs.py
@@ -158,6 +158,9 @@ class MinixFS:
         zmap_offset = imap_offset + self.superblock.s_imap_blocks * block_size
         self.inode_offset = zmap_offset + self.superblock.s_zmap_blocks * block_size
         self.zone_size = (block_size << self.superblock.s_log_zone_size) & 0xFF_FF_FF_FF
+        self.zone_count = (
+            self.superblock.s_nzones if self.version == 1 else self.superblock.s_zones
+        )
         self.inode_size = self.struct_parser.cparser_le.minix_inode.size
         self.zone_ptr_size = self.struct_parser.cparser_le.minix_inode.fields[
             "i_zone"
@@ -178,6 +181,8 @@ class MinixFS:
         raise InvalidInputFormat(f"Invalid magic: {self.superblock.s_magic:x}")
 
     def _read_zone_data(self, zone_index: int) -> bytes:
+        if not self.superblock.s_firstdatazone <= zone_index < self.zone_count:
+            raise InvalidInputFormat(f"Zone index out of range: {zone_index}")
         self.file.seek(zone_index * self.zone_size, io.SEEK_SET)
         return self.file.read(self.zone_size)
 

--- a/tests/handlers/filesystem/test_minixfs.py
+++ b/tests/handlers/filesystem/test_minixfs.py
@@ -2,6 +2,8 @@ import pytest
 
 from unblob.file_utils import Endian, File, InvalidInputFormat
 from unblob.handlers.filesystem.minixfs import (
+    VERSION_TO_C_DEFINITIONS,
+    MinixFS,
     MinixFSv1Handler,
     MinixFSv2Handler,
     MinixFSv3Handler,
@@ -163,6 +165,38 @@ def test_invalid(superblock, error, handler):
     )
     with pytest.raises(InvalidInputFormat, match=error):
         handler.calculate_chunk(file, 0)
+
+
+def _v1_minixfs() -> MinixFS:
+    # firstdatazone == 5, s_nzones == 32, so valid data zones are 5..31
+    image = bytearray(
+        NULL * BLOCK_SIZE
+        + SUPERBLOCK_V1_LE_14
+        + NULL * (BLOCK_SIZE - len(SUPERBLOCK_V1_LE_14))
+        + NULL * BLOCK_SIZE * 31
+    )
+    return MinixFS(File.from_bytes(bytes(image)), 1, VERSION_TO_C_DEFINITIONS[1])
+
+
+def test_read_zone_data_accepts_valid_data_zone():
+    minix = _v1_minixfs()
+    valid_zone = minix.superblock.s_firstdatazone
+    assert len(minix._read_zone_data(valid_zone)) == minix.zone_size  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    "zone_index",
+    [
+        4,  # inode table block, below the first data zone
+        0,  # boot block
+        32,  # one past the last zone
+        1000,  # well past the end of the filesystem
+    ],
+)
+def test_read_zone_data_rejects_out_of_range_zone(zone_index):
+    minix = _v1_minixfs()
+    with pytest.raises(InvalidInputFormat, match="Zone index out of range"):
+        minix._read_zone_data(zone_index)  # noqa: SLF001
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Out-of-range zone index in MinixFS extraction**

`MinixFS._read_zone_data` turns a zone index into a byte offset (`zone_index * zone_size`) with no check that the index falls inside the filesystem's data area. The indices come straight from an inode's `i_zone[]` table and from indirect zone-pointer blocks, so a crafted image can point a regular file (or directory) at a zone below `s_firstdatazone`, which makes extraction read the boot block, superblock, inode bitmap or inode table and write that metadata into the extracted file; an index at or past the zone count instead seeks beyond the image and aborts the extraction. The inode *number* is already range-checked in `_read_inode`, but the zone numbers reached from a valid inode were not.

The guard goes in the single `_read_zone_data` choke point shared by the direct, indirect and directory read paths, rejecting anything outside `s_firstdatazone <= zone < zone_count` (`s_nzones` for v1, `s_zones` for v2/v3). Images whose data zones sit in the data area are unaffected.

Added a unit test that builds a minimal v1 superblock and checks a valid data zone still reads while metadata and out-of-filesystem zones are rejected.