### PR TITLE
fix(handlers): bound fpkg filename to the file header

### DIFF
--- a/python/unblob/handlers/archive/dlink/fpkg.py
+++ b/python/unblob/handlers/archive/dlink/fpkg.py
@@ -50,6 +50,10 @@ CPKG_HEADER = "cpkg_header_t"
 FILE_HEADER = "file_header_t"
 CPKG_HEADER_SIZE = 12
 FILE_HEADER_SIZE = 0x1C
+# offset of the filename within a file header (header_len + type + unknown + file_size)
+FILE_HEADER_NAME_OFFSET = 12
+# space left for the filename plus its terminator inside the fixed header
+MAX_FILENAME_SIZE = FILE_HEADER_SIZE - FILE_HEADER_NAME_OFFSET
 VALID_MAGICS = {b"FPKG", b"CPKG"}
 
 
@@ -100,6 +104,11 @@ class FPKGParser:
         if file_header.header_len != FILE_HEADER_SIZE:
             raise InvalidInputFormat(
                 f"Invalid file header length: {file_header.header_len}"
+            )
+        if len(file_header.filename) >= MAX_FILENAME_SIZE:
+            raise InvalidInputFormat(
+                "Filename not terminated within file header: "
+                f"{file_header.filename[:MAX_FILENAME_SIZE]}..."
             )
         if not file_header.filename.isascii():
             raise InvalidInputFormat(f"Invalid filename: {file_header.filename}")

--- a/tests/handlers/archive/test_fpkg.py
+++ b/tests/handlers/archive/test_fpkg.py
@@ -47,6 +47,11 @@ def test_chunk_calculation():
             DB_FILE_CONTENTS[:0x40] + bytes.fromhex("FF FF") + DB_FILE_CONTENTS[0x42:],
             "Invalid filename",
         ),
+        (
+            # 16 byte name with no NUL inside the fixed header (data starts at +0x1C)
+            DB_FILE_CONTENTS[:0x40] + b"A" * 16 + b"\x00" * 16,
+            "Filename not terminated within file header",
+        ),
     ],
 )
 def test_invalid_chunk(contents, error):


### PR DESCRIPTION
**Filename overruns the fixed FPKG file header**

FPKG file headers are a fixed `0x1C` bytes and each file's data is read from `entry + header_len`, but the name is parsed as an unbounded NUL terminated string and never checked to terminate inside that header. A crafted entry whose name has no terminator within the header is then read out of the following payload, so the carved data starts inside the name and the entry walk desyncs. Bounded the name to `header_len` so such entries are rejected; images whose names fit the header are unaffected.