### PR TITLE
fix(lzip): detect members with odd total length

### DIFF
--- a/python/unblob/handlers/compression/lzip.py
+++ b/python/unblob/handlers/compression/lzip.py
@@ -19,8 +19,9 @@ logger = get_logger()
 
 # magic (4 bytes) + VN (1 byte) + DS (1 byte)
 HEADER_LEN = 4 + 1 + 1
-# LZMA stream is 2 bytes aligned
-LZMA_ALIGNMENT = 2
+# lzip does not pad the LZMA stream, so a member's total length can be odd;
+# scan byte-by-byte so the member_size trailer is found at any offset
+LZMA_ALIGNMENT = 1
 
 
 class LZipHandler(Handler):
@@ -53,7 +54,7 @@ class LZipHandler(Handler):
     def calculate_chunk(self, file: File, start_offset: int) -> ValidChunk | None:
         file.seek(HEADER_LEN, io.SEEK_CUR)
         # quite the naive idea but it works
-        # the idea is to read 8 bytes uint64 every 2 bytes alignment
+        # the idea is to read 8 bytes uint64 at every byte offset
         # until we end up reading the Member Size field which corresponds
         # to "the total size of the member, including header and trailer".
         # We either find it or reach EOF, which will be caught by finder.

--- a/tests/handlers/compression/test_lzip.py
+++ b/tests/handlers/compression/test_lzip.py
@@ -1,0 +1,28 @@
+import pytest
+
+from unblob.file_utils import File
+from unblob.handlers.compression.lzip import LZipHandler
+
+
+@pytest.mark.parametrize(
+    "content, expected_end_offset",
+    [
+        # `printf A | lzip -9` produces a 37-byte member whose total length is
+        # odd. The member_size field then lands on an odd offset, which the
+        # scan used to skip over.
+        pytest.param(
+            bytes.fromhex(
+                "4c5a4950010c0020c1fbffffffe00000008b9ed9d3"
+                "01000000000000002500000000000000"
+            ),
+            0x25,
+            id="odd_length_member",
+        ),
+    ],
+)
+def test_odd_length_member(content: bytes, expected_end_offset: int):
+    handler = LZipHandler()
+    fake_file = File.from_bytes(content)
+    chunk = handler.calculate_chunk(fake_file, 0)
+    assert chunk is not None
+    assert chunk.end_offset == expected_end_offset


### PR DESCRIPTION
The lzip handler works out where a member ends by scanning for the `member_size` field in the trailer. The problem is it steps forward 2 bytes at a time, based on a comment that says "LZMA stream is 2 bytes aligned". That isn't true. lzip doesn't pad the LZMA stream, so a member's total length comes out odd roughly half the time. When it's odd, the `member_size` field lands on an odd offset that the 2-byte scan skips over, the loop runs off the end of the file, and the chunk gets dropped.

So right now unblob quietly misses about half of all lzip files. The smallest way to see it:

```
printf A | lzip -9
```

That gives a 37-byte member that passes `lzip -t` and decompresses fine, but unblob won't pick it up.

I tested with a batch of files made by real lzip (1.24.1) and every odd-sized one got dropped. Scanning a byte at a time instead of two picks all of them up, and nothing else changes. I added a small regression test using that 37-byte file.

There's a separate, rarer issue I left alone here: the brute-force scan can also match a stray 8 bytes inside the stream that happen to equal their own offset, which would end the chunk too early. That one is unrelated to this fix and much less common, so it felt better as its own change.
