### PR TITLE
fix(handlers): scale ntfs chunk end by bytes_per_sector

### DIFF
--- a/python/unblob/handlers/filesystem/ntfs.py
+++ b/python/unblob/handlers/filesystem/ntfs.py
@@ -88,7 +88,8 @@ class NTFSHandler(StructHandler):
         if fsize == 0:
             raise InvalidInputFormat("NTFS header with null disk size.")
 
-        end_offset = start_offset + len(header) + fsize
+        trailing_backup_boot_sector_size = header.bytes_per_sector
+        end_offset = start_offset + fsize + trailing_backup_boot_sector_size
         return ValidChunk(
             start_offset=start_offset,
             end_offset=end_offset,

--- a/python/unblob/handlers/filesystem/ntfs.py
+++ b/python/unblob/handlers/filesystem/ntfs.py
@@ -88,7 +88,10 @@ class NTFSHandler(StructHandler):
         if fsize == 0:
             raise InvalidInputFormat("NTFS header with null disk size.")
 
-        end_offset = start_offset + len(header) + fsize
+        # total_sectors excludes the trailing backup boot sector, so the volume
+        # spans one extra sector. That sector is bytes_per_sector wide, not a
+        # fixed 512, so scale it with the sector size rather than the header.
+        end_offset = start_offset + fsize + header.bytes_per_sector
         return ValidChunk(
             start_offset=start_offset,
             end_offset=end_offset,

--- a/tests/handlers/filesystem/test_ntfs.py
+++ b/tests/handlers/filesystem/test_ntfs.py
@@ -1,0 +1,44 @@
+import struct
+
+import pytest
+
+from unblob.file_utils import File
+from unblob.handlers.filesystem.ntfs import NTFSHandler
+
+handler = NTFSHandler()
+
+BOOT_SECTOR_SIZE = 512
+
+
+def build_volume(bytes_per_sector: int, total_sectors: int) -> bytes:
+    """Build a minimal NTFS volume.
+
+    ``total_sectors`` excludes the trailing backup boot sector, so the volume
+    occupies ``(total_sectors + 1) * bytes_per_sector`` bytes on disk.
+    """
+    boot = bytearray(BOOT_SECTOR_SIZE)
+    boot[0:3] = b"\xeb\x52\x90"  # jump instruction
+    boot[3:11] = b"NTFS    "  # oem_id
+    struct.pack_into("<H", boot, 11, bytes_per_sector)
+    boot[13] = 8  # sectors_per_cluster
+    struct.pack_into("<Q", boot, 40, total_sectors)
+    boot[510:512] = b"\x55\xaa"  # boot magic
+
+    volume_size = (total_sectors + 1) * bytes_per_sector
+    return bytes(boot) + b"\x11" * (volume_size - BOOT_SECTOR_SIZE)
+
+
+@pytest.mark.parametrize("bytes_per_sector", [256, 512, 4096])
+def test_chunk_covers_whole_volume(bytes_per_sector):
+    total_sectors = 8
+    volume = build_volume(bytes_per_sector, total_sectors)
+    # trailing bytes belonging to whatever follows the volume
+    file = File.from_bytes(volume + b"\xee" * 64)
+
+    chunk = handler.calculate_chunk(file, 0)
+
+    assert chunk is not None
+    assert chunk.start_offset == 0
+    # the backup boot sector is one sector wide, so the chunk must end exactly
+    # at the volume boundary regardless of the sector size
+    assert chunk.end_offset == len(volume)


### PR DESCRIPTION
**NTFS chunk end sized by a fixed 512 rather than the sector size**

`calculate_chunk` ended the chunk at `start + len(header) + fsize`, but `total_sectors` excludes the trailing backup boot sector, so the volume runs one `bytes_per_sector`-wide sector past `fsize`. Hardcoding 512 for that sector overshoots on 256-byte-sector volumes (pulling the following bytes into the carved chunk, which the scan then skips) and falls short on 4096-byte ones; scaling it by `bytes_per_sector` fixes both directions and leaves the common 512-byte case unchanged, so the bundled sample still carves identically.