### PR TITLE
Reject zero-length Airoha TLV to avoid extraction hang

### DIFF
--- a/python/unblob/handlers/archive/airoha.py
+++ b/python/unblob/handlers/archive/airoha.py
@@ -71,7 +71,11 @@ class AirohaExtractor(Extractor):
     def _read_sections(self, file: File) -> list:
         tlv = self._struct_parser.parse("airoha_tlv_header_t", file, Endian.LITTLE)
         while tlv.tlv_type != TlvType.MOVER_INFO:
+            if tlv.tlv_length == 0:
+                raise InvalidInputFormat("Airoha TLV with zero length, cannot advance")
             file.seek(tlv.tlv_length, io.SEEK_CUR)
+            if file.tell() >= file.size():
+                raise InvalidInputFormat("Airoha MOVER_INFO TLV not found")
             tlv = self._struct_parser.parse("airoha_tlv_header_t", file, Endian.LITTLE)
 
         mover = self._struct_parser.parse(


### PR DESCRIPTION
While reading the Airoha handler I noticed _read_sections can spin forever. It walks the TLV list looking for MOVER_INFO, and each iteration does file.seek(tlv.tlv_length, SEEK_CUR) before parsing the next TLV. If a crafted image has a TLV whose length is 0 and it isn't MOVER_INFO, the seek advances nothing, the same 4 bytes get parsed again, and the loop never terminates, so unblob just hangs on that input with no timeout.

I added a guard that bails out with InvalidInputFormat when a TLV reports zero length, plus a stop once the walk runs off the end of the file before finding MOVER_INFO. Valid images are unaffected since their TLVs advance normally.