### PR TITLE
fix(handlers): bound xiaomi hdr blob size to the signature

### DIFF
--- a/python/unblob/handlers/archive/xiaomi/hdr.py
+++ b/python/unblob/handlers/archive/xiaomi/hdr.py
@@ -122,11 +122,15 @@ class HDRExtractor(Extractor):
             if not is_valid_blob_header(blob_header):
                 raise InvalidInputFormat("Invalid HDR blob header.")
 
+            # file.tell() points to right after the blob_header == start_offset
+            blob_start = file.tell()
+            if blob_start + blob_header.blob_size > header.signature_offset:
+                raise InvalidInputFormat("HDR blob data extends past the signature.")
+
             yield (
                 (
                     Path(snull(blob_header.name).decode("utf-8")),
-                    # file.tell() points to right after the blob_header == start_offset
-                    file.tell(),
+                    blob_start,
                     blob_header.blob_size,
                 )
             )

--- a/tests/handlers/archive/test_hdr.py
+++ b/tests/handlers/archive/test_hdr.py
@@ -9,18 +9,30 @@ VALID_BLOB_MAGIC = b"\xbe\xba\x00\x00"  # 0x0000babe, little-endian
 INVALID_BLOB_MAGIC = b"\xde\xad\xbe\xef"
 
 BLOB_OFFSET = 0x30
+BLOB_HEADER_LEN = 0x30  # magic + flash_offset + blob_size + type + unused + name[32]
+BLOB_SIZE = 41
 
 
-def build_hdr1(blob_magic: bytes) -> bytes:
+def build_hdr1(
+    blob_magic: bytes,
+    blob_size: int = BLOB_SIZE,
+    signature_offset: int | None = None,
+) -> bytes:
+    # The signature block follows the blobs, so by default place it right where
+    # the single blob's data ends.
+    blob_data_start = BLOB_OFFSET + BLOB_HEADER_LEN
+    if signature_offset is None:
+        signature_offset = blob_data_start + blob_size
+
     header = b"HDR1"
-    header += struct.pack("<I", BLOB_OFFSET)  # signature_offset
+    header += struct.pack("<I", signature_offset)  # signature_offset
     header += struct.pack("<I", 0)  # crc32 (checked by calculate_chunk, not parse)
     header += struct.pack("<HH", 0, 0)  # unused, device_id
     header += struct.pack("<8I", BLOB_OFFSET, 0, 0, 0, 0, 0, 0, 0)  # blob_offsets
 
     blob = blob_magic
     blob += struct.pack("<I", 0)  # flash_offset
-    blob += struct.pack("<I", 41)  # blob_size
+    blob += struct.pack("<I", blob_size)  # blob_size
     blob += struct.pack("<HH", 7, 0)  # type, unused
     blob += b"blob0".ljust(32, b"\x00")  # name
     return header + blob
@@ -34,5 +46,16 @@ def test_blob_with_magic_is_parsed():
 
 def test_blob_without_magic_is_rejected():
     file = File.from_bytes(build_hdr1(INVALID_BLOB_MAGIC))
+    with pytest.raises(InvalidInputFormat):
+        list(HDRExtractor("hdr1_header_t").parse(file))
+
+
+def test_blob_reaching_into_signature_is_rejected():
+    # The blob has 16 bytes of room before the signature but declares a much
+    # larger size, which would otherwise carve the signature block into its output.
+    signature_offset = BLOB_OFFSET + BLOB_HEADER_LEN + 16
+    file = File.from_bytes(
+        build_hdr1(VALID_BLOB_MAGIC, blob_size=4096, signature_offset=signature_offset)
+    )
     with pytest.raises(InvalidInputFormat):
         list(HDRExtractor("hdr1_header_t").parse(file))


### PR DESCRIPTION
**Unbounded blob size in HDR extraction**

Each blob's size is read from the image and carved without checking it against the blob region, which ends where the trailing signature block starts, so a blob declaring an oversized length runs past its own data and pulls the signature header and any following blobs into that blob's output file. Bounded each blob's data range to `signature_offset` in the shared parser so both HDR1 and HDR2 reject it; blobs that sit before the signature are unaffected.
