### PR TITLE
fix(tar): contain tar hard link targets

### DIFF
--- a/python/unblob/handlers/archive/_safe_tarfile.py
+++ b/python/unblob/handlers/archive/_safe_tarfile.py
@@ -164,25 +164,25 @@ class SafeTarFile:
         # prevent traversal attempts through links
         if tarinfo.islnk() or tarinfo.issym():
             if Path(tarinfo.linkname).is_absolute():
-
-                def calculate_linkname():
+                if tarinfo.islnk():
+                    link_path = Path(tarinfo.linkname)
+                    relative_linkname = str(link_path.relative_to(link_path.anchor))
+                else:
                     root = extract_root.resolve()
                     path = (extract_root / tarinfo.name).resolve()
 
                     if path.parts[: len(root.parts)] != root.parts:
-                        return None
+                        self.record_problem(
+                            tarinfo,
+                            "Absolute path conversion to extraction relative failed - would escape root.",
+                            "Skipped.",
+                        )
+                        return
 
                     depth = max(0, len(path.parts) - len(root.parts) - 1)
-                    return ("/".join([".."] * depth) or ".") + tarinfo.linkname
-
-                relative_linkname = calculate_linkname()
-                if relative_linkname is None:
-                    self.record_problem(
-                        tarinfo,
-                        "Absolute path conversion to extraction relative failed - would escape root.",
-                        "Skipped.",
-                    )
-                    return
+                    relative_linkname = (
+                        "/".join([".."] * depth) or "."
+                    ) + tarinfo.linkname
 
                 assert not Path(relative_linkname).is_absolute()
                 self.record_problem(
@@ -192,7 +192,12 @@ class SafeTarFile:
                 )
                 tarinfo.linkname = relative_linkname
 
-            resolved_path = (extract_root / tarinfo.name).parent / tarinfo.linkname
+            # Symbolic link targets are relative to the link's parent, while tar
+            # hard link targets are relative to the extraction root.
+            if tarinfo.islnk():
+                resolved_path = extract_root / tarinfo.linkname
+            else:
+                resolved_path = (extract_root / tarinfo.name).parent / tarinfo.linkname
             if not is_safe_path(basedir=extract_root, path=resolved_path):
                 self.record_problem(
                     tarinfo,

--- a/tests/handlers/archive/test_tar.py
+++ b/tests/handlers/archive/test_tar.py
@@ -428,6 +428,86 @@ def test_extractall_ignores_gnu_timestamp_prefix(tmp_path):
     assert not (tmp_path / "extract" / "13327342752").exists()
 
 
+def test_extractall_rejects_hardlink_escaping_extraction_root(tmp_path):
+    outside_path = tmp_path / "outside"
+    outside_path.write_bytes(b"outside")
+    tar_path = tmp_path / "hardlink-escape.tar"
+
+    with tarfile.open(tar_path, "w") as archive:
+        hardlink = tarfile.TarInfo("nested/link")
+        hardlink.type = tarfile.LNKTYPE
+        hardlink.linkname = "../outside"
+        archive.addfile(hardlink)
+
+    extract_root = tmp_path / "extract"
+    extractor = SafeTarFile(tar_path)
+    try:
+        extractor.extractall(extract_root)  # noqa: S202
+    finally:
+        extractor.close()
+
+    assert not (extract_root / "nested" / "link").exists()
+    assert [report.problem for report in extractor.reports] == [
+        "Traversal attempt through link path."
+    ]
+
+
+def test_extractall_accepts_root_relative_hardlink_target(tmp_path):
+    tar_path = tmp_path / "hardlink.tar"
+
+    with tarfile.open(tar_path, "w") as archive:
+        target = tarfile.TarInfo("target")
+        target.size = len(b"content")
+        archive.addfile(target, io.BytesIO(b"content"))
+
+        hardlink = tarfile.TarInfo("nested/link")
+        hardlink.type = tarfile.LNKTYPE
+        hardlink.linkname = "target"
+        archive.addfile(hardlink)
+
+    extract_root = tmp_path / "extract"
+    extractor = SafeTarFile(tar_path)
+    try:
+        extractor.extractall(extract_root)  # noqa: S202
+    finally:
+        extractor.close()
+
+    target_path = extract_root / "target"
+    link_path = extract_root / "nested" / "link"
+    assert extractor.reports == []
+    assert link_path.read_bytes() == b"content"
+    assert link_path.samefile(target_path)
+
+
+def test_extractall_converts_absolute_hardlink_target(tmp_path):
+    tar_path = tmp_path / "absolute-hardlink.tar"
+
+    with tarfile.open(tar_path, "w") as archive:
+        target = tarfile.TarInfo("target")
+        target.size = len(b"content")
+        archive.addfile(target, io.BytesIO(b"content"))
+
+        hardlink = tarfile.TarInfo("nested/link")
+        hardlink.type = tarfile.LNKTYPE
+        hardlink.linkname = "/target"
+        archive.addfile(hardlink)
+
+    extract_root = tmp_path / "extract"
+    extractor = SafeTarFile(tar_path)
+    try:
+        extractor.extractall(extract_root)  # noqa: S202
+    finally:
+        extractor.close()
+
+    target_path = extract_root / "target"
+    link_path = extract_root / "nested" / "link"
+    assert [report.problem for report in extractor.reports] == [
+        "Absolute path as link target."
+    ]
+    assert link_path.read_bytes() == b"content"
+    assert link_path.samefile(target_path)
+
+
 def test_unblob_tarinfo__frombuf_ignores_gnu_timestamp_prefix():
     archive = _build_gnu_tar_with_timestamp_prefix()
 


### PR DESCRIPTION
Tar hard links use extraction-root semantics, unlike symbolic links.

Validate and normalize them against the extraction root so crafted targets cannot reference files outside it. Add regression coverage for traversal rejection and valid relative and absolute hard link targets.