### PR TITLE
fix(handlers): reject qca_lzma stream ending before compressed_size

### DIFF
--- a/python/unblob/handlers/compression/qca_lzma.py
+++ b/python/unblob/handlers/compression/qca_lzma.py
@@ -61,6 +61,16 @@ def _decompress(file: File, header, chunk_size: int = 1_024) -> Iterator[bytes]:
         bytes_read += len(chunk)
         yield decompressor.decompress(chunk)
 
+    # The end offset is derived from compressed_size, so the stream must actually
+    # fill it. When the LZMA stream terminates earlier, the surplus bytes inside
+    # the declared region (which may be a following file) would be carved into the
+    # chunk and skipped during the scan instead of being extracted on their own.
+    consumed = bytes_read - len(decompressor.unused_data)
+    if decompressor.eof and consumed < header.compressed_size:
+        raise InvalidInputFormat(
+            "QCA LZMA stream ends before its declared compressed_size"
+        )
+
 
 class QcaLzmaHandler(StructHandler):
     NAME = "qca_lzma"

--- a/tests/handlers/compression/test_qca_lzma.py
+++ b/tests/handlers/compression/test_qca_lzma.py
@@ -60,3 +60,25 @@ def test_invalid_chunk(contents, error):
     file = File.from_bytes(contents)
     with pytest.raises(InvalidInputFormat, match=error):
         handler.calculate_chunk(file, 0)
+
+
+def test_compressed_size_past_stream_end():
+    # A crafted image whose declared compressed_size reaches past the end of the
+    # LZMA stream into trailing bytes (here a following gzip header). Decompression
+    # still succeeds, so without the guard those bytes are carved into the chunk
+    # and skipped during the scan instead of being extracted on their own.
+    chunk_bytes = FILE_CONTENTS[
+        START_OFFSET : START_OFFSET + 34
+    ]  # 16 header + 18 stream
+    trailing = bytes.fromhex("1f 8b 08 00 de ad be ef")
+    compressed_size = int.from_bytes(chunk_bytes[8:12], "little")
+    header = (
+        chunk_bytes[:8]
+        + (compressed_size + len(trailing)).to_bytes(4, "little")
+        + chunk_bytes[12:16]
+    )
+    file = File.from_bytes(header + chunk_bytes[16:] + trailing)
+    with pytest.raises(
+        InvalidInputFormat, match="ends before its declared compressed_size"
+    ):
+        handler.calculate_chunk(file, 0)


### PR DESCRIPTION
**QCA LZMA chunk over-claims past the compressed stream**

The chunk end is taken straight from the header's `compressed_size`, but a raw LZMA1 stream carries its own end marker and can finish earlier, so a crafted image can declare a size that runs past the stream into trailing bytes which then get carved into the chunk and hidden from the scan while decompression still succeeds. The handler now tracks the bytes the decompressor actually consumes and rejects the image when the stream ends before the declared `compressed_size`, so valid images (where the two match) are unaffected.