### PR TITLE
fix(tar): accept non-standard header checksum format

### DIFF
--- a/python/unblob/handlers/archive/tar.py
+++ b/python/unblob/handlers/archive/tar.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import re
 import tarfile
 from pathlib import Path
 
@@ -140,15 +141,16 @@ class _TarHandler(StructHandler):
         def signed_sum(octets) -> int:
             return sum(b if b < 128 else 256 - b for b in octets)
 
-        if header.chksum[6:8] not in (b"\x00 ", b" \x00"):
+        chksum_match = re.search(rb"^(?P<digits>[0-7]+)[\x00\x20]+$", header.chksum)
+        if not chksum_match:
             logger.debug(
                 "Invalid checksum format",
-                actual_last_2_bytes=header.chksum[6:8],
+                chksum=header.chksum,
                 handler=self.NAME,
                 _verbosity=3,
             )
             return None
-        checksum = decode_int(header.chksum[:6], 8)
+        checksum = decode_int(chksum_match.group("digits"), 8)
         header_bytes_for_checksum = (
             file[start_offset : start_offset + 148]
             + b" " * 8  # chksum field is replaced with "blanks"

--- a/tests/handlers/archive/test_tar.py
+++ b/tests/handlers/archive/test_tar.py
@@ -230,6 +230,24 @@ def _build_ustar_prefixed_tar(path: str) -> bytes:
     return info.tobuf(format=tarfile.USTAR_FORMAT) + (b"\0" * tarfile.BLOCKSIZE * 2)
 
 
+def _build_ustar_tar_with_7digit_checksum() -> bytes:
+    # Some real-world tar writers encode the header checksum as 7 octal
+    # digits followed by a single NUL (filling all 8 bytes), instead of the
+    # POSIX "6 octal digits, NUL, space" convention. GNU tar reads both.
+    info = tarfile.TarInfo("test/foo.dat")
+    info.mode = 0o644
+    info.uid = 0
+    info.gid = 0
+    info.size = 0
+    info.mtime = 0
+
+    header = bytearray(info.tobuf(format=tarfile.USTAR_FORMAT))
+    header[148:156] = b" " * 8
+    checksum = sum(header)
+    header[148:156] = f"{checksum:07o}\0".encode()
+    return bytes(header) + (b"\0" * tarfile.BLOCKSIZE * 2)
+
+
 @pytest.mark.parametrize(
     "contents, expected_length, message",
     [
@@ -466,3 +484,17 @@ def test_calculate_chunk_unix(prefix):
     assert chunk is not None
     assert chunk.start_offset == len(prefix)
     assert chunk.end_offset == len(prefix) + len(UNIX_TAR_CONTENT)
+
+
+def test_calculate_chunk_seven_digit_checksum():
+    # The header checksum can be stored as 7 octal digits + NUL rather than
+    # the POSIX "6 digits, NUL, space". unblob must accept it, like GNU tar.
+    archive = _build_ustar_tar_with_7digit_checksum()
+    tar_file = File.from_bytes(archive)
+    handler = TarUstarHandler()
+
+    chunk = handler.calculate_chunk(tar_file, 0)
+
+    assert chunk is not None
+    assert chunk.start_offset == 0
+    assert chunk.end_offset == len(archive)


### PR DESCRIPTION
The chksum field was validated by requiring its last two bytes to be NUL+space or space+NUL, and decoded from only its first 6 bytes. Tar writers that encode the checksum as 7 octal digits followed by a single NUL (filling all 8 bytes) failed both checks: the format guard rejected the header, and even without it the 6-byte decode yielded the wrong value and mismatched the computed checksum.

Because this is applied to every header, an affected archive matches no tar chunk at all and is silently carved into raw unknown blobs instead of extracted, so nested content is never analyzed.

Parse the checksum the way tar readers do: take the octal digits up to the first NUL, ignoring surrounding space padding. Integrity is still enforced by the existing comparison against the computed checksum.