### PR TITLE
fix(handlers): derive dmg chunk start from all koly offsets

### DIFF
--- a/python/unblob/handlers/archive/dmg.py
+++ b/python/unblob/handlers/archive/dmg.py
@@ -104,8 +104,18 @@ class DMGHandler(StructHandler):
         # │koly trailer │
         # └─────────────┘
         #
+        # The image begins where the furthest structure the trailer references
+        # ends, walking back from the trailer. Deriving the start from
+        # DataForkLength alone assumes the XML plist sits right after the data
+        # fork; images with a resource fork (or any gap) are then carved from
+        # inside the data fork.
+        image_size = max(
+            header.DataForkOffset + header.DataForkLength,
+            header.RsrcForkOffset + header.RsrcForkLength,
+            header.XMLOffset + header.XMLLength,
+        )
 
         return ValidChunk(
-            start_offset=start_offset - header.XMLLength - header.DataForkLength,
+            start_offset=start_offset - image_size,
             end_offset=start_offset + len(header),
         )

--- a/tests/integration/archive/dmg/__input__/fruits_rsrc_fork.dmg
+++ b/tests/integration/archive/dmg/__input__/fruits_rsrc_fork.dmg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:230c7c5404e65d3c00f40bf4c844085ca18760c54fcd5011654eaef6c2c94aee
+size 29394

--- a/tests/integration/archive/dmg/__output__/fruits_rsrc_fork.dmg_extract/fruits/apple.txt
+++ b/tests/integration/archive/dmg/__output__/fruits_rsrc_fork.dmg_extract/fruits/apple.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303980bcb9e9e6cdec515230791af8b0ab1aaa244b58a8d99152673aa22197d0
+size 6

--- a/tests/integration/archive/dmg/__output__/fruits_rsrc_fork.dmg_extract/fruits/cherry.txt
+++ b/tests/integration/archive/dmg/__output__/fruits_rsrc_fork.dmg_extract/fruits/cherry.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86baf3529da550a44b0681ffa031b6b676e620e9e06dc5ac1119d0cd21cbcf55
+size 7


### PR DESCRIPTION
dmghandler.calculate_chunk reconstructs the chunk start by subtracting datafork_length and xmllength from the koly trailer position, which only holds when the xml plist sits right after the data fork. a dmg that carries a resource fork, or leaves any gap before the plist, then has its start computed inside the data fork and loses the leading bytes of the image; and since datafork_length comes straight from the trailer, an oversized value walks the start in front of the image so unrelated preceding bytes get pulled into the carved chunk. derive the extent from the furthest structure the koly actually references (data fork, resource fork and xml offsets together with their lengths), the same shape the elf handler already uses, so the chunk covers the whole image whatever the layout.

the integration sample `fruits_rsrc_fork.dmg` carries a genuine resource fork between the data fork and the plist (`RsrcForkOffset`/`RsrcForkLength` set in the koly). without the fix the start lands `RsrcForkLength` bytes inside the image and 7z can't open the carved chunk; with it the chunk spans the whole image and extraction matches `fruits.dmg`.
