### PR TITLE
fix(devenv): fix temporary paths in nix/direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,3 +8,9 @@ if ${UNBLOB_USE_DEVENV:-true}; then
         --option extra-substituters "https://unblob.cachix.org" \
         --option extra-trusted-public-keys "unblob.cachix.org-1:5kWA6DwOg176rSqU8TOTBXWxsDB4LoCMfGfTgL5qCAE="
 fi
+
+export TMPDIR="${XDG_RUNTIME_DIR:-/tmp}/unblob-$UID"
+export TMP="$TMPDIR"
+export TEMP="$TMPDIR"
+export TEMPDIR="$TMPDIR"
+mkdir -p -m 700 "$TMPDIR"


### PR DESCRIPTION
The temporary nix-shell used by direnv is removed after evaluation, leaving its temporary-directory variables pointing to a path that no longer exists.

Keep the replacement outside the repository so sandbox tests can grant the repository write access without also making their temporary fixtures writable.